### PR TITLE
Set minimum Android SDK to API level 10 (Android 2.3.3).

### DIFF
--- a/Applications/Android/Samples/AndroidManifest.xml
+++ b/Applications/Android/Samples/AndroidManifest.xml
@@ -11,7 +11,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <uses-sdk
-        android:minSdkVersion="9"
+        android:minSdkVersion="10"
         android:targetSdkVersion="22" />
 
     <application

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The mapsforge project provides free and open software for the rendering of maps 
 - It provides [simple boilerplate code](docs/Getting-Started-Android-App.md) to [build](docs/Getting-Started-Developers.md) applications for Android that display OpenStreetMap-based maps.
 - It provides a library to build standalone applications in Java.
 - Mapsforge maps can be flexibly styled with XML style files ([render themes](docs/Rendertheme.md)).
-- Mapsforge supports Android 2.3 and above. Mapsforge has been tested on Android 5 Lollipop.
+- Mapsforge supports Android 2.3.3 and above. Mapsforge has been tested on Android 5 Lollipop.
 - Mapsforge is used by many [applications](docs/Mapsforge-Applications.md).
 - Mapsforge is in active development: [changelog](docs/Changelog.md), [contributors](docs/Contributors.md). 
 - [API documentation](http://mapsforge.org/docs).

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ allprojects {
 
 // no injection of functions, so via inheritance
 def androidCompileSdk() { return 23 }
-def androidMinSdk() { return 9 }
+def androidMinSdk() { return 10 }
 def androidTargetSdk() { return 22 }
 def versionCode() { return 52 }
 def versionName() { return version }

--- a/mapsforge-map-android/AndroidManifest.xml
+++ b/mapsforge-map-android/AndroidManifest.xml
@@ -4,7 +4,7 @@
     android:versionCode="50"
     android:versionName="0.5.0" >
     <uses-sdk
-        android:minSdkVersion="9"
+        android:minSdkVersion="10"
         android:targetSdkVersion="22" />
     <application
         android:allowBackup="true"


### PR DESCRIPTION
API level 9 (Android 2.3-2.3.2) is not in use any more. Also, it's not compatible to Java5, forcing us to use Java 1.4 only!