### PR TITLE
Cache persistence and expiration timestamp for cached tiles

### DIFF
--- a/Applications/Android/Samples/src/main/java/org/mapsforge/applications/android/samples/SamplesBaseActivity.java
+++ b/Applications/Android/Samples/src/main/java/org/mapsforge/applications/android/samples/SamplesBaseActivity.java
@@ -15,6 +15,20 @@
 
 package org.mapsforge.applications.android.samples;
 
+import org.mapsforge.core.model.LatLong;
+import org.mapsforge.core.model.MapPosition;
+import org.mapsforge.map.android.graphics.AndroidSvgBitmapStore;
+import org.mapsforge.map.android.util.AndroidUtil;
+import org.mapsforge.map.android.util.MapViewerTemplate;
+import org.mapsforge.map.layer.renderer.MapWorker;
+import org.mapsforge.map.layer.renderer.TileRendererLayer;
+import org.mapsforge.map.model.DisplayModel;
+import org.mapsforge.map.model.MapViewPosition;
+import org.mapsforge.map.reader.MapFile;
+import org.mapsforge.map.scalebar.ImperialUnitAdapter;
+import org.mapsforge.map.scalebar.MetricUnitAdapter;
+import org.mapsforge.map.scalebar.NauticalUnitAdapter;
+
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.content.DialogInterface;
@@ -30,24 +44,11 @@ import android.widget.EditText;
 import android.widget.SeekBar;
 import android.widget.TextView;
 
-import org.mapsforge.core.model.LatLong;
-import org.mapsforge.core.model.MapPosition;
-import org.mapsforge.map.android.graphics.AndroidSvgBitmapStore;
-import org.mapsforge.map.android.util.AndroidUtil;
-import org.mapsforge.map.android.util.MapViewerTemplate;
-import org.mapsforge.map.layer.renderer.MapWorker;
-import org.mapsforge.map.layer.renderer.TileRendererLayer;
-import org.mapsforge.map.model.DisplayModel;
-import org.mapsforge.map.model.MapViewPosition;
-import org.mapsforge.map.reader.MapFile;
-import org.mapsforge.map.scalebar.ImperialUnitAdapter;
-import org.mapsforge.map.scalebar.MetricUnitAdapter;
-import org.mapsforge.map.scalebar.NauticalUnitAdapter;
-
 /**
  * Code common to most activities in the Samples app.
  */
-public abstract class SamplesBaseActivity extends MapViewerTemplate implements SharedPreferences.OnSharedPreferenceChangeListener {
+public abstract class SamplesBaseActivity extends MapViewerTemplate implements
+		SharedPreferences.OnSharedPreferenceChangeListener {
 
 	public static final String SETTING_SCALEBAR = "scalebar";
 	public static final String SETTING_SCALEBAR_METRIC = "metric";
@@ -91,13 +92,12 @@ public abstract class SamplesBaseActivity extends MapViewerTemplate implements S
 
 	protected void createTileCaches() {
 		boolean threaded = sharedPreferences.getBoolean(SamplesApplication.SETTING_TILECACHE_THREADING, true);
-		int queueSize = Integer.parseInt(sharedPreferences.getString(SamplesApplication.SETTING_TILECACHE_QUEUESIZE, "4"));
+		int queueSize = Integer.parseInt(sharedPreferences.getString(SamplesApplication.SETTING_TILECACHE_QUEUESIZE,
+				"4"));
 
 		this.tileCaches.add(AndroidUtil.createTileCache(this, getPersistableId(),
 				this.mapView.getModel().displayModel.getTileSize(), this.getScreenRatio(),
-				this.mapView.getModel().frameBufferModel.getOverdrawFactor(),
-				threaded, queueSize
-		));
+				this.mapView.getModel().frameBufferModel.getOverdrawFactor(), threaded, queueSize, false));
 	}
 
 	/**
@@ -149,11 +149,11 @@ public abstract class SamplesBaseActivity extends MapViewerTemplate implements S
 								.toString());
 						double lon = Double.parseDouble(((EditText) view.findViewById(R.id.longitude)).getText()
 								.toString());
-						byte zoomLevel = (byte) ((((SeekBar) view.findViewById(R.id.zoomlevel)).getProgress()) +
-								SamplesBaseActivity.this.mapView.getModel().mapViewPosition.getZoomLevelMin());
+						byte zoomLevel = (byte) ((((SeekBar) view.findViewById(R.id.zoomlevel)).getProgress()) + SamplesBaseActivity.this.mapView
+								.getModel().mapViewPosition.getZoomLevelMin());
 
-						SamplesBaseActivity.this.mapView.getModel().mapViewPosition.setMapPosition(
-								new MapPosition(new LatLong(lat, lon), zoomLevel));
+						SamplesBaseActivity.this.mapView.getModel().mapViewPosition.setMapPosition(new MapPosition(
+								new LatLong(lat, lon), zoomLevel));
 					}
 				});
 				builder.setNegativeButton(R.string.cancelbutton, null);
@@ -237,7 +237,8 @@ public abstract class SamplesBaseActivity extends MapViewerTemplate implements S
 		if (SamplesApplication.SETTING_TEXTWIDTH.equals(key)) {
 			AndroidUtil.restartActivity(this);
 		}
-		if (SamplesApplication.SETTING_TILECACHE_QUEUESIZE.equals(key) || SamplesApplication.SETTING_TILECACHE_THREADING.equals(key)) {
+		if (SamplesApplication.SETTING_TILECACHE_QUEUESIZE.equals(key)
+				|| SamplesApplication.SETTING_TILECACHE_THREADING.equals(key)) {
 			AndroidUtil.restartActivity(this);
 		}
 		if (SETTING_SCALEBAR.equals(key)) {
@@ -246,11 +247,12 @@ public abstract class SamplesBaseActivity extends MapViewerTemplate implements S
 		if (SamplesApplication.SETTING_DEBUG_TIMING.equals(key)) {
 			MapWorker.DEBUG_TIMING = preferences.getBoolean(SamplesApplication.SETTING_DEBUG_TIMING, false);
 		}
-		if (SamplesApplication.SETTING_WAYFILTERING_DISTANCE.equals(key) ||
-				SamplesApplication.SETTING_WAYFILTERING.equals(key)) {
+		if (SamplesApplication.SETTING_WAYFILTERING_DISTANCE.equals(key)
+				|| SamplesApplication.SETTING_WAYFILTERING.equals(key)) {
 			MapFile.wayFilterEnabled = preferences.getBoolean(SamplesApplication.SETTING_WAYFILTERING, true);
 			if (MapFile.wayFilterEnabled) {
-				MapFile.wayFilterDistance = Integer.parseInt(preferences.getString(SamplesApplication.SETTING_WAYFILTERING_DISTANCE, "20"));
+				MapFile.wayFilterDistance = Integer.parseInt(preferences.getString(
+						SamplesApplication.SETTING_WAYFILTERING_DISTANCE, "20"));
 			}
 		}
 	}
@@ -280,7 +282,8 @@ public abstract class SamplesBaseActivity extends MapViewerTemplate implements S
 	 * sets the value for breaking line text in labels.
 	 */
 	protected void setMaxTextWidthFactor() {
-		mapView.getModel().displayModel.setMaxTextWidthFactor(Float.valueOf(sharedPreferences.getString(SamplesApplication.SETTING_TEXTWIDTH, "0.7")));
+		mapView.getModel().displayModel.setMaxTextWidthFactor(Float.valueOf(sharedPreferences.getString(
+				SamplesApplication.SETTING_TEXTWIDTH, "0.7")));
 	}
 
 }

