### PR TITLE
Fix wrong tile bitmap expiration check.

### DIFF
--- a/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidTileBitmap.java
+++ b/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidTileBitmap.java
@@ -155,7 +155,7 @@ public class AndroidTileBitmap extends AndroidBitmap implements TileBitmap {
     public boolean isExpired() {
         if (expiration == 0)
             return false;
-        return (expiration >= System.currentTimeMillis());
+        return (expiration <= System.currentTimeMillis());
     }
 
     @Override

--- a/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/graphics/AwtTileBitmap.java
+++ b/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/graphics/AwtTileBitmap.java
@@ -45,7 +45,7 @@ public class AwtTileBitmap extends AwtBitmap implements TileBitmap {
     public boolean isExpired() {
         if (expiration == 0)
             return false;
-        return (expiration >= System.currentTimeMillis());
+        return (expiration <= System.currentTimeMillis());
     }
 
     @Override


### PR DESCRIPTION
This patch fix the wrong expiration check in the tile bitmap objects.