### PR TITLE
Persistent Cache: cleaned-up version as implemented by @mvglasow

### DIFF
--- a/Applications/Android/Samples/src/main/java/org/mapsforge/applications/android/samples/SamplesBaseActivity.java
+++ b/Applications/Android/Samples/src/main/java/org/mapsforge/applications/android/samples/SamplesBaseActivity.java
@@ -96,7 +96,7 @@ public abstract class SamplesBaseActivity extends MapViewerTemplate implements S
 		this.tileCaches.add(AndroidUtil.createTileCache(this, getPersistableId(),
 				this.mapView.getModel().displayModel.getTileSize(), this.getScreenRatio(),
 				this.mapView.getModel().frameBufferModel.getOverdrawFactor(),
-				threaded, queueSize
+				threaded, queueSize, true
 		));
 	}
 

--- a/Applications/Android/Samples/src/main/java/org/mapsforge/applications/android/samples/SimplestMapViewer.java
+++ b/Applications/Android/Samples/src/main/java/org/mapsforge/applications/android/samples/SimplestMapViewer.java
@@ -78,7 +78,7 @@ public class SimplestMapViewer extends MapViewerTemplate {
 		this.tileCaches.add(AndroidUtil.createTileCache(this, getPersistableId(),
 				this.mapView.getModel().displayModel.getTileSize(), this.getScreenRatio(),
 				this.mapView.getModel().frameBufferModel.getOverdrawFactor(),
-				false, 0
+				false, 0, false
 		));
 	}
 

--- a/mapsforge-core/src/main/java/org/mapsforge/core/graphics/TileBitmap.java
+++ b/mapsforge-core/src/main/java/org/mapsforge/core/graphics/TileBitmap.java
@@ -15,5 +15,52 @@
 package org.mapsforge.core.graphics;
 
 public interface TileBitmap extends Bitmap {
-	// only different behaviour
+
+	/**
+	 * Returns the timestamp of the tile in milliseconds since January 1, 1970 GMT or 0 if this timestamp is unknown.
+	 * <p>
+	 * The timestamp indicates when the tile was created and can be used together with a TTL in order to determine
+	 * whether to treat it as expired.
+	 */
+	public long getTimestamp();
+
+	/**
+	 * Whether the TileBitmap has expired.
+	 * <p>
+	 * When a tile has expired, the requester should try to replace it with a fresh copy as soon as possible. The
+	 * expired tile may still be displayed to the user until the fresh copy is available. This may be desirable if
+	 * obtaining a fresh copy is time-consuming or a fresh copy is currently unavailable (e.g. because no network
+	 * connection is available for a {@link org.mapsforge.map.layer.download.tilesource.TileSource}).
+	 * 
+	 * @return {@code true} if expired, {@code false} otherwise.
+	 */
+	public boolean isExpired();
+
+	/**
+	 * Returns the timestamp when this tile will be expired in milliseconds since January 1, 1970 GMT or 0 if this
+	 * timestamp is unknown.
+	 * <p>
+	 * The timestamp indicates when the tile should be treated it as expired, i.e. {@link #isExpired()} will return
+	 * {@code true}. For a downloaded tile, pass the value returned by
+	 * {@link java.net.HttpURLConnection#getExpiration()}, if set by the server. In all other cases you can pass current
+	 * time plus a fixed TTL in order to have the tile expire after the specified time.
+	 */
+	public void setExpiration(long expiration);
+
+	/**
+	 * Sets the timestamp of the tile in milliseconds since January 1, 1970 GMT.
+	 * <p>
+	 * The timestamp indicates when the information to create the tile was last retrieved from the source. It can be
+	 * used together with a TTL in order to determine whether to treat it as expired.
+	 * <p>
+	 * The timestamp of a locally rendered tile should be set to the timestamp of the map database used to render it, as
+	 * returned by {@link org.mapsforge.map.reader.header.MapFileInfo#mapDate}. For a tile read from a disk cache, it
+	 * should be the file's timestamp. In all other cases (including downloaded tiles), the timestamp should be set to
+	 * wall clock time (as returned by {@link java.lang.System#currentTimeMillis()}) when the tile is created.
+	 * <p>
+	 * Classes that implement this interface should call {@link java.lang.System#currentTimeMillis()} upon creating an
+	 * instance, store the result and return it unless {@code setTimestamp()} has been called for that instance.
+	 */
+	public void setTimestamp(long timestamp);
+
 }

