### PR TITLE
Feature: public map read result builder

### DIFF
--- a/mapsforge-map-reader/src/main/java/org/mapsforge/map/reader/MapFile.java
+++ b/mapsforge-map-reader/src/main/java/org/mapsforge/map/reader/MapFile.java
@@ -563,7 +563,7 @@ public class MapFile implements MapDataStore {
 
 		// the query is finished, was the water flag set for all blocks?
 		if (queryIsWater && queryReadWaterInfo) {
-			mapReadResultBuilder.isWater = true;
+			mapReadResultBuilder.setWater(true);
 		}
 
 		return mapReadResultBuilder.build();

--- a/mapsforge-map-reader/src/main/java/org/mapsforge/map/reader/MapReadResult.java
+++ b/mapsforge-map-reader/src/main/java/org/mapsforge/map/reader/MapReadResult.java
@@ -37,8 +37,8 @@ public class MapReadResult {
 	public final List<Way> ways;
 
 	MapReadResult(MapReadResultBuilder mapReadResultBuilder) {
-		this.pointOfInterests = mapReadResultBuilder.pointOfInterests;
-		this.ways = mapReadResultBuilder.ways;
-		this.isWater = mapReadResultBuilder.isWater;
+		this.pointOfInterests = mapReadResultBuilder.getPointOfInterests();
+		this.ways = mapReadResultBuilder.getWays();
+		this.isWater = mapReadResultBuilder.isWater();
 	}
 }

--- a/mapsforge-map-reader/src/main/java/org/mapsforge/map/reader/MapReadResultBuilder.java
+++ b/mapsforge-map-reader/src/main/java/org/mapsforge/map/reader/MapReadResultBuilder.java
@@ -17,22 +17,38 @@ package org.mapsforge.map.reader;
 import java.util.ArrayList;
 import java.util.List;
 
-class MapReadResultBuilder {
-	boolean isWater;
-	final List<PointOfInterest> pointOfInterests;
-	final List<Way> ways;
+public class MapReadResultBuilder {
+	private boolean isWater;
+	private final List<PointOfInterest> pointOfInterests;
+	private final List<Way> ways;
 
-	MapReadResultBuilder() {
+	public MapReadResultBuilder() {
 		this.pointOfInterests = new ArrayList<PointOfInterest>();
 		this.ways = new ArrayList<Way>();
 	}
 
-	void add(PoiWayBundle poiWayBundle) {
+	public void add(PoiWayBundle poiWayBundle) {
 		this.pointOfInterests.addAll(poiWayBundle.pois);
 		this.ways.addAll(poiWayBundle.ways);
 	}
 
-	MapReadResult build() {
+	public List<PointOfInterest> getPointOfInterests() {
+		return pointOfInterests;
+	}
+
+	public List<Way> getWays() {
+		return ways;
+	}
+
+	public boolean isWater() {
+		return isWater;
+	}
+
+	public void setWater(boolean isWater) {
+		this.isWater = isWater;
+	}
+
+	public MapReadResult build() {
 		return new MapReadResult(this);
 	}
 }

--- a/mapsforge-map-reader/src/main/java/org/mapsforge/map/reader/MultiMapDataStore.java
+++ b/mapsforge-map-reader/src/main/java/org/mapsforge/map/reader/MultiMapDataStore.java
@@ -178,32 +178,34 @@ public class MultiMapDataStore implements MapDataStore {
 				if (result == null) {
 					continue;
 				}
-				mapReadResultBuilder.isWater &= result.isWater;
+				boolean isWater = mapReadResultBuilder.isWater() & result.isWater;
+				mapReadResultBuilder.setWater(isWater);
+
 
 				if (first) {
-					mapReadResultBuilder.ways.addAll(result.ways);
+					mapReadResultBuilder.getWays().addAll(result.ways);
 				} else {
 					if (deduplicate) {
 						for (Way way : result.ways) {
-							if (!mapReadResultBuilder.ways.contains(way)) {
-								mapReadResultBuilder.ways.add(way);
+							if (!mapReadResultBuilder.getWays().contains(way)) {
+								mapReadResultBuilder.getWays().add(way);
 							}
 						}
 					} else {
-						mapReadResultBuilder.ways.addAll(result.ways);
+						mapReadResultBuilder.getWays().addAll(result.ways);
 					}
 				}
 				if (first) {
-					mapReadResultBuilder.pointOfInterests.addAll(result.pointOfInterests);
+					mapReadResultBuilder.getPointOfInterests().addAll(result.pointOfInterests);
 				} else {
 					if (deduplicate) {
 						for (PointOfInterest poi : result.pointOfInterests) {
-							if (!mapReadResultBuilder.pointOfInterests.contains(poi)) {
-								mapReadResultBuilder.pointOfInterests.add(poi);
+							if (!mapReadResultBuilder.getPointOfInterests().contains(poi)) {
+								mapReadResultBuilder.getPointOfInterests().add(poi);
 							}
 						}
 					} else {
-						mapReadResultBuilder.pointOfInterests.addAll(result.pointOfInterests);
+						mapReadResultBuilder.getPointOfInterests().addAll(result.pointOfInterests);
 					}
 				}
 				first = false;


### PR DESCRIPTION
I need to write a custom MapDataStore so needed to create make the MapReadResult builder public.

I left the variables with no modifier so they could still be added directly by the package, I guess it would be better to mark them provide and make the package also access them via the getter/settings.

Did you want me to make this change?
