### PR TITLE
Setup Travis continuous integration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+# configuration for https://travis-ci.org/mapsforge/mapsforge
+sudo: false
+language: android
+jdk: openjdk7
+android:
+  components:
+    - build-tools-23.0.1
+    - android-22
+script: gradle build


### PR DESCRIPTION
To enable it, all the mapsforge account owner needs to do it log in on https://travis-ci.org and flip the enable switch for the mapsforge repository.

In a future update, we could add other forms of notifications. Currently, it notifies via GitHub (very convenient!) and I think email.

A preview can be seen on my account: https://travis-ci.org/schildbach/mapsforge
If you want to try out how pull requests work, just open a PR against my GitHub repo and you'll see the Travis integration.