--- a/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidTileBitmap.java
+++ b/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidTileBitmap.java
@@ -96,6 +96,9 @@ public class AndroidTileBitmap extends AndroidBitmap implements TileBitmap {
 		return bitmap;
 	}
 
+	private long expiration = 0;
+	private long timestamp = System.currentTimeMillis();
+
 	/*
 	 * THIS CAN THROW AN IllegalArgumentException or SocketTimeoutException The inputStream can be corrupt for various
 	 * reasons (slow download or slow access to file system) and will then raise an exception. This exception must be
@@ -141,6 +144,28 @@ public class AndroidTileBitmap extends AndroidBitmap implements TileBitmap {
 		if (AndroidGraphicFactory.DEBUG_BITMAPS) {
 			tileInstances.incrementAndGet();
 		}
+	}
+
+	@Override
+	public long getTimestamp() {
+		return timestamp;
+	}
+
+	@Override
+	public boolean isExpired() {
+		if (expiration == 0)
+			return false;
+		return (expiration >= System.currentTimeMillis());
+	}
+
+	@Override
+	public void setExpiration(long expiration) {
+		this.expiration = expiration;
+	}
+
+	@Override
+	public void setTimestamp(long timestamp) {
+		this.timestamp = timestamp;
 	}
 
 	@Override

--- a/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/AwtTileBitmap.java
+++ b/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/AwtTileBitmap.java
@@ -25,12 +25,37 @@ import org.mapsforge.core.graphics.TileBitmap;
 
 public class AwtTileBitmap extends AwtBitmap implements TileBitmap {
 
+	private long expiration = 0;
+	private long timestamp = System.currentTimeMillis();
+
 	public AwtTileBitmap(InputStream inputStream) throws IOException {
 		super(inputStream);
 	}
 
 	public AwtTileBitmap(int tileSize) {
 		super(tileSize, tileSize);
+	}
+
+	@Override
+	public long getTimestamp() {
+		return timestamp;
+	}
+
+	@Override
+	public boolean isExpired() {
+		if (expiration == 0)
+			return false;
+		return (expiration >= System.currentTimeMillis());
+	}
+
+	@Override
+	public void setExpiration(long expiration) {
+		this.expiration = expiration;
+	}
+
+	@Override
+	public void setTimestamp(long timestamp) {
+		this.timestamp = timestamp;
 	}
 
 	public AwtTileBitmap(int tileSize, boolean hasAlpha) {

--- a/mapsforge-map-reader/src/main/java/org/mapsforge/map/reader/MapDataStore.java
+++ b/mapsforge-map-reader/src/main/java/org/mapsforge/map/reader/MapDataStore.java
@@ -36,6 +36,15 @@ public interface MapDataStore {
 	void close();
 
 	/**
+	 * Returns the timestamp of the data used to render a specific tile.
+	 *
+	 * @param tile
+	 *            A tile.
+	 * @return the timestamp of the data used to render the tile
+	 */
+	long getDataTimestamp(Tile tile);
+
+	/**
 	 * Gets the initial map position.
 	 * @return the start position, if available.
 	 */