--- a/Applications/Android/Samples/src/main/java/org/mapsforge/applications/android/samples/SimplestMapViewer.java
+++ b/Applications/Android/Samples/src/main/java/org/mapsforge/applications/android/samples/SimplestMapViewer.java
@@ -28,6 +28,7 @@ public class SimplestMapViewer extends MapViewerTemplate {
 
 	/**
 	 * This MapViewer uses the deprecated built-in osmarender theme.
+	 * 
 	 * @return the render theme to use
 	 */
 	@Override
@@ -37,6 +38,7 @@ public class SimplestMapViewer extends MapViewerTemplate {
 
 	/**
 	 * This MapViewer uses the standard xml layout in the Samples app.
+	 * 
 	 * @return
 	 */
 	@Override
@@ -46,6 +48,7 @@ public class SimplestMapViewer extends MapViewerTemplate {
 
 	/**
 	 * The id of the mapview inside the layout.
+	 * 
 	 * @return the id of the MapView inside the layout.
 	 */
 	@Override
@@ -55,6 +58,7 @@ public class SimplestMapViewer extends MapViewerTemplate {
 
 	/**
 	 * The name of the map file.
+	 * 
 	 * @return map file name
 	 */
 	@Override
@@ -77,9 +81,7 @@ public class SimplestMapViewer extends MapViewerTemplate {
 	protected void createTileCaches() {
 		this.tileCaches.add(AndroidUtil.createTileCache(this, getPersistableId(),
 				this.mapView.getModel().displayModel.getTileSize(), this.getScreenRatio(),
-				this.mapView.getModel().frameBufferModel.getOverdrawFactor(),
-				false, 0
-		));
+				this.mapView.getModel().frameBufferModel.getOverdrawFactor(), false, 0, false));
 	}
 
 }

--- a/mapsforge-core/src/main/java/org/mapsforge/core/graphics/TileBitmap.java
+++ b/mapsforge-core/src/main/java/org/mapsforge/core/graphics/TileBitmap.java
@@ -15,5 +15,52 @@
 package org.mapsforge.core.graphics;
 
 public interface TileBitmap extends Bitmap {
-	// only different behaviour
+
+	/**
+	 * Returns the timestamp of the tile in milliseconds since January 1, 1970 GMT or 0 if this timestamp is unknown.
+	 * <p>
+	 * The timestamp indicates when the tile was created and can be used together with a TTL in order to determine
+	 * whether to treat it as expired.
+	 */
+	public long getTimestamp();
+
+	/**
+	 * Whether the TileBitmap has expired.
+	 * <p>
+	 * When a tile has expired, the requester should try to replace it with a fresh copy as soon as possible. The
+	 * expired tile may still be displayed to the user until the fresh copy is available. This may be desirable if
+	 * obtaining a fresh copy is time-consuming or a fresh copy is currently unavailable (e.g. because no network
+	 * connection is available for a {@link org.mapsforge.map.layer.download.tilesource.TileSource}).
+	 * 
+	 * @return {@code true} if expired, {@code false} otherwise.
+	 */
+	public boolean isExpired();
+
+	/**
+	 * Returns the timestamp when this tile will be expired in milliseconds since January 1, 1970 GMT or 0 if this
+	 * timestamp is unknown.
+	 * <p>
+	 * The timestamp indicates when the tile should be treated it as expired, i.e. {@link #isExpired()} will return
+	 * {@code true}. For a downloaded tile, pass the value returned by
+	 * {@link java.net.HttpURLConnection#getExpiration()}, if set by the server. In all other cases you can pass current
+	 * time plus a fixed TTL in order to have the tile expire after the specified time.
+	 */
+	public void setExpiration(long expiration);
+
+	/**
+	 * Sets the timestamp of the tile in milliseconds since January 1, 1970 GMT.
+	 * <p>
+	 * The timestamp indicates when the information to create the tile was last retrieved from the source. It can be
+	 * used together with a TTL in order to determine whether to treat it as expired.
+	 * <p>
+	 * The timestamp of a locally rendered tile should be set to the timestamp of the map database used to render it, as
+	 * returned by {@link org.mapsforge.map.reader.header.MapFileInfo#mapDate}. For a tile read from a disk cache, it
+	 * should be the file's timestamp. In all other cases (including downloaded tiles), the timestamp should be set to
+	 * wall clock time (as returned by {@link java.lang.System#currentTimeMillis()}) when the tile is created.
+	 * <p>
+	 * Classes that implement this interface should call {@link java.lang.System#currentTimeMillis()} upon creating an
+	 * instance, store the result and return it unless {@code setTimestamp()} has been called for that instance.
+	 */
+	public void setTimestamp(long timestamp);
+
 }

--- a/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidTileBitmap.java
+++ b/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidTileBitmap.java
@@ -96,6 +96,9 @@ public class AndroidTileBitmap extends AndroidBitmap implements TileBitmap {
 		return bitmap;
 	}
 
+	private long expiration = 0;
+	private long timestamp = System.currentTimeMillis();
+
 	/*
 	 * THIS CAN THROW AN IllegalArgumentException or SocketTimeoutException The inputStream can be corrupt for various
 	 * reasons (slow download or slow access to file system) and will then raise an exception. This exception must be
@@ -141,6 +144,28 @@ public class AndroidTileBitmap extends AndroidBitmap implements TileBitmap {
 		if (AndroidGraphicFactory.DEBUG_BITMAPS) {
 			tileInstances.incrementAndGet();
 		}
+	}
+
+	@Override
+	public long getTimestamp() {
+		return timestamp;
+	}
+
+	@Override
+	public boolean isExpired() {
+		if (expiration == 0)
+			return false;
+		return (expiration >= System.currentTimeMillis());
+	}
+
+	@Override
+	public void setExpiration(long expiration) {
+		this.expiration = expiration;
+	}
+
+	@Override
+	public void setTimestamp(long timestamp) {
+		this.timestamp = timestamp;
 	}
 
 	@Override

--- a/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/AwtTileBitmap.java
+++ b/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/AwtTileBitmap.java
@@ -25,12 +25,37 @@ import org.mapsforge.core.graphics.TileBitmap;
 
 public class AwtTileBitmap extends AwtBitmap implements TileBitmap {
 
+	private long expiration = 0;
+	private long timestamp = System.currentTimeMillis();
+
 	public AwtTileBitmap(InputStream inputStream) throws IOException {
 		super(inputStream);
 	}
 
 	public AwtTileBitmap(int tileSize) {
 		super(tileSize, tileSize);
+	}
+
+	@Override
+	public long getTimestamp() {
+		return timestamp;
+	}
+
+	@Override
+	public boolean isExpired() {
+		if (expiration == 0)
+			return false;
+		return (expiration >= System.currentTimeMillis());
+	}
+
+	@Override
+	public void setExpiration(long expiration) {
+		this.expiration = expiration;
+	}
+
+	@Override
+	public void setTimestamp(long timestamp) {
+		this.timestamp = timestamp;
 	}
 
 	public AwtTileBitmap(int tileSize, boolean hasAlpha) {

--- a/mapsforge-map-reader/src/main/java/org/mapsforge/map/reader/MapDataStore.java
+++ b/mapsforge-map-reader/src/main/java/org/mapsforge/map/reader/MapDataStore.java
@@ -26,37 +26,53 @@ public interface MapDataStore {
 
 	/**
 	 * Returns the area for which data is supplied.
+	 * 
 	 * @return bounding box of area.
 	 */
 	BoundingBox boundingBox();
 
-	/*
+	/**
 	 * Closes the map database.
 	 */
 	void close();
 
 	/**
+	 * Returns the timestamp of the data used to render a specific tile.
+	 * 
+	 * @param tile
+	 *            A tile.
+	 * @return the timestamp of the data used to render the tile
+	 */
+	long getDataTimestamp(Tile tile);
+
+	/**
 	 * Gets the initial map position.
+	 * 
 	 * @return the start position, if available.
 	 */
 	LatLong startPosition();
 
 	/**
 	 * Gets the initial zoom level.
+	 * 
 	 * @return the start zoom level.
 	 */
 	Byte startZoomLevel();
 
 	/**
 	 * Reads data for tile.
-	 * @param tile tile for which data is requested.
+	 * 
+	 * @param tile
+	 *            tile for which data is requested.
 	 * @return map data for the tile.
 	 */
 	MapReadResult readMapData(Tile tile);
 
 	/**
 	 * Returns true if MapDatabase contains tile.
-	 * @param tile tile to be rendered.
+	 * 
+	 * @param tile
+	 *            tile to be rendered.
 	 * @return true if tile is part of database.
 	 */
 	boolean supportsTile(Tile tile);

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/cache/FileSystemTileCache.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/cache/FileSystemTileCache.java
@@ -51,8 +51,8 @@ class StorageJob {
 	}
 
 	/**
-	 * Equality is just defined over the key, not over the bitmap content. This allows
-	 * finding a StorageJob in the queue without knowing the data.
+	 * Equality is just defined over the key, not over the bitmap content. This allows finding a StorageJob in the queue
+	 * without knowing the data.
 	 */
 	@Override
 	public boolean equals(Object obj) {
@@ -72,9 +72,16 @@ class StorageJob {
 }
 
 /**
- * A thread-safe cache for image files with a fixed size and LRU policy. The cache writes
- * the data on a separate thread, i.e. when the call to put a job/tile into the cache returns
- * the data is not actually written to disk.
+ * A thread-safe cache for image files with a fixed size and LRU policy.
+ * <p>
+ * A {@code FileSystemTileCache} caches tiles in a dedicated path in the file system, specified in the constructor. The
+ * cache writes the data on a separate thread, i.e. when the call to put a job/tile into the cache returns the data is
+ * not actually written to disk.
+ * <p>
+ * When used for a {@link org.mapsforge.map.layer.renderer.TileRendererLayer}, persistent caching may result in clipped
+ * labels when tiles from different instances are used. To work around this, either display labels in a separate
+ * {@link org.mapsforge.map.layer.labels.LabelLayer} (experimental) or disable persistence as described in
+ * {@link #FileSystemTileCache(int, File, GraphicFactory, boolean)}.
  */
 public class FileSystemTileCache extends PausableThread implements TileCache {
 	static final String FILE_EXTENSION = ".tile";
@@ -87,44 +94,46 @@ public class FileSystemTileCache extends PausableThread implements TileCache {
 		return true;
 	}
 
-    /**
-     * Recursively deletes directory and all files.
-     * See http://stackoverflow.com/questions/3775694/deleting-folder-from-java/3775723#3775723
-     *
-     * @param dir the directory to delete with all its content
-     * @return true if directory and all content has been deleted, false if not
-     */
+	/**
+	 * Recursively deletes directory and all files. See
+	 * http://stackoverflow.com/questions/3775694/deleting-folder-from-java/3775723#3775723
+	 * 
+	 * @param dir
+	 *            the directory to delete with all its content
+	 * @return true if directory and all content has been deleted, false if not
+	 */
 
-    private static boolean deleteDirectory(File dir) {
-        if (dir.isDirectory()) {
-            String[] children = dir.list();
-            if (children != null) {
-            	for (int i = 0; i < children.length; i++) {
-            		boolean success = deleteDirectory(new File(dir, children[i]));
-            		if (!success) {
-            			return false;
-            		}
-            	}
-            }
-        }
-        // The directory is now empty so delete it
-        return dir.delete();
-    }
+	private static boolean deleteDirectory(File dir) {
+		if (dir.isDirectory()) {
+			String[] children = dir.list();
+			if (children != null) {
+				for (int i = 0; i < children.length; i++) {
+					boolean success = deleteDirectory(new File(dir, children[i]));
+					if (!success) {
+						return false;
+					}
+				}
+			}
+		}
+		// The directory is now empty so delete it
+		return dir.delete();
+	}
 
 	private final File cacheDirectory;
 	private final GraphicFactory graphicFactory;
 	private final AtomicInteger jobs;
 	private FileWorkingSetCache<String> lruCache;
 	private final ReentrantReadWriteLock lock;
+	private boolean persistent;
 
 	// if threaded is true, the bitmap writing is executed on a separate thread,
 	// and jobs are stored in the jobStack. The false option remains for testing.
 	private final boolean threaded;
 	private final LinkedBlockingQueue<StorageJob> storageJobs;
 
-
 	/**
-	 * Compatibility constructor that creates a threaded FSTC.
+	 * Compatibility constructor that creates a non-threaded, non-persistent FSTC.
+	 * 
 	 * @param capacity
 	 *            the maximum number of entries in this cache.
 	 * @param cacheDirectory
@@ -135,10 +144,18 @@ public class FileSystemTileCache extends PausableThread implements TileCache {
 	 *             if the capacity is negative.
 	 */
 	public FileSystemTileCache(int capacity, File cacheDirectory, GraphicFactory graphicFactory) {
-		this(capacity, cacheDirectory, graphicFactory, false, 0);
+		this(capacity, cacheDirectory, graphicFactory, false, 0, false);
 	}
 
 	/**
+	 * Creates a new FileSystemTileCache.
+	 * <p>
+	 * Use the {@code persistent} argument to specify whether cache contents should be kept across instances. A
+	 * persistent cache will serve any tiles it finds in {@code cacheDirectory}. Calling {@link #destroy()} on a
+	 * persistent cache will not delete the cache directory. Conversely, a non-persistent cache will serve only tiles
+	 * added to it via the {@link #put(Job, TileBitmap)} method, and calling {@link #destroy()} on a non-persistent
+	 * cache will delete {@code cacheDirectory}.
+	 * 
 	 * @param capacity
 	 *            the maximum number of entries in this cache.
 	 * @param cacheDirectory
@@ -149,8 +166,11 @@ public class FileSystemTileCache extends PausableThread implements TileCache {
 	 *            if cache will use background thread to store data (more responsive).
 	 * @throws IllegalArgumentException
 	 *             if the capacity is negative.
+	 * @throws IllegalArgumentException
+	 *             if the capacity is negative.
 	 */
-	public FileSystemTileCache(int capacity, File cacheDirectory, GraphicFactory graphicFactory, boolean threaded, int queueSize) {
+	public FileSystemTileCache(int capacity, File cacheDirectory, GraphicFactory graphicFactory, boolean threaded,
+			int queueSize, boolean persistent) {
 		this.jobs = new AtomicInteger(0);
 		this.threaded = threaded;
 		if (threaded) {
@@ -166,6 +186,7 @@ public class FileSystemTileCache extends PausableThread implements TileCache {
 		}
 		this.graphicFactory = graphicFactory;
 		this.lock = new ReentrantReadWriteLock();
+		this.persistent = persistent;
 		if (this.threaded) {
 			this.start();
 		}
@@ -177,25 +198,31 @@ public class FileSystemTileCache extends PausableThread implements TileCache {
 			lock.readLock().lock();
 			// if we are using a threaded cache we return true if the tile is still in the
 			// queue to reduce double rendering
-			return this.lruCache.containsKey(key.getKey()) || (threaded && storageJobs.contains(key));
+			if (this.lruCache.containsKey(key.getKey()) || (threaded && storageJobs.contains(key)))
+				return true;
 		} finally {
 			lock.readLock().unlock();
 		}
+		return this.persistent && getOutputFile(key).exists();
 	}
 
+	/**
+	 * Destroys this cache.
+	 * <p>
+	 * Applications are expected to call this method when they no longer require the cache.
+	 * <p>
+	 * If the cache is not persistent, calling this method is equivalent to calling {@link #purge()}. If the cache is
+	 * persistent, it does nothing.
+	 * <p>
+	 * Beginning with 0.6.0, accessing the cache after calling {@code destroy()} is discouraged. In order to empty the
+	 * cache and force all tiles to be re-rendered or re-requested from the source, use {@link #purge()} instead.
+	 * Earlier versions lacked the {@link #purge()} method and used {@code destroy()} instead, but this practice is now
+	 * discouraged and may lead to unexpected results when used with features introduced in 0.6.0 or later.
+	 */
 	@Override
 	public void destroy() {
-		try {
-			lock.writeLock().lock();
-			this.lruCache.clear();
-			if (this.threaded) {
-				this.interrupt();
-			}
-		} finally {
-			lock.writeLock().unlock();
-		}
-
-		deleteDirectory(this.cacheDirectory);
+		if (!this.persistent)
+			purge();
 	}
 
 	@Override
@@ -209,13 +236,20 @@ public class FileSystemTileCache extends PausableThread implements TileCache {
 			lock.readLock().unlock();
 		}
 		if (file == null) {
-			return null;
+			if (this.persistent) {
+				file = getOutputFile(key);
+				if (!file.exists())
+					return null;
+			} else
+				return null;
 		}
 
 		InputStream inputStream = null;
 		try {
 			inputStream = new FileInputStream(file);
-			return this.graphicFactory.createTileBitmap(inputStream, key.tile.tileSize, key.hasAlpha);
+			TileBitmap result = this.graphicFactory.createTileBitmap(inputStream, key.tile.tileSize, key.hasAlpha);
+			result.setTimestamp(file.lastModified());
+			return result;
 		} catch (CorruptedInputStreamException e) {
 			// this can happen, at least on Android, when the input stream
 			// is somehow corrupted, returning null ensures it will be loaded
@@ -253,7 +287,42 @@ public class FileSystemTileCache extends PausableThread implements TileCache {
 	}
 
 	/**
+	 * Whether the cache is persistent.
+	 */
+	public boolean isPersistent() {
+		return this.persistent;
+	}
+
+	/**
+	 * Purges this cache.
+	 * <p>
+	 * Calls to {@link #get(Job)} issued after purging will not return any tiles added before the purge operation.
+	 * Purging will also delete the cache directory on disk, freeing up disk space.
+	 * <p>
+	 * Applications should purge the tile cache when map model parameters change, such as the render style for locally
+	 * rendered tiles, or the source for downloaded tiles. Applications which frequently alternate between a limited
+	 * number of map model configurations may want to consider using a different cache for each.
+	 * 
+	 * @since 0.5.0
+	 */
+	@Override
+	public void purge() {
+		try {
+			this.lock.writeLock().lock();
+			this.lruCache.clear();
+			if (this.threaded) {
+				this.interrupt();
+			}
+		} finally {
+			this.lock.writeLock().unlock();
+		}
+
+		deleteDirectory(this.cacheDirectory);
+	}
+
+	/**
 	 * Gets the number of remaining tiles still in the queue to be written to disk.
+	 * 
 	 * @return number of jobs in queue, 0 if not threaded.
 	 */
 	public int getQueueLength() {
@@ -293,9 +362,9 @@ public class FileSystemTileCache extends PausableThread implements TileCache {
 		String file = this.cacheDirectory + File.separator + job.getKey();
 		String dir = file.substring(0, file.lastIndexOf(File.separatorChar));
 		if (isValidCacheDirectory(new File(dir))) {
-            return new File(file + FILE_EXTENSION);
-        }
-        return null;
+			return new File(file + FILE_EXTENSION);
+		}
+		return null;
 	}
 
 	private void remove(Job key) {
@@ -329,8 +398,11 @@ public class FileSystemTileCache extends PausableThread implements TileCache {
 
 	/**
 	 * stores the bitmap data on disk with filename key
-	 * @param key filename
-	 * @param bitmap tile image
+	 * 
+	 * @param key
+	 *            filename
+	 * @param bitmap
+	 *            tile image
 	 */
 	private void storeData(Job key, TileBitmap bitmap) {
 		OutputStream outputStream = null;

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/cache/InMemoryTileCache.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/cache/InMemoryTileCache.java
@@ -41,7 +41,6 @@ public class InMemoryTileCache implements TileCache {
 		this.lruCache = new BitmapLRUCache(capacity);
 	}
 
-
 	@Override
 	public synchronized boolean containsKey(Job key) {
 		return this.lruCache.containsKey(key);
@@ -49,12 +48,8 @@ public class InMemoryTileCache implements TileCache {
 
 	@Override
 	public synchronized void destroy() {
-		for (TileBitmap bitmap : this.lruCache.values()) {
-			bitmap.decrementRefCount();
-		}
-		this.lruCache.clear();
+		purge();
 	}
-
 
 	@Override
 	public synchronized TileBitmap get(Job key) {
@@ -80,7 +75,13 @@ public class InMemoryTileCache implements TileCache {
 		return get(key);
 	}
 
-
+	@Override
+	public void purge() {
+		for (TileBitmap bitmap : this.lruCache.values()) {
+			bitmap.decrementRefCount();
+		}
+		this.lruCache.clear();
+	}
 
 	@Override
 	public synchronized void put(Job key, TileBitmap bitmap) {

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/cache/TileCache.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/cache/TileCache.java
@@ -33,6 +33,13 @@ public interface TileCache {
 
 	/**
 	 * Destroys this cache.
+	 * <p>
+	 * Applications are expected to call this method when they no longer require the cache.
+	 * <p>
+	 * In versions prior to 0.5.0, it was common practice to call this method but continue using the cache, in order to
+	 * empty it, forcing all tiles to be re-rendered or re-requested from the source. Beginning with 0.5.0,
+	 * {@link #purge()} should be used for this purpose. The earlier practice is now discouraged and may lead to
+	 * unexpected results when used with features introduced in 0.5.0 or later.
 	 */
 	void destroy();
 
@@ -53,11 +60,24 @@ public interface TileCache {
 	int getCapacityFirstLevel();
 
 	/**
-	 * Returns tileBitmap only if available at fastest cache in case of multi-layered
-	 * cache, null otherwise.
+	 * Returns tileBitmap only if available at fastest cache in case of multi-layered cache, null otherwise.
+	 * 
 	 * @return tileBitmap if available without getting from lower storage levels
 	 */
 	TileBitmap getImmediately(Job key);
+
+	/**
+	 * Purges this cache.
+	 * <p>
+	 * Calls to {@link #get(Job)} issued after purging will not return any tiles added before the purge operation.
+	 * <p>
+	 * Applications should purge the tile cache when map model parameters change, such as the render style for locally
+	 * rendered tiles, or the source for downloaded tiles. Applications which frequently alternate between a limited
+	 * number of map model configurations may want to consider using a different cache for each.
+	 * 
+	 * @since 0.5.0
+	 */
+	void purge();
 
 	/**
 	 * @throws IllegalArgumentException
@@ -67,8 +87,8 @@ public interface TileCache {
 	void put(Job key, TileBitmap bitmap);
 
 	/**
-	 * Reserves a working set in this cache, for multi-level caches this means bringing
-	 * the elements in workingSet into the fastest cache.
+	 * Reserves a working set in this cache, for multi-level caches this means bringing the elements in workingSet into
+	 * the fastest cache.
 	 */
 	void setWorkingSet(Set<Job> workingSet);
 }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/cache/TileStore.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/cache/TileStore.java
@@ -15,12 +15,6 @@
  */
 package org.mapsforge.map.layer.cache;
 
-import org.mapsforge.core.graphics.CorruptedInputStreamException;
-import org.mapsforge.core.graphics.GraphicFactory;
-import org.mapsforge.core.graphics.TileBitmap;
-import org.mapsforge.core.util.IOUtils;
-import org.mapsforge.map.layer.queue.Job;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -28,10 +22,15 @@ import java.io.InputStream;
 import java.util.Set;
 import java.util.logging.Logger;
 
+import org.mapsforge.core.graphics.CorruptedInputStreamException;
+import org.mapsforge.core.graphics.GraphicFactory;
+import org.mapsforge.core.graphics.TileBitmap;
+import org.mapsforge.core.util.IOUtils;
+import org.mapsforge.map.layer.queue.Job;
+
 /**
- * A "tilecache" storing map tiles that is prepopulated and never removes any files.
- * This tile store uses the standard TMS directory layout of zoomlevel/y/x . To support
- * a different directory structure override the findFile method.
+ * A "tilecache" storing map tiles that is prepopulated and never removes any files. This tile store uses the standard
+ * TMS directory layout of zoomlevel/y/x . To support a different directory structure override the findFile method.
  */
 public class TileStore implements TileCache {
 
@@ -109,6 +108,10 @@ public class TileStore implements TileCache {
 		return get(key);
 	}
 
+	@Override
+	public synchronized void purge() {
+		// no-op
+	}
 
 	@Override
 	public synchronized void put(Job key, TileBitmap bitmap) {

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/cache/TwoLevelTileCache.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/cache/TwoLevelTileCache.java
@@ -15,15 +15,14 @@
  */
 package org.mapsforge.map.layer.cache;
 
-import org.mapsforge.core.graphics.TileBitmap;
-import org.mapsforge.map.layer.queue.Job;
-
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-public class TwoLevelTileCache implements TileCache {
+import org.mapsforge.core.graphics.TileBitmap;
+import org.mapsforge.map.layer.queue.Job;
 
+public class TwoLevelTileCache implements TileCache {
 
 	private final TileCache firstLevelTileCache;
 	private final TileCache secondLevelTileCache;
@@ -76,6 +75,12 @@ public class TwoLevelTileCache implements TileCache {
 	@Override
 	public TileBitmap getImmediately(Job key) {
 		return firstLevelTileCache.get(key);
+	}
+
+	@Override
+	public void purge() {
+		this.firstLevelTileCache.purge();
+		this.secondLevelTileCache.purge();
 	}
 
 	@Override

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/download/TileDownloadLayer.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/download/TileDownloadLayer.java
@@ -17,6 +17,7 @@ package org.mapsforge.map.layer.download;
 
 import org.mapsforge.core.graphics.Canvas;
 import org.mapsforge.core.graphics.GraphicFactory;
+import org.mapsforge.core.graphics.TileBitmap;
 import org.mapsforge.core.model.BoundingBox;
 import org.mapsforge.core.model.Point;
 import org.mapsforge.core.model.Tile;
@@ -29,6 +30,7 @@ import org.mapsforge.map.model.MapViewPosition;
 public class TileDownloadLayer extends TileLayer<DownloadJob> {
 	private static final int DOWNLOAD_THREADS_MAX = 8;
 
+	private long cacheTTL = 0;
 	private final GraphicFactory graphicFactory;
 	private boolean started;
 	private final TileCache tileCache;
@@ -41,6 +43,7 @@ public class TileDownloadLayer extends TileLayer<DownloadJob> {
 
 		this.tileCache = tileCache;
 		this.tileSource = tileSource;
+		this.cacheTTL = tileSource.getDefaultTTL();
 		this.graphicFactory = graphicFactory;
 	}
 
@@ -51,6 +54,15 @@ public class TileDownloadLayer extends TileLayer<DownloadJob> {
 		}
 
 		super.draw(boundingBox, zoomLevel, canvas, topLeftPoint);
+	}
+
+	/**
+	 * Returns the time-to-live (TTL) for tiles in the cache, or 0 if not set.
+	 * <p>
+	 * Refer to {@link #isTileStale(TileBitmap)} for information on how the TTL is enforced.
+	 */
+	public long getCacheTTL() {
+		return cacheTTL;
 	}
 
 	@Override
@@ -75,6 +87,20 @@ public class TileDownloadLayer extends TileLayer<DownloadJob> {
 		for (TileDownloadThread tileDownloadThread : this.tileDownloadThreads) {
 			tileDownloadThread.proceed();
 		}
+	}
+
+	/**
+	 * Sets the time-to-live (TTL) for tiles in the cache.
+	 * <p>
+	 * The initial TTL is obtained by calling the {@link org.mapsforge.map.layer.download.tilesource.TileSource}'s
+	 * {@link org.mapsforge.map.layer.download.tilesource.TileSource#getDefaultTTL()} method. Refer to
+	 * {@link #isTileStale(TileBitmap)} for information on how the TTL is enforced.
+	 * 
+	 * @param ttl
+	 *            The TTL. If set to 0, no TTL will be enforced.
+	 */
+	public void setCacheTTL(long ttl) {
+		cacheTTL = ttl;
 	}
 
 	@Override
@@ -107,5 +133,39 @@ public class TileDownloadLayer extends TileLayer<DownloadJob> {
 	@Override
 	protected DownloadJob createJob(Tile tile) {
 		return new DownloadJob(tile, this.tileSource);
+	}
+
+	/**
+	 * Whether the tile is stale and should be refreshed.
+	 * <p>
+	 * This method is called from {@link #draw(BoundingBox, byte, Canvas, Point)} to determine whether the tile needs to
+	 * be refreshed.
+	 * <p>
+	 * A tile is considered stale if one or more of the following two conditions apply:
+	 * <ul>
+	 * <li>The {@code bitmap}'s {@link org.mapsforge.core.graphics.TileBitmap#isExpired()} method returns {@code True}.</li>
+	 * <li>The layer has a time-to-live (TTL) set ({@link #getCacheTTL()} returns a nonzero value) and the sum of the
+	 * {@code bitmap}'s {@link org.mapsforge.core.graphics.TileBitmap#getTimestamp()} and TTL is less than current time
+	 * (as returned by {@link java.lang.System#currentTimeMillis()}).</li>
+	 * </ul>
+	 * <p>
+	 * When a tile has become stale, the layer will first display the tile referenced by {@code bitmap} and attempt to
+	 * obtain a fresh copy in the background. When a fresh copy becomes available, the layer will replace it and update
+	 * the cache. If a fresh copy cannot be obtained (e.g. because the tile is obtained from an online source which
+	 * cannot be reached), the stale tile will continue to be used until another
+	 * {@code #draw(BoundingBox, byte, Canvas, Point)} operation requests it again.
+	 * 
+	 * @param tile
+	 *            A tile. This parameter is not used for a {@code TileDownloadLayer} and can be null.
+	 * @param bitmap
+	 *            The bitmap for {@code tile} currently held in the layer's cache.
+	 */
+	@Override
+	protected boolean isTileStale(Tile tile, TileBitmap bitmap) {
+		if (bitmap.isExpired())
+			return true;
+		if (cacheTTL == 0)
+			return false;
+		return ((bitmap.getTimestamp() + cacheTTL) < System.currentTimeMillis());
 	}
 }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/download/TileDownloader.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/download/TileDownloader.java
@@ -64,8 +64,10 @@ class TileDownloader {
 		InputStream inputStream = getInputStream(urlConnection);
 
 		try {
-			return this.graphicFactory.createTileBitmap(inputStream, this.downloadJob.tile.tileSize,
+			TileBitmap result = this.graphicFactory.createTileBitmap(inputStream, this.downloadJob.tile.tileSize,
 					this.downloadJob.hasAlpha);
+			result.setExpiration(urlConnection.getExpiration());
+			return result;
 		} catch (CorruptedInputStreamException e) {
 			// the creation of the tile bit map can fail at, at least on Android,
 			// when the connection is slow or busy, returning null here ensures that

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/download/tilesource/AbstractTileSource.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/download/tilesource/AbstractTileSource.java
@@ -18,7 +18,23 @@ package org.mapsforge.map.layer.download.tilesource;
 
 import java.util.Random;
 
+/**
+ * The abstract base class for tiles downloaded from a web server.
+ * <p>
+ * This class defines a default TTL for cached tiles, accessible through the {@link #getDefaultTTL()} method. The value
+ * here will be used as the initial TTL by the {@link org.mapsforge.map.layer.download.TileDownloadLayer} using this
+ * tile source, but applications can change the TTL at any time (refer to
+ * {@link org.mapsforge.map.layer.download.TileDownloadLayer} for details). The default value is set to one day, or
+ * 86,400,000 milliseconds. Subclasses should set {@code #defaultTTL} in their constructor to a value that is
+ * appropriate for their tile source.
+ */
 public abstract class AbstractTileSource implements TileSource {
+
+	/**
+	 * The default TTL for cached tiles.
+	 */
+	protected long defaultTTL = 86400000;
+
 	protected final String[] hostNames;
 	protected final int port;
 	protected final Random random = new Random();
@@ -35,7 +51,6 @@ public abstract class AbstractTileSource implements TileSource {
 				throw new IllegalArgumentException("empty host name in host name list");
 			}
 		}
-
 
 		this.hostNames = hostNames;
 		this.port = port;
@@ -59,6 +74,14 @@ public abstract class AbstractTileSource implements TileSource {
 			return false;
 		}
 		return true;
+	}
+
+	/**
+	 * Returns the default TTL for cached tiles.
+	 */
+	@Override
+	public long getDefaultTTL() {
+		return defaultTTL;
 	}
 
 	@Override

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/download/tilesource/OpenStreetMapMapnik.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/download/tilesource/OpenStreetMapMapnik.java
@@ -21,9 +21,18 @@ import java.net.URL;
 
 import org.mapsforge.core.model.Tile;
 
+/**
+ * A tile source which fetches standard Mapnik tiles from OpenStreetMap.
+ * <p>
+ * Layers using this tile source will enforce a TTL of 6,649,000 milliseconds for cached tiles (unless the application
+ * explicitly sets a different TTL for that layer). The default TTL corresponds to the lifetime which the OSM server
+ * sets on a newly rendered tile.
+ * <p>
+ * Refer to {@link org.mapsforge.map.layer.download.TileDownloadLayer} for details on the TTL mechanism.
+ */
 public class OpenStreetMapMapnik extends AbstractTileSource {
 	public static final OpenStreetMapMapnik INSTANCE = new OpenStreetMapMapnik(new String[] {
-			"a.tile.openstreetmap.org",	"b.tile.openstreetmap.org", "c.tile.openstreetmap.org" }, 80);
+			"a.tile.openstreetmap.org", "b.tile.openstreetmap.org", "c.tile.openstreetmap.org" }, 80);
 	private static final int PARALLEL_REQUESTS_LIMIT = 8;
 	private static final String PROTOCOL = "http";
 	private static final int ZOOM_LEVEL_MAX = 18;
@@ -31,6 +40,7 @@ public class OpenStreetMapMapnik extends AbstractTileSource {
 
 	public OpenStreetMapMapnik(String[] hostNames, int port) {
 		super(hostNames, port);
+		defaultTTL = 6649000;
 	}
 
 	@Override

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/download/tilesource/TileSource.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/download/tilesource/TileSource.java
@@ -22,6 +22,11 @@ import org.mapsforge.core.model.Tile;
 
 public interface TileSource {
 	/**
+	 * Returns the default TTL for cached tiles.
+	 */
+	long getDefaultTTL();
+
+	/**
 	 * @return the maximum number of parallel requests which this {@code TileSource} supports.
 	 */
 	int getParallelRequestsLimit();

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/DatabaseRenderer.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/DatabaseRenderer.java
@@ -16,7 +16,6 @@
  */
 package org.mapsforge.map.layer.renderer;
 
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -31,12 +30,12 @@ import java.util.logging.Logger;
 import org.mapsforge.core.graphics.Bitmap;
 import org.mapsforge.core.graphics.Color;
 import org.mapsforge.core.graphics.Display;
-import org.mapsforge.core.mapelements.MapElementContainer;
-import org.mapsforge.core.graphics.Position;
 import org.mapsforge.core.graphics.GraphicFactory;
 import org.mapsforge.core.graphics.Paint;
-import org.mapsforge.core.mapelements.SymbolContainer;
+import org.mapsforge.core.graphics.Position;
 import org.mapsforge.core.graphics.TileBitmap;
+import org.mapsforge.core.mapelements.MapElementContainer;
+import org.mapsforge.core.mapelements.SymbolContainer;
 import org.mapsforge.core.model.LatLong;
 import org.mapsforge.core.model.Point;
 import org.mapsforge.core.model.Rectangle;
@@ -57,15 +56,10 @@ import org.mapsforge.map.rendertheme.rule.RenderThemeHandler;
 import org.mapsforge.map.util.LayerUtil;
 import org.xmlpull.v1.XmlPullParserException;
 
-
 /**
- * The DatabaseRenderer renders map tiles by reading from a {@link org.mapsforge.map.reader.MapFile}.
- *
- * Up to version 0.4.x the DatabaseRenderer was responsible for rendering ways, areas as
- * well as labels. However, the label placement algorithm suffered from multiple problems,
- * such as clipped labels at tile bounds.
- *
- *
+ * The DatabaseRenderer renders map tiles by reading from a {@link org.mapsforge.map.reader.MapFile}. Up to version
+ * 0.4.x the DatabaseRenderer was responsible for rendering ways, areas as well as labels. However, the label placement
+ * algorithm suffered from multiple problems, such as clipped labels at tile bounds.
  */
 public class DatabaseRenderer implements RenderCallback {
 
@@ -111,14 +105,13 @@ public class DatabaseRenderer implements RenderCallback {
 	private final TileDependencies tileDependencies;
 
 	/**
-	 * Constructs a new DatabaseRenderer that will not draw labels, instead it stores the label
-	 * information in the labelStore for drawing by a LabelLayer.
+	 * Constructs a new DatabaseRenderer that will not draw labels, instead it stores the label information in the
+	 * labelStore for drawing by a LabelLayer.
 	 * 
 	 * @param mapDatabase
 	 *            the MapDatabase from which the map data will be read.
 	 */
-	public DatabaseRenderer(MapDataStore mapDatabase, GraphicFactory graphicFactory,
-	                        TileBasedLabelStore labelStore) {
+	public DatabaseRenderer(MapDataStore mapDatabase, GraphicFactory graphicFactory, TileBasedLabelStore labelStore) {
 		this.mapDatabase = mapDatabase;
 		this.graphicFactory = graphicFactory;
 
@@ -131,12 +124,11 @@ public class DatabaseRenderer implements RenderCallback {
 
 	/**
 	 * Constructs a new DatabaseRenderer that will draw labels onto the tiles.
-	 *
+	 * 
 	 * @param mapFile
 	 *            the MapDatabase from which the map data will be read.
 	 */
-	public DatabaseRenderer(MapDataStore mapFile, GraphicFactory graphicFactory,
-	                        TileCache tileCache) {
+	public DatabaseRenderer(MapDataStore mapFile, GraphicFactory graphicFactory, TileCache tileCache) {
 		this.mapDatabase = mapFile;
 		this.graphicFactory = graphicFactory;
 
@@ -146,7 +138,6 @@ public class DatabaseRenderer implements RenderCallback {
 		this.tileCache = tileCache;
 		this.tileDependencies = new TileDependencies();
 	}
-
 
 	public void destroy() {
 		this.canvasRasterer.destroy();
@@ -199,8 +190,10 @@ public class DatabaseRenderer implements RenderCallback {
 
 			if (!rendererJob.labelsOnly) {
 				bitmap = this.graphicFactory.createTileBitmap(tileSize, rendererJob.hasAlpha);
+				bitmap.setTimestamp(rendererJob.mapDataStore.getDataTimestamp(rendererJob.tile));
 				this.canvasRasterer.setCanvasBitmap(bitmap);
-				if (!rendererJob.hasAlpha && rendererJob.displayModel.getBackgroundColor() != this.renderTheme.getMapBackground()) {
+				if (!rendererJob.hasAlpha
+						&& rendererJob.displayModel.getBackgroundColor() != this.renderTheme.getMapBackground()) {
 					this.canvasRasterer.fill(this.renderTheme.getMapBackground());
 				}
 				this.canvasRasterer.drawWays(ways, rendererJob.tile);
@@ -349,10 +342,11 @@ public class DatabaseRenderer implements RenderCallback {
 	}
 
 	@Override
-	public void renderAreaCaption(PolylineContainer way, Display display, int priority, String caption, float horizontalOffset, float verticalOffset,
-	                              Paint fill, Paint stroke, Position position, int maxTextWidth) {
+	public void renderAreaCaption(PolylineContainer way, Display display, int priority, String caption,
+			float horizontalOffset, float verticalOffset, Paint fill, Paint stroke, Position position, int maxTextWidth) {
 		Point centerPoint = way.getCenterAbsolute().offset(horizontalOffset, verticalOffset);
-		this.currentLabels.add(this.graphicFactory.createPointTextContainer(centerPoint, display, priority, caption, fill, stroke, null, position, maxTextWidth));
+		this.currentLabels.add(this.graphicFactory.createPointTextContainer(centerPoint, display, priority, caption,
+				fill, stroke, null, position, maxTextWidth));
 	}
 
 	@Override
@@ -363,16 +357,19 @@ public class DatabaseRenderer implements RenderCallback {
 	}
 
 	@Override
-	public void renderPointOfInterestCaption(PointOfInterest poi, Display display, int priority, String caption, float horizontalOffset, float verticalOffset,
-	                                         Paint fill, Paint stroke, Position position, int maxTextWidth, Tile tile) {
+	public void renderPointOfInterestCaption(PointOfInterest poi, Display display, int priority, String caption,
+			float horizontalOffset, float verticalOffset, Paint fill, Paint stroke, Position position,
+			int maxTextWidth, Tile tile) {
 		Point poiPosition = MercatorProjection.getPixelAbsolute(poi.position, tile.mapSize);
 
-		this.currentLabels.add(this.graphicFactory.createPointTextContainer(poiPosition.offset(horizontalOffset, verticalOffset), display, priority, caption, fill,
-				stroke, null, position, maxTextWidth));
+		this.currentLabels.add(this.graphicFactory.createPointTextContainer(
+				poiPosition.offset(horizontalOffset, verticalOffset), display, priority, caption, fill, stroke, null,
+				position, maxTextWidth));
 	}
 
 	@Override
-	public void renderPointOfInterestCircle(PointOfInterest poi, float radius, Paint fill, Paint stroke, int level, Tile tile) {
+	public void renderPointOfInterestCircle(PointOfInterest poi, float radius, Paint fill, Paint stroke, int level,
+			Tile tile) {
 		List<ShapePaintContainer> list = this.drawingLayers.get(level);
 		Point poiPosition = MercatorProjection.getPixelRelativeToTile(poi.position, tile);
 		list.add(new ShapePaintContainer(new CircleContainer(poiPosition, radius), stroke));
@@ -391,15 +388,17 @@ public class DatabaseRenderer implements RenderCallback {
 	}
 
 	@Override
-	public void renderWaySymbol(PolylineContainer way, Display display, int priority, Bitmap symbol, float dy, boolean alignCenter, boolean repeat,
-	                     float repeatGap, float repeatStart, boolean rotate) {
-		WayDecorator.renderSymbol(symbol, display, priority, dy, alignCenter, repeat, repeatGap,
-				repeatStart, rotate, way.getCoordinatesAbsolute(), this.currentLabels);
+	public void renderWaySymbol(PolylineContainer way, Display display, int priority, Bitmap symbol, float dy,
+			boolean alignCenter, boolean repeat, float repeatGap, float repeatStart, boolean rotate) {
+		WayDecorator.renderSymbol(symbol, display, priority, dy, alignCenter, repeat, repeatGap, repeatStart, rotate,
+				way.getCoordinatesAbsolute(), this.currentLabels);
 	}
 
 	@Override
-	public void renderWayText(PolylineContainer way, Display display, int priority, String textKey, float dy, Paint fill, Paint stroke) {
-		WayDecorator.renderText(way.getTile(), textKey, display, priority, dy, fill, stroke, way.getCoordinatesAbsolute(), this.currentLabels);
+	public void renderWayText(PolylineContainer way, Display display, int priority, String textKey, float dy,
+			Paint fill, Paint stroke) {
+		WayDecorator.renderText(way.getTile(), textKey, display, priority, dy, fill, stroke,
+				way.getCoordinatesAbsolute(), this.currentLabels);
 	}
 
 	private List<List<List<ShapePaintContainer>>> createWayLists() {
@@ -427,7 +426,8 @@ public class DatabaseRenderer implements RenderCallback {
 		return null;
 	}
 
-	private void processReadMapData(final List<List<List<ShapePaintContainer>>> ways, MapReadResult mapReadResult, Tile tile) {
+	private void processReadMapData(final List<List<List<ShapePaintContainer>>> ways, MapReadResult mapReadResult,
+			Tile tile) {
 		if (mapReadResult == null) {
 			return;
 		}
@@ -445,7 +445,8 @@ public class DatabaseRenderer implements RenderCallback {
 		}
 	}
 
-	private void renderPointOfInterest(final List<List<List<ShapePaintContainer>>> ways, PointOfInterest pointOfInterest, Tile tile) {
+	private void renderPointOfInterest(final List<List<List<ShapePaintContainer>>> ways,
+			PointOfInterest pointOfInterest, Tile tile) {
 		this.drawingLayers = ways.get(getValidLayer(pointOfInterest.layer));
 		this.renderTheme.matchNode(this, pointOfInterest, tile);
 	}

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/TileRendererLayer.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/TileRendererLayer.java
@@ -16,7 +16,11 @@
  */
 package org.mapsforge.map.layer.renderer;
 
+import org.mapsforge.core.graphics.Canvas;
 import org.mapsforge.core.graphics.GraphicFactory;
+import org.mapsforge.core.graphics.TileBitmap;
+import org.mapsforge.core.model.BoundingBox;
+import org.mapsforge.core.model.Point;
 import org.mapsforge.core.model.Tile;
 import org.mapsforge.map.layer.TileLayer;
 import org.mapsforge.map.layer.cache.TileCache;
@@ -37,15 +41,22 @@ public class TileRendererLayer extends TileLayer<RendererJob> {
 
 	/**
 	 * Creates a TileRendererLayer.
-	 * @param tileCache cache where tiles are stored
-	 * @param mapDataStore the mapsforge map file
-	 * @param mapViewPosition the mapViewPosition to know which tiles to render
-	 * @param isTransparent true if the tile should have an alpha/transparency
-	 * @param renderLabels true if labels should be rendered onto tiles
-	 * @param graphicFactory the graphicFactory to carry out platform specific operations
+	 * 
+	 * @param tileCache
+	 *            cache where tiles are stored
+	 * @param mapDataStore
+	 *            the mapsforge map file
+	 * @param mapViewPosition
+	 *            the mapViewPosition to know which tiles to render
+	 * @param isTransparent
+	 *            true if the tile should have an alpha/transparency
+	 * @param renderLabels
+	 *            true if labels should be rendered onto tiles
+	 * @param graphicFactory
+	 *            the graphicFactory to carry out platform specific operations
 	 */
-	public TileRendererLayer(TileCache tileCache, MapDataStore mapDataStore, MapViewPosition mapViewPosition, boolean isTransparent,
-	                         boolean renderLabels, GraphicFactory graphicFactory) {
+	public TileRendererLayer(TileCache tileCache, MapDataStore mapDataStore, MapViewPosition mapViewPosition,
+			boolean isTransparent, boolean renderLabels, GraphicFactory graphicFactory) {
 		super(tileCache, mapViewPosition, graphicFactory.createMatrix(), isTransparent);
 
 		this.mapDataStore = mapDataStore;
@@ -60,8 +71,9 @@ public class TileRendererLayer extends TileLayer<RendererJob> {
 	}
 
 	/**
-	 * If the labels are not rendered onto the tile directly, they are stored in a LabelStore for
-	 * rendering on a separate Layer.
+	 * If the labels are not rendered onto the tile directly, they are stored in a LabelStore for rendering on a
+	 * separate Layer.
+	 * 
 	 * @return the LabelStore used for storing labels, null if labels are rendered onto tiles directly.
 	 */
 	public LabelStore getLabelStore() {
@@ -100,7 +112,6 @@ public class TileRendererLayer extends TileLayer<RendererJob> {
 		}
 	}
 
-
 	public void setTextScale(float textScale) {
 		this.textScale = textScale;
 	}
@@ -113,6 +124,30 @@ public class TileRendererLayer extends TileLayer<RendererJob> {
 	protected RendererJob createJob(Tile tile) {
 		return new RendererJob(tile, this.mapDataStore, this.xmlRenderTheme, this.displayModel, this.textScale,
 				this.isTransparent, false);
+	}
+
+	/**
+	 * Whether the tile is stale and should be refreshed.
+	 * <p>
+	 * This method is called from {@link #draw(BoundingBox, byte, Canvas, Point)} to determine whether the tile needs to
+	 * be refreshed.
+	 * <p>
+	 * A tile is considered stale if the timestamp of the layer's {@link #mapDatabase} is more recent than the
+	 * {@code bitmap}'s {@link org.mapsforge.core.graphics.TileBitmap#getTimestamp()}.
+	 * <p>
+	 * When a tile has become stale, the layer will first display the tile referenced by {@code bitmap} and attempt to
+	 * obtain a fresh copy in the background. When a fresh copy becomes available, the layer will replace is and update
+	 * the cache. If a fresh copy cannot be obtained for whatever reason, the stale tile will continue to be used until
+	 * another {@code #draw(BoundingBox, byte, Canvas, Point)} operation requests it again.
+	 * 
+	 * @param tile
+	 *            A tile.
+	 * @param bitmap
+	 *            The bitmap for {@code tile} currently held in the layer's cache.
+	 */
+	@Override
+	protected boolean isTileStale(Tile tile, TileBitmap bitmap) {
+		return this.mapDataStore.getDataTimestamp(tile) > bitmap.getTimestamp();
 	}
 
 	@Override

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/tilestore/TileStoreLayer.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/tilestore/TileStoreLayer.java
@@ -15,16 +15,17 @@
 package org.mapsforge.map.layer.tilestore;
 
 import org.mapsforge.core.graphics.GraphicFactory;
+import org.mapsforge.core.graphics.TileBitmap;
 import org.mapsforge.core.model.Tile;
 import org.mapsforge.map.layer.TileLayer;
 import org.mapsforge.map.layer.cache.TileCache;
 import org.mapsforge.map.layer.queue.Job;
 import org.mapsforge.map.model.MapViewPosition;
 
-
 public class TileStoreLayer extends TileLayer<Job> {
 
-	public TileStoreLayer(TileCache tileCache, MapViewPosition mapViewPosition, GraphicFactory graphicFactory, boolean isTransparent) {
+	public TileStoreLayer(TileCache tileCache, MapViewPosition mapViewPosition, GraphicFactory graphicFactory,
+			boolean isTransparent) {
 		super(tileCache, mapViewPosition, graphicFactory.createMatrix(), isTransparent, false);
 	}
 
@@ -33,4 +34,18 @@ public class TileStoreLayer extends TileLayer<Job> {
 		return new Job(tile, isTransparent);
 	}
 
+	/**
+	 * Whether the tile is stale and should be refreshed.
+	 * <p>
+	 * This method is not needed for a TileStoreLayer and will always return {@code false}. Both arguments can be null.
+	 * 
+	 * @param tile
+	 *            A tile.
+	 * @param bitmap
+	 *            The bitmap for {@code tile} currently held in the layer's cache.
+	 */
+	@Override
+	protected boolean isTileStale(Tile tile, TileBitmap bitmap) {
+		return false;
+	}
 }

--- a/mapsforge-map/src/test/java/org/mapsforge/map/layer/cache/FileSystemTileCacheTest.java
+++ b/mapsforge-map/src/test/java/org/mapsforge/map/layer/cache/FileSystemTileCacheTest.java
@@ -87,7 +87,7 @@ public class FileSystemTileCacheTest {
 	@Test
 	public void capacityZeroTest() {
 		for (int tileSize : TILE_SIZES) {
-			TileCache tileCache = new FileSystemTileCache(0, this.cacheDirectory, GRAPHIC_FACTORY, false, 0);
+			TileCache tileCache = new FileSystemTileCache(0, this.cacheDirectory, GRAPHIC_FACTORY, false, 0, false);
 			Tile tile = new Tile(0, 0, (byte) 0, tileSize);
 			TileSource tileSource = OpenStreetMapMapnik.INSTANCE;
 			Job job = new DownloadJob(tile, tileSource);

--- a/mapsforge-map/src/test/java/org/mapsforge/map/layer/download/InvalidTileSource.java
+++ b/mapsforge-map/src/test/java/org/mapsforge/map/layer/download/InvalidTileSource.java
@@ -22,6 +22,11 @@ import org.mapsforge.map.layer.download.tilesource.TileSource;
 
 class InvalidTileSource implements TileSource {
 	@Override
+	public long getDefaultTTL() {
+		throw new AssertionError();
+	}
+
+	@Override
 	public int getParallelRequestsLimit() {
 		throw new AssertionError();
 	}


### PR DESCRIPTION
Here's the squashed commit. All files contain logical changes; however, I've been unable to undo pure formatting changes (as soon as I try to restore the old formatting and save, Eclipse reformats everyting).

FileSystemTileCache can be created as a persistent cache, which will retain its contents across instances.
Lifetime of a tile in cache can now be limited; stale tiles will still be served from cache but a refresh will be attempted
Cache purge (delete contents) and destroy (prepare to exit) are now separate operations

Signed-off-by: mvglasow <michael -at- vonglasow.com>
