### PR TITLE
bugfix: Way equals comparison typo

### DIFF
--- a/mapsforge-map/src/main/java/org/mapsforge/map/datastore/Way.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/datastore/Way.java
@@ -65,7 +65,7 @@ public class Way {
 			return false;
 		} else if (this.labelPosition == null && other.labelPosition != null) {
 			return false;
-		} else if (this.labelPosition!= null && this.labelPosition.equals(other.labelPosition)) {
+		} else if (this.labelPosition!= null && !this.labelPosition.equals(other.labelPosition)) {
 			return false;
 		} else if (this.latLongs.length != other.latLongs.length) {
 			return false;


### PR DESCRIPTION
typo in equal comparison causes 2 equal but not same objects to never compare true
See #711 