--- a/mapsforge-map-reader/src/main/java/org/mapsforge/map/reader/MapFile.java
+++ b/mapsforge-map-reader/src/main/java/org/mapsforge/map/reader/MapFile.java
@@ -295,6 +295,27 @@ public class MapFile implements MapDataStore {
 	}
 
 	/**
+	 * Returns the creation timestamp of the map file.
+	 * @param tile not used, as all tiles will shared the same creation date.
+	 * @return the creation timestamp inside the map file.
+	 */
+	@Override
+	public long getDataTimestamp(Tile tile) {
+		/*
+		* FIXME: we should really use the timestamp of the underlying file. Assume the following case: We have a map
+		* file with mapDate = January 1. On March 1 we render a tile. The OS doesn't let us change the file date, so
+		* the cached file has a timestamp of March 1. On March 15 we download a new map with mapDate = February 15. The
+		* same day, we request the same tile again. Since its timestamp reads March 1 and getDataTimestamp() returns
+		* February 15, the cached bitmap is deemed up to date and returned. In reality the tile is stale and should be
+		* re-rendered. Examining the timestamp of the underlying file would reveal that (bitmap: March 1, map: March
+		* 15) and cause the tile to be re-rendered. It would also behave as expected when the user downgrades to an
+		* older map file for whatever reason, as long as the file timestamp reflects the date when the old file was
+		* copied back in place.
+		*/
+		return this.getMapFileInfo().mapDate;
+	}
+
+	/**
 	 * Reads all map data for the area covered by the given tile at the tile zoom level.
 	 *
 	 * @param tile

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/TileLayer.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/TileLayer.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import org.mapsforge.core.graphics.Bitmap;
 import org.mapsforge.core.graphics.Canvas;
 import org.mapsforge.core.graphics.Matrix;
+import org.mapsforge.core.graphics.TileBitmap;
 import org.mapsforge.core.model.BoundingBox;
 import org.mapsforge.core.model.Point;
 import org.mapsforge.core.model.Tile;
@@ -92,7 +93,7 @@ public abstract class TileLayer<T extends Job> extends Layer {
 			Point point = tilePosition.point;
 			Tile tile = tilePosition.tile;
 			T job = createJob(tile);
-			Bitmap bitmap = this.tileCache.getImmediately(job);
+			TileBitmap bitmap = this.tileCache.getImmediately(job);
 
 			if (bitmap == null) {
 				if (this.hasJobQueue && !this.tileCache.containsKey(job)) {
@@ -102,6 +103,9 @@ public abstract class TileLayer<T extends Job> extends Layer {
 				}
 				drawParentTileBitmap(canvas, point, tile);
 			} else {
+				if (isTileStale(tile, bitmap) && this.hasJobQueue && !this.tileCache.containsKey(job)) {
+					this.jobQueue.add(job);
+				}
 				retrieveLabelsOnly(job);
 				canvas.drawBitmap(bitmap, (int) Math.round(point.x), (int) Math.round(point.y));
 				bitmap.decrementRefCount();
@@ -127,7 +131,31 @@ public abstract class TileLayer<T extends Job> extends Layer {
 	}
 
 	protected abstract T createJob(Tile tile);
-	protected void retrieveLabelsOnly(T job) {}
+
+	/**
+	 * Whether the tile is stale and should be refreshed.
+	 * <p>
+	 * This method is called from {@link #draw(BoundingBox, byte, Canvas, Point)} to determine whether the tile needs to
+	 * be refreshed. Subclasses must override this method and implement appropriate checks to determine when a tile is
+	 * stale.
+	 * <p>
+	 * Return {@code false} to use the cached copy without attempting to refresh it.
+	 * <p>
+	 * Return {@code true} to cause the layer to attempt to obtain a fresh copy of the tile. The layer will first
+	 * display the tile referenced by {@code bitmap} and attempt to obtain a fresh copy in the background. When a fresh
+	 * copy becomes available, the layer will replace is and update the cache. If a fresh copy cannot be obtained (e.g.
+	 * because the tile is obtained from an online source which cannot be reached), the stale tile will continue to be
+	 * used until another {@code #draw(BoundingBox, byte, Canvas, Point)} operation requests it again.
+	 *
+	 * @param tile
+	 *            A tile.
+	 * @param bitmap
+	 *            The bitmap for {@code tile} currently held in the layer's cache.
+	 */
+	protected abstract boolean isTileStale(Tile tile, TileBitmap bitmap);
+
+	protected void retrieveLabelsOnly(T job) {
+	}
 
 	private void drawParentTileBitmap(Canvas canvas, Point point, Tile tile) {
 		Tile cachedParentTile = getCachedParentTile(tile, 4);

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/cache/InMemoryTileCache.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/cache/InMemoryTileCache.java
@@ -41,7 +41,6 @@ public class InMemoryTileCache implements TileCache {
 		this.lruCache = new BitmapLRUCache(capacity);
 	}
 
-
 	@Override
 	public synchronized boolean containsKey(Job key) {
 		return this.lruCache.containsKey(key);
@@ -49,12 +48,8 @@ public class InMemoryTileCache implements TileCache {
 
 	@Override
 	public synchronized void destroy() {
-		for (TileBitmap bitmap : this.lruCache.values()) {
-			bitmap.decrementRefCount();
-		}
-		this.lruCache.clear();
+		purge();
 	}
-
 
 	@Override
 	public synchronized TileBitmap get(Job key) {
@@ -80,7 +75,13 @@ public class InMemoryTileCache implements TileCache {
 		return get(key);
 	}
 
-
+	@Override
+	public void purge() {
+		for (TileBitmap bitmap : this.lruCache.values()) {
+			bitmap.decrementRefCount();
+		}
+		this.lruCache.clear();
+	}
 
 	@Override
 	public synchronized void put(Job key, TileBitmap bitmap) {

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/cache/TileCache.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/cache/TileCache.java
@@ -33,6 +33,13 @@ public interface TileCache {
 
 	/**
 	 * Destroys this cache.
+	 * <p>
+	 * Applications are expected to call this method when they no longer require the cache.
+	 * <p>
+	 * In versions prior to 0.5.0, it was common practice to call this method but continue using the cache, in order to
+	 * empty it, forcing all tiles to be re-rendered or re-requested from the source. Beginning with 0.5.0,
+	 * {@link #purge()} should be used for this purpose. The earlier practice is now discouraged and may lead to
+	 * unexpected results when used with features introduced in 0.5.0 or later.
 	 */
 	void destroy();
 
@@ -53,11 +60,24 @@ public interface TileCache {
 	int getCapacityFirstLevel();
 
 	/**
-	 * Returns tileBitmap only if available at fastest cache in case of multi-layered
-	 * cache, null otherwise.
+	 * Returns tileBitmap only if available at fastest cache in case of multi-layered cache, null otherwise.
+	 * 
 	 * @return tileBitmap if available without getting from lower storage levels
 	 */
 	TileBitmap getImmediately(Job key);
+
+	/**
+	 * Purges this cache.
+	 * <p>
+	 * Calls to {@link #get(Job)} issued after purging will not return any tiles added before the purge operation.
+	 * <p>
+	 * Applications should purge the tile cache when map model parameters change, such as the render style for locally
+	 * rendered tiles, or the source for downloaded tiles. Applications which frequently alternate between a limited
+	 * number of map model configurations may want to consider using a different cache for each.
+	 * 
+	 * @since 0.5.0
+	 */
+	void purge();
 
 	/**
 	 * @throws IllegalArgumentException
@@ -67,8 +87,8 @@ public interface TileCache {
 	void put(Job key, TileBitmap bitmap);
 
 	/**
-	 * Reserves a working set in this cache, for multi-level caches this means bringing
-	 * the elements in workingSet into the fastest cache.
+	 * Reserves a working set in this cache, for multi-level caches this means bringing the elements in workingSet into
+	 * the fastest cache.
 	 */
 	void setWorkingSet(Set<Job> workingSet);
 }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/cache/TileStore.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/cache/TileStore.java
@@ -109,6 +109,10 @@ public class TileStore implements TileCache {
 		return get(key);
 	}
 
+	@Override
+	public synchronized void purge() {
+		// no-op
+	}
 
 	@Override
 	public synchronized void put(Job key, TileBitmap bitmap) {

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/cache/TwoLevelTileCache.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/cache/TwoLevelTileCache.java
@@ -79,6 +79,12 @@ public class TwoLevelTileCache implements TileCache {
 	}
 
 	@Override
+	public void purge() {
+		this.firstLevelTileCache.purge();
+		this.secondLevelTileCache.purge();
+	}
+
+	@Override
 	public void put(Job key, TileBitmap bitmap) {
 		if (this.workingSet.contains(key)) {
 			this.firstLevelTileCache.put(key, bitmap);

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/download/TileDownloadLayer.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/download/TileDownloadLayer.java
@@ -17,6 +17,7 @@ package org.mapsforge.map.layer.download;
 
 import org.mapsforge.core.graphics.Canvas;
 import org.mapsforge.core.graphics.GraphicFactory;
+import org.mapsforge.core.graphics.TileBitmap;
 import org.mapsforge.core.model.BoundingBox;
 import org.mapsforge.core.model.Point;
 import org.mapsforge.core.model.Tile;
@@ -29,6 +30,7 @@ import org.mapsforge.map.model.MapViewPosition;
 public class TileDownloadLayer extends TileLayer<DownloadJob> {
 	private static final int DOWNLOAD_THREADS_MAX = 8;
 
+	private long cacheTTL = 0;
 	private final GraphicFactory graphicFactory;
 	private boolean started;
 	private final TileCache tileCache;
@@ -41,6 +43,7 @@ public class TileDownloadLayer extends TileLayer<DownloadJob> {
 
 		this.tileCache = tileCache;
 		this.tileSource = tileSource;
+		this.cacheTTL = tileSource.getDefaultTTL();
 		this.graphicFactory = graphicFactory;
 	}
 
@@ -51,6 +54,15 @@ public class TileDownloadLayer extends TileLayer<DownloadJob> {
 		}
 
 		super.draw(boundingBox, zoomLevel, canvas, topLeftPoint);
+	}
+
+	/**
+	 * Returns the time-to-live (TTL) for tiles in the cache, or 0 if not set.
+	 * <p>
+	 * Refer to {@link #isTileStale(TileBitmap)} for information on how the TTL is enforced.
+	 */
+	public long getCacheTTL() {
+		return cacheTTL;
 	}
 
 	@Override
@@ -75,6 +87,20 @@ public class TileDownloadLayer extends TileLayer<DownloadJob> {
 		for (TileDownloadThread tileDownloadThread : this.tileDownloadThreads) {
 			tileDownloadThread.proceed();
 		}
+	}
+
+	/**
+	 * Sets the time-to-live (TTL) for tiles in the cache.
+	 * <p>
+	 * The initial TTL is obtained by calling the {@link org.mapsforge.map.layer.download.tilesource.TileSource}'s
+	 * {@link org.mapsforge.map.layer.download.tilesource.TileSource#getDefaultTTL()} method. Refer to
+	 * {@link #isTileStale(TileBitmap)} for information on how the TTL is enforced.
+	 * 
+	 * @param ttl
+	 *            The TTL. If set to 0, no TTL will be enforced.
+	 */
+	public void setCacheTTL(long ttl) {
+		cacheTTL = ttl;
 	}
 
 	@Override
@@ -107,5 +133,39 @@ public class TileDownloadLayer extends TileLayer<DownloadJob> {
 	@Override
 	protected DownloadJob createJob(Tile tile) {
 		return new DownloadJob(tile, this.tileSource);
+	}
+
+	/**
+	 * Whether the tile is stale and should be refreshed.
+	 * <p>
+	 * This method is called from {@link #draw(BoundingBox, byte, Canvas, Point)} to determine whether the tile needs to
+	 * be refreshed.
+	 * <p>
+	 * A tile is considered stale if one or more of the following two conditions apply:
+	 * <ul>
+	 * <li>The {@code bitmap}'s {@link org.mapsforge.core.graphics.TileBitmap#isExpired()} method returns {@code True}.</li>
+	 * <li>The layer has a time-to-live (TTL) set ({@link #getCacheTTL()} returns a nonzero value) and the sum of the
+	 * {@code bitmap}'s {@link org.mapsforge.core.graphics.TileBitmap#getTimestamp()} and TTL is less than current time
+	 * (as returned by {@link java.lang.System#currentTimeMillis()}).</li>
+	 * </ul>
+	 * <p>
+	 * When a tile has become stale, the layer will first display the tile referenced by {@code bitmap} and attempt to
+	 * obtain a fresh copy in the background. When a fresh copy becomes available, the layer will replace it and update
+	 * the cache. If a fresh copy cannot be obtained (e.g. because the tile is obtained from an online source which
+	 * cannot be reached), the stale tile will continue to be used until another
+	 * {@code #draw(BoundingBox, byte, Canvas, Point)} operation requests it again.
+	 * 
+	 * @param tile
+	 *            A tile. This parameter is not used for a {@code TileDownloadLayer} and can be null.
+	 * @param bitmap
+	 *            The bitmap for {@code tile} currently held in the layer's cache.
+	 */
+	@Override
+	protected boolean isTileStale(Tile tile, TileBitmap bitmap) {
+		if (bitmap.isExpired())
+			return true;
+		if (cacheTTL == 0)
+			return false;
+		return ((bitmap.getTimestamp() + cacheTTL) < System.currentTimeMillis());
 	}
 }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/download/TileDownloader.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/download/TileDownloader.java
@@ -64,8 +64,10 @@ class TileDownloader {
 		InputStream inputStream = getInputStream(urlConnection);
 
 		try {
-			return this.graphicFactory.createTileBitmap(inputStream, this.downloadJob.tile.tileSize,
+			TileBitmap result = this.graphicFactory.createTileBitmap(inputStream, this.downloadJob.tile.tileSize,
 					this.downloadJob.hasAlpha);
+			result.setExpiration(urlConnection.getExpiration());
+			return result;
 		} catch (CorruptedInputStreamException e) {
 			// the creation of the tile bit map can fail at, at least on Android,
 			// when the connection is slow or busy, returning null here ensures that

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/download/tilesource/AbstractTileSource.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/download/tilesource/AbstractTileSource.java
@@ -18,7 +18,23 @@ package org.mapsforge.map.layer.download.tilesource;
 
 import java.util.Random;
 
+/**
+ * The abstract base class for tiles downloaded from a web server.
+ * <p>
+ * This class defines a default TTL for cached tiles, accessible through the {@link #getDefaultTTL()} method. The value
+ * here will be used as the initial TTL by the {@link org.mapsforge.map.layer.download.TileDownloadLayer} using this
+ * tile source, but applications can change the TTL at any time (refer to
+ * {@link org.mapsforge.map.layer.download.TileDownloadLayer} for details). The default value is set to one day, or
+ * 86,400,000 milliseconds. Subclasses should set {@code #defaultTTL} in their constructor to a value that is
+ * appropriate for their tile source.
+ */
 public abstract class AbstractTileSource implements TileSource {
+
+	/**
+	 * The default TTL for cached tiles.
+	 */
+	protected long defaultTTL = 86400000;
+
 	protected final String[] hostNames;
 	protected final int port;
 	protected final Random random = new Random();
@@ -35,7 +51,6 @@ public abstract class AbstractTileSource implements TileSource {
 				throw new IllegalArgumentException("empty host name in host name list");
 			}
 		}
-
 
 		this.hostNames = hostNames;
 		this.port = port;
@@ -59,6 +74,14 @@ public abstract class AbstractTileSource implements TileSource {
 			return false;
 		}
 		return true;
+	}
+
+	/**
+	 * Returns the default TTL for cached tiles.
+	 */
+	@Override
+	public long getDefaultTTL() {
+		return defaultTTL;
 	}
 
 	@Override

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/download/tilesource/OpenStreetMapMapnik.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/download/tilesource/OpenStreetMapMapnik.java
@@ -21,9 +21,18 @@ import java.net.URL;
 
 import org.mapsforge.core.model.Tile;
 
+/**
+ * A tile source which fetches standard Mapnik tiles from OpenStreetMap.
+ * <p>
+ * Layers using this tile source will enforce a TTL of 6,649,000 milliseconds for cached tiles (unless the application
+ * explicitly sets a different TTL for that layer). The default TTL corresponds to the lifetime which the OSM server
+ * sets on a newly rendered tile.
+ * <p>
+ * Refer to {@link org.mapsforge.map.layer.download.TileDownloadLayer} for details on the TTL mechanism.
+ */
 public class OpenStreetMapMapnik extends AbstractTileSource {
 	public static final OpenStreetMapMapnik INSTANCE = new OpenStreetMapMapnik(new String[] {
-			"a.tile.openstreetmap.org",	"b.tile.openstreetmap.org", "c.tile.openstreetmap.org" }, 80);
+			"a.tile.openstreetmap.org", "b.tile.openstreetmap.org", "c.tile.openstreetmap.org" }, 80);
 	private static final int PARALLEL_REQUESTS_LIMIT = 8;
 	private static final String PROTOCOL = "http";
 	private static final int ZOOM_LEVEL_MAX = 18;
@@ -31,6 +40,7 @@ public class OpenStreetMapMapnik extends AbstractTileSource {
 
 	public OpenStreetMapMapnik(String[] hostNames, int port) {
 		super(hostNames, port);
+		defaultTTL = 6649000;
 	}
 
 	@Override

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/download/tilesource/TileSource.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/download/tilesource/TileSource.java
@@ -22,6 +22,11 @@ import org.mapsforge.core.model.Tile;
 
 public interface TileSource {
 	/**
+	 * Returns the default TTL for cached tiles.
+	 */
+	long getDefaultTTL();
+
+	/**
 	 * @return the maximum number of parallel requests which this {@code TileSource} supports.
 	 */
 	int getParallelRequestsLimit();

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/DatabaseRenderer.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/DatabaseRenderer.java
@@ -199,6 +199,7 @@ public class DatabaseRenderer implements RenderCallback {
 
 			if (!rendererJob.labelsOnly) {
 				bitmap = this.graphicFactory.createTileBitmap(tileSize, rendererJob.hasAlpha);
+				bitmap.setTimestamp(rendererJob.mapDataStore.getDataTimestamp(rendererJob.tile));
 				this.canvasRasterer.setCanvasBitmap(bitmap);
 				if (!rendererJob.hasAlpha && rendererJob.displayModel.getBackgroundColor() != this.renderTheme.getMapBackground()) {
 					this.canvasRasterer.fill(this.renderTheme.getMapBackground());

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/TileRendererLayer.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/TileRendererLayer.java
@@ -17,6 +17,7 @@
 package org.mapsforge.map.layer.renderer;
 
 import org.mapsforge.core.graphics.GraphicFactory;
+import org.mapsforge.core.graphics.TileBitmap;
 import org.mapsforge.core.model.Tile;
 import org.mapsforge.map.layer.TileLayer;
 import org.mapsforge.map.layer.cache.TileCache;
@@ -113,6 +114,30 @@ public class TileRendererLayer extends TileLayer<RendererJob> {
 	protected RendererJob createJob(Tile tile) {
 		return new RendererJob(tile, this.mapDataStore, this.xmlRenderTheme, this.displayModel, this.textScale,
 				this.isTransparent, false);
+	}
+
+	/**
+	 * Whether the tile is stale and should be refreshed.
+	 * <p>
+	 * This method is called from {@link #draw(org.mapsforge.core.model.BoundingBox, byte, org.mapsforge.core.graphics.Canvas, org.mapsforge.core.model.Point)} to determine whether the tile needs to
+	 * be refreshed.
+	 * <p>
+	 * A tile is considered stale if the timestamp of the layer's {@link #mapDataStore} is more recent than the
+	 * {@code bitmap}'s {@link org.mapsforge.core.graphics.TileBitmap#getTimestamp()}.
+	 * <p>
+	 * When a tile has become stale, the layer will first display the tile referenced by {@code bitmap} and attempt to
+	 * obtain a fresh copy in the background. When a fresh copy becomes available, the layer will replace is and update
+	 * the cache. If a fresh copy cannot be obtained for whatever reason, the stale tile will continue to be used until
+	 * another {@code #draw(BoundingBox, byte, Canvas, Point)} operation requests it again.
+	 *
+	 * @param tile
+	 *            A tile.
+	 * @param bitmap
+	 *            The bitmap for {@code tile} currently held in the layer's cache.
+	 */
+	@Override
+	protected boolean isTileStale(Tile tile, TileBitmap bitmap) {
+		return this.mapDataStore.getDataTimestamp(tile) > bitmap.getTimestamp();
 	}
 
 	@Override

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/tilestore/TileStoreLayer.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/tilestore/TileStoreLayer.java
@@ -15,6 +15,7 @@
 package org.mapsforge.map.layer.tilestore;
 
 import org.mapsforge.core.graphics.GraphicFactory;
+import org.mapsforge.core.graphics.TileBitmap;
 import org.mapsforge.core.model.Tile;
 import org.mapsforge.map.layer.TileLayer;
 import org.mapsforge.map.layer.cache.TileCache;
@@ -33,4 +34,18 @@ public class TileStoreLayer extends TileLayer<Job> {
 		return new Job(tile, isTransparent);
 	}
 
+	/**
+	 * Whether the tile is stale and should be refreshed.
+	 * <p>
+	 * This method is not needed for a TileStoreLayer and will always return {@code false}. Both arguments can be null.
+	 *
+	 * @param tile
+	 *            A tile.
+	 * @param bitmap
+	 *            The bitmap for {@code tile} currently held in the layer's cache.
+	 */
+	@Override
+	protected boolean isTileStale(Tile tile, TileBitmap bitmap) {
+		return false;
+	}
 }

--- a/mapsforge-map/src/test/java/org/mapsforge/map/layer/cache/FileSystemTileCacheTest.java
+++ b/mapsforge-map/src/test/java/org/mapsforge/map/layer/cache/FileSystemTileCacheTest.java
@@ -87,7 +87,7 @@ public class FileSystemTileCacheTest {
 	@Test
 	public void capacityZeroTest() {
 		for (int tileSize : TILE_SIZES) {
-			TileCache tileCache = new FileSystemTileCache(0, this.cacheDirectory, GRAPHIC_FACTORY, false, 0);
+			TileCache tileCache = new FileSystemTileCache(0, this.cacheDirectory, GRAPHIC_FACTORY, false, 0, false);
 			Tile tile = new Tile(0, 0, (byte) 0, tileSize);
 			TileSource tileSource = OpenStreetMapMapnik.INSTANCE;
 			Job job = new DownloadJob(tile, tileSource);

--- a/mapsforge-map/src/test/java/org/mapsforge/map/layer/download/InvalidTileSource.java
+++ b/mapsforge-map/src/test/java/org/mapsforge/map/layer/download/InvalidTileSource.java
@@ -22,6 +22,11 @@ import org.mapsforge.map.layer.download.tilesource.TileSource;
 
 class InvalidTileSource implements TileSource {
 	@Override
+	public long getDefaultTTL() {
+		throw new AssertionError();
+	}
+
+	@Override
 	public int getParallelRequestsLimit() {
 		throw new AssertionError();
 	}


### PR DESCRIPTION
This is a cleaned-up version of the pull request by @mvglasow with most formatting-only changes removed. The main activities in the Samples app use persistent tile caching. 
