### PR TITLE
AssetsRenderTheme shouldn't ignore relativePathPrefix

### DIFF
--- a/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidGraphicFactory.java
+++ b/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidGraphicFactory.java
@@ -272,7 +272,6 @@ public final class AndroidGraphicFactory implements GraphicFactory {
 	public InputStream platformSpecificSources(String relativePathPrefix, String src) throws IOException {
 		// this allows loading of resource bitmaps from the Andorid assets folder
 		if (src.startsWith(PREFIX_ASSETS)) {
-		    String pathName = (relativePathPrefix == null) ? "" : relativePathPrefix + src.substring(PREFIX_ASSETS.length());
 			InputStream inputStream = this.application.getAssets().open(pathName);
 			if (inputStream == null) {
 				throw new FileNotFoundException("resource not found: " + pathName);

--- a/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidGraphicFactory.java
+++ b/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidGraphicFactory.java
@@ -272,7 +272,7 @@ public final class AndroidGraphicFactory implements GraphicFactory {
 	public InputStream platformSpecificSources(String relativePathPrefix, String src) throws IOException {
 		// this allows loading of resource bitmaps from the Andorid assets folder
 		if (src.startsWith(PREFIX_ASSETS)) {
-			String pathName = src.substring(PREFIX_ASSETS.length());
+		    String pathName = (relativePathPrefix == null) ? "" : relativePathPrefix + src.substring(PREFIX_ASSETS.length());
 			InputStream inputStream = this.application.getAssets().open(pathName);
 			if (inputStream == null) {
 				throw new FileNotFoundException("resource not found: " + pathName);

--- a/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidGraphicFactory.java
+++ b/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidGraphicFactory.java
@@ -272,6 +272,7 @@ public final class AndroidGraphicFactory implements GraphicFactory {
 	public InputStream platformSpecificSources(String relativePathPrefix, String src) throws IOException {
 		// this allows loading of resource bitmaps from the Andorid assets folder
 		if (src.startsWith(PREFIX_ASSETS)) {
+			String pathName = (relativePathPrefix == null) ? "" : relativePathPrefix + src.substring(PREFIX_ASSETS.length());
 			InputStream inputStream = this.application.getAssets().open(pathName);
 			if (inputStream == null) {
 				throw new FileNotFoundException("resource not found: " + pathName);

--- a/mapsforge-map-android/src/main/java/org/mapsforge/map/android/rendertheme/AssetsRenderTheme.java
+++ b/mapsforge-map-android/src/main/java/org/mapsforge/map/android/rendertheme/AssetsRenderTheme.java
@@ -43,7 +43,6 @@ public class AssetsRenderTheme implements XmlRenderTheme {
 	public AssetsRenderTheme(Context context, String relativePathPrefix, String fileName, XmlRenderThemeMenuCallback menuCallback) throws IOException {
 		this.assetName = fileName;
 		this.relativePathPrefix = relativePathPrefix;
-        this.inputStream = context.getAssets().open((this.relativePathPrefix == null) ? "" : this.relativePathPrefix + this.assetName);
 		this.menuCallback = menuCallback;
 	}
 

--- a/mapsforge-map-android/src/main/java/org/mapsforge/map/android/rendertheme/AssetsRenderTheme.java
+++ b/mapsforge-map-android/src/main/java/org/mapsforge/map/android/rendertheme/AssetsRenderTheme.java
@@ -43,7 +43,7 @@ public class AssetsRenderTheme implements XmlRenderTheme {
 	public AssetsRenderTheme(Context context, String relativePathPrefix, String fileName, XmlRenderThemeMenuCallback menuCallback) throws IOException {
 		this.assetName = fileName;
 		this.relativePathPrefix = relativePathPrefix;
-		this.inputStream = context.getAssets().open(this.assetName);
+        this.inputStream = context.getAssets().open((this.relativePathPrefix == null) ? "" : this.relativePathPrefix + this.assetName);
 		this.menuCallback = menuCallback;
 	}
 

--- a/mapsforge-map-android/src/main/java/org/mapsforge/map/android/rendertheme/AssetsRenderTheme.java
+++ b/mapsforge-map-android/src/main/java/org/mapsforge/map/android/rendertheme/AssetsRenderTheme.java
@@ -43,6 +43,7 @@ public class AssetsRenderTheme implements XmlRenderTheme {
 	public AssetsRenderTheme(Context context, String relativePathPrefix, String fileName, XmlRenderThemeMenuCallback menuCallback) throws IOException {
 		this.assetName = fileName;
 		this.relativePathPrefix = relativePathPrefix;
+		this.inputStream = context.getAssets().open((this.relativePathPrefix == null) ? "" : this.relativePathPrefix + this.assetName);
 		this.menuCallback = menuCallback;
 	}
 


### PR DESCRIPTION
AssetsRenderTheme was ignoring relativePathPrefix, so symbol & pattern folders had to be in root of assets.