### PR TITLE
Add highways to POI search; Add tool geo-tagger

### DIFF
--- a/docs/POI.md
+++ b/docs/POI.md
@@ -51,6 +51,7 @@ The `--poi-writer`, or short `--pw` task indicates that the POI writer plugin sh
 |`tag-conf-file`|Path to an XML configuration file that contains mappings from OSM tags to category names and a hierarchy of those categories.|path to an XML file|(blank) internal default poi mapping is used|
 |`ways`|Also parse ways.|true/false|true|
 |`filter-categories`|Drop empty categories.|true/false|true|
+|`geo-tags`|Auto complete geo tag "is_in". Works only if ways are enabled.|true/false|false|
 
 ### Example
 

--- a/mapsforge-poi-writer/build.gradle
+++ b/mapsforge-poi-writer/build.gradle
@@ -3,6 +3,7 @@ dependencies {
     compile 'com.vividsolutions:jts:1.13'
     compile 'org.xerial:sqlite-jdbc:3.15.1'
     compileOnly 'org.openstreetmap.osmosis:osmosis-core:0.45'
+    compile 'com.google.guava:guava:20.0'
 }
 
 jar {

--- a/mapsforge-poi-writer/src/main/config/poi-mapping.xml
+++ b/mapsforge-poi-writer/src/main/config/poi-mapping.xml
@@ -607,6 +607,89 @@
         <!--<category title="Turning cycles">
             <mapping tag="highway=turning_cycle" />
         </category>-->
+
+        <!--Streets added-->
+        <!--<category title="Bridleway">-->
+            <!--<mapping tag="highway=bridleway" />-->
+        <!--</category>-->
+        <!--<category title="Bus guideway">-->
+            <!--<mapping tag="highway=bus_guideway" />-->
+        <!--</category>-->
+        <!--<category title="Byway">-->
+            <!--<mapping tag="highway=byway" />-->
+        <!--</category>-->
+        <!--<category title="Construction way">-->
+            <!--<mapping tag="highway=construction" />-->
+        <!--</category>-->
+        <!--<category title="Cycleway">-->
+            <!--<mapping tag="highway=cycleway" />-->
+        <!--</category>-->
+        <!--<category title="Footway">-->
+            <!--<mapping tag="highway=footway" />-->
+        <!--</category>-->
+        <category title="Living street">
+            <mapping tag="highway=living_street" />
+        </category>
+        <!--<category title="Motorway">-->
+            <!--<mapping tag="highway=motorway" />-->
+        <!--</category>-->
+        <!--<category title="Motorway link">-->
+            <!--<mapping tag="highway=motorway_link" />-->
+        <!--</category>-->
+        <!--<category title="Path">-->
+            <!--<mapping tag="highway=path" />-->
+        <!--</category>-->
+        <!--<category title="Pedestrian way">-->
+            <!--<mapping tag="highway=pedestrian" />-->
+        <!--</category>-->
+        <!--<category title="Primary way">-->
+            <!--<mapping tag="highway=primary" />-->
+        <!--</category>-->
+        <!--<category title="Primary way link">-->
+            <!--<mapping tag="highway=primary_link" />-->
+        <!--</category>-->
+        <!--<category title="Raceway">-->
+            <!--<mapping tag="highway=raceway" />-->
+        <!--</category>-->
+        <category title="Residential way">
+            <mapping tag="highway=residential" />
+        </category>
+        <category title="Road">
+            <mapping tag="highway=road" />
+        </category>
+        <!--<category title="Secondary way">-->
+            <!--<mapping tag="highway=secondary" />-->
+        <!--</category>-->
+        <!--<category title="Secondary way link">-->
+            <!--<mapping tag="highway=secondary_link" />-->
+        <!--</category>-->
+        <!--<category title="Service way">-->
+            <!--<mapping tag="highway=service" />-->
+        <!--</category>-->
+        <!--<category title="Services way">-->
+            <!--<mapping tag="highway=services" />-->
+        <!--</category>-->
+        <!--<category title="Steps way">-->
+            <!--<mapping tag="highway=steps" />-->
+        <!--</category>-->
+        <!--<category title="Tertiary way">-->
+            <!--<mapping tag="highway=tertiary" />-->
+        <!--</category>-->
+        <!--<category title="Tertiary way link">-->
+            <!--<mapping tag="highway=tertiary_link" />-->
+        <!--</category>-->
+        <!--<category title="Track way">-->
+            <!--<mapping tag="highway=track" />-->
+        <!--</category>-->
+        <category title="Trunk way">
+            <mapping tag="highway=trunk" />
+        </category>
+        <!--<category title="Trunk way link">-->
+            <!--<mapping tag="highway=trunk_link" />-->
+        <!--</category>-->
+        <!--<category title="Unclassified way">-->
+            <!--<mapping tag="highway=unclassified" />-->
+        <!--</category>-->
     </category>
 
     <!-- Historic -->

--- a/mapsforge-poi-writer/src/main/java/org/mapsforge/poi/writer/GeoTagger.java
+++ b/mapsforge-poi-writer/src/main/java/org/mapsforge/poi/writer/GeoTagger.java
@@ -66,7 +66,6 @@ public class GeoTagger {
         Collection<Tag> tags = way.getTags();
         for (Tag tag : tags) {
             switch (tag.getKey()) {
-                //TOO laggy to get bounds like the follwing.
                 case "building":
                 case "highway":
                 case "landuse":
@@ -80,24 +79,22 @@ public class GeoTagger {
 //                    //"natural is no nonBound-case"
                     return;
                 //TODO Add more cases for other nonboundaries
-//                default:
                 case "boundary":
-                    //This case is simpler than exclude all non valid cases.
-                    //But it will not get all bound results, some have no tags set and exist only as
+                    // This case is simpler than exclude all non valid cases.
+                    // But it will not get all bound results, some have no tags set and exist only as
                     // relation; it's better to exclude them and
                     // then add possible boundaries to database
-                    // It is possible too, to add all ways, but this is not that efficient
                     if (tag.getValue().equalsIgnoreCase("administrative")) {
                         storeWay(way);
                     }
                     return;
             }
         }
+        //No tags occured that speek against a boundary
         storeWay(way);
     }
 
     private void storeWay(Way way){
-        //No tags occured that speek against a boundary
         int i = 0;
         try {
             for (WayNode wayNode : way.getWayNodes()) {
@@ -131,8 +128,7 @@ public class GeoTagger {
         if(adminLevelValue == null) return;
         switch(adminLevelValue.trim()){
             //TODO Specify cultural/regional diffs for admin_levels,
-            //TODO which should be the lowest level of administrative boundary, tagged with is_in
-            //or simply loop all admin_levels descendent, and add the is_in tag if it doesn't exist
+            // which should be the lowest level of administrative boundary, tagged with is_in
             case "7":
                 administrativeBoundaries.get(6).add(relation);
                 return;

--- a/mapsforge-poi-writer/src/main/java/org/mapsforge/poi/writer/GeoTagger.java
+++ b/mapsforge-poi-writer/src/main/java/org/mapsforge/poi/writer/GeoTagger.java
@@ -1,0 +1,432 @@
+package org.mapsforge.poi.writer;
+
+import com.google.common.collect.Lists;
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.GeometryFactory;
+import com.vividsolutions.jts.geom.Point;
+import com.vividsolutions.jts.geom.Polygon;
+
+import org.mapsforge.core.model.BoundingBox;
+import org.mapsforge.core.model.LatLong;
+import org.mapsforge.poi.storage.DbConstants;
+import org.openstreetmap.osmosis.core.domain.v0_6.EntityType;
+import org.openstreetmap.osmosis.core.domain.v0_6.Relation;
+import org.openstreetmap.osmosis.core.domain.v0_6.RelationMember;
+import org.openstreetmap.osmosis.core.domain.v0_6.Tag;
+import org.openstreetmap.osmosis.core.domain.v0_6.Way;
+import org.openstreetmap.osmosis.core.domain.v0_6.WayNode;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mapsforge.poi.writer.PoiWriter.LOGGER;
+
+/**
+ * Created by gustl on 03.04.17.
+ */
+
+public class GeoTagger {
+    private PoiWriter writer;
+    private Connection conn = null;
+    private final int BATCH_LIMIT;
+    private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory();
+    private PreparedStatement pStmtInsertWayNodes = null;
+    private PreparedStatement pStmtUpdateData = null;
+    private PreparedStatement pStmtNodesInBox = null;
+
+    public GeoTagger(PoiWriter writer){
+        this.writer = writer;
+        conn = writer.getConnection();
+        BATCH_LIMIT = writer.BATCH_LIMIT;
+        try {
+            this.pStmtInsertWayNodes = conn.prepareStatement(DbConstants.INSERT_WAYNODES_STATEMENT);
+            this.pStmtUpdateData = this.conn.prepareStatement(DbConstants.UPDATE_DATA_STATEMENT);
+            this.pStmtNodesInBox = this.conn.prepareStatement(DbConstants.FIND_IN_BOX_STATEMENT);
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private int batchCountWays = 0;
+    public void storeAdministrativeBoundaries(Way way) {
+
+        Collection<Tag> tags = way.getTags();
+        for (Tag tag : tags) {
+            switch (tag.getKey()) {
+                //TOO laggy to get bounds like the follwing.
+//                case "highway":
+//                case "landuse":
+//                case "sport":
+//                case "building":
+//                case "waterway":
+//                    //"natural is no nonBound-case"
+//                    return;
+                //TODO Add more cases for other nonboundaries
+                case "boundary":
+                    //This case is simpler than exclude all non valid cases.
+                    //But it will not get all bound results, some have no tags set and exist only as
+                    // relation; it's better to exclude them and
+                    // then add possible boundaries to database
+                    // It is possible too, to add all ways, but this is not that efficient
+                    if (tag.getValue().equalsIgnoreCase("administrative")) {
+                        //No tags occured that speek against a boundary
+                        int i = 0;
+                        try {
+                            for (WayNode wayNode : way.getWayNodes()) {
+                                pStmtInsertWayNodes.setLong(1, way.getId());
+                                pStmtInsertWayNodes.setLong(2, wayNode.getNodeId());
+                                pStmtInsertWayNodes.setInt(3, i);
+                                pStmtInsertWayNodes.addBatch();
+
+                                i++;
+                            }
+                            batchCountWays++;
+                            if (batchCountWays % BATCH_LIMIT == 0) {
+                                pStmtInsertWayNodes.executeBatch();
+                                pStmtInsertWayNodes.clearBatch();
+                            }
+                        } catch (SQLException e) {
+                            e.printStackTrace();
+                        }
+                    }
+                    return;
+            }
+        }
+    }
+
+    private int batchCountRelation = 0;
+
+    public void filterBoundaries(Relation relation) {
+        if (!("boundary".equalsIgnoreCase(writer.getValueOfTag("type", relation.getTags()))
+                && "administrative".equalsIgnoreCase(writer.getValueOfTag("boundary", relation.getTags())))) {
+            return;
+        }
+        String adminLevelValue = writer.getValueOfTag("admin_level", relation.getTags());
+        if(adminLevelValue == null) return;
+        switch(adminLevelValue.trim()){
+            //TODO Specify cultural/regional diffs for admin_levels,
+            //TODO which should be the lowest level of administrative boundary, tagged with is_in
+            //or simply loop all admin_levels descendent, and add the is_in tag if it doesn't exist
+            case "9":
+                //German administrative level for city/village boundry
+                break;
+            default:
+                return;
+        }
+        List<List<Long>> bounds = new ArrayList<>();
+        for (RelationMember relationMember : relation.getMembers()) {
+            if (relationMember.getMemberType().equals(EntityType.Way)
+                    && "outer".equalsIgnoreCase(relationMember.getMemberRole())) {
+                List<Long> waynodes = writer.findWayNodesByWayID(relationMember.getMemberId());
+                if (waynodes != null && !waynodes.isEmpty()) {
+                    bounds.add(waynodes);
+                    continue;
+                }
+                LOGGER.finer("\n---> Member not found | Membertype= " + relationMember.getMemberType().name()
+                        + ", Memberrole= " + relationMember.getMemberRole() + "\n");
+                continue;
+            }
+            LOGGER.finer("\n---> Member not accepted | Membertype= " + relationMember.getMemberType().name()
+                    + ", Memberrole= " + relationMember.getMemberRole() + "\n");
+        }
+        //Merge bound nodes (There's may a simpler method)
+        if (!bounds.isEmpty()) {
+            LOGGER.fine("Administrative: " + writer.getValueOfTag("name", relation.getTags())
+                    + " #Members: " + relation.getMembers().size()
+                    + " #Segments: " + bounds.size());
+            //Iterate through given list
+
+            //Debug
+            int counter = bounds.size();
+            if (counter < 6) {
+                String builder2 = "Bound nodes: ";
+                for (int j = 0; j < bounds.size(); j++) {
+                    //LOGGER.info("j: "+ j+"; i: "+i);
+                    List<Long> J = bounds.get(j);
+                    LatLong Ja = writer.findNodeByID(J.get(0));
+                    LatLong Jb = writer.findNodeByID(J.get(J.size() - 1));
+                    builder2 += ("\nJa coord: " + Ja.latitude + ", " + Ja.longitude
+                            + "\nJb coord: " + Jb.latitude + ", " + Jb.longitude);
+                }
+                builder2 += "\n++++++++++++++++++++++++++++++";
+                LOGGER.finer(builder2);
+            }
+            //Debugend
+
+            final double threshold = 20; //In meters;
+            for (int i = 1; i < bounds.size(); i++) {
+                //Create second list, to compare values
+                List<Long> I = bounds.get(i);
+                List<Long> check = I;
+                long nIa = I.get(0);
+                long nIb = I.get(I.size() - 1);
+                LatLong Ia = writer.findNodeByID(I.get(0));
+                LatLong Ib = writer.findNodeByID(I.get(I.size() - 1));
+                boolean isMerged = false;
+                for (int j = 0; j < bounds.size(); j++) {
+                    if (i == j) continue;
+                    //LOGGER.info("j: "+ j+"; i: "+i);
+                    List<Long> J = bounds.get(j);
+                    long nJa = J.get(0);
+                    long nJb = J.get(J.size() - 1);
+                    LatLong Ja = writer.findNodeByID(J.get(0));
+                    LatLong Jb = writer.findNodeByID(J.get(J.size() - 1));
+                    if (Ia == null || Ib == null || Ja == null || Jb == null) return;
+                    //If first of I and last of J matches: merge
+                    if (Ia.sphericalDistance(Jb) < threshold) {
+                        I.remove(0);
+                        J.addAll(I);
+                        bounds.set(j, J);
+                        bounds.remove(i);
+                        i--;
+                        isMerged = true;
+                        LOGGER.finest("matches: " + Ia.latitude + ", " + Ia.longitude
+                                + "; Ids: " + nIa + ", " + nJb);
+                        break;
+                    } else if (Ib.sphericalDistance(Jb) < threshold) {
+                        //If list I is reversed
+                        I = Lists.reverse(I);
+                        I.remove(0);
+                        J.addAll(I);
+                        bounds.set(j, J);
+                        bounds.remove(i);
+                        i--;
+                        isMerged = true;
+                        LOGGER.finest("reverse I matches: " + Ib.latitude + ", " + Ib.longitude
+                                + "; Ids: " + nIb + ", " + nJb);
+                        break;
+                    } else if (Ia.sphericalDistance(Ja) < threshold) {
+                        //If list J is reversed
+                        J = Lists.reverse(J);
+                        I.remove(0);
+                        J.addAll(I);
+                        bounds.set(j, J);
+                        bounds.remove(i);
+                        i--;
+                        isMerged = true;
+                        LOGGER.finest("reverse J matches: " + Ia.latitude + ", " + Ia.longitude
+                                + "; Ids: " + nIa + ", " + nJb);
+                        break;
+                    } else if (Ib.sphericalDistance(Ja) < threshold) {
+                        //If both are reversed
+                        J = Lists.reverse(J);
+                        I = Lists.reverse(I);
+                        I.remove(0);
+                        J.addAll(I);
+                        bounds.set(j, J);
+                        bounds.remove(i);
+                        i--;
+                        isMerged = true;
+                        LOGGER.finest("reverse Both matches: " + Ib.latitude + ", " + Ib.longitude
+                                + "; Ids: " + nIb + ", " + nJa);
+                        break;
+                    }
+                }
+                //One path does'not match, so return
+                if (bounds.contains(check) && bounds.size() > 1) {
+                    if (counter > 6) continue;
+                    String builder = "Bound merging failed; Merged: " + isMerged
+                            + "\nIa coord: " + Ia.latitude + ", " + Ia.longitude
+                            + "\nIb coord: " + Ib.latitude + ", " + Ib.longitude + "\n";
+                    for (int j = 0; j < bounds.size(); j++) {
+                        if (i == j) continue;
+                        //LOGGER.info("j: "+ j+"; i: "+i);
+                        List<Long> J = bounds.get(j);
+                        LatLong Ja = writer.findNodeByID(J.get(0));
+                        LatLong Jb = writer.findNodeByID(J.get(J.size() - 1));
+                        builder += ("\nJa coord: " + Ja.latitude + ", " + Ja.longitude
+                                + "\nJb coord: " + Jb.latitude + ", " + Jb.longitude);
+                    }
+                    builder += "\n-------------------------------\n\n";
+                    LOGGER.fine(builder);
+                }
+            }
+            LOGGER.finer("Bound merging finished; Size= " + bounds.size());
+            //Check the result
+            //TODO Calculate areas which have more than 1 circle bound. (Simple cover func.)
+            if (bounds.size() != 1) {
+                return;
+            }
+            LOGGER.finer("Bound has right size; ");
+
+            Long[] area = bounds.get(0).toArray(new Long[bounds.get(0).size()]);
+            if (!(writer.findNodeByID(area[0]).sphericalDistance(writer.findNodeByID(area[area.length - 1])) < threshold)) {
+                return;
+            }
+            area[0] = area[area.length - 1];
+            LOGGER.finer("Last node is first node; ");
+            // Convert the way to a JTS polygon
+            Coordinate[] coordinates = new Coordinate[area.length];
+            for (int j = 0; j < area.length; j++) {
+                LatLong wayNode = writer.findNodeByID(area[j]);
+                if (wayNode == null) return;
+                coordinates[j] = new Coordinate(wayNode.longitude, wayNode.latitude);
+            }
+
+            LOGGER.finer("Polygon created; ");
+            Polygon polygon = GEOMETRY_FACTORY.createPolygon(GEOMETRY_FACTORY.createLinearRing(coordinates), null);
+            double minLat = coordinates[0].y;
+            double minLon = coordinates[0].x;
+            BoundingBox bbox = new BoundingBox(minLat, minLon, minLat, minLon);
+            for (Coordinate coord : coordinates) {
+                bbox = bbox.extendCoordinates(coord.y, coord.x);
+            }
+
+            //Get pois in bounds
+            Map<Poi, Map<String, String>> pois = getPoisInsideBounds(bbox);
+
+            Map.Entry<Poi, Map<String, String>> adminArea = null;
+            for (Map.Entry<Poi, Map<String, String>> entry : pois.entrySet()) {
+                Poi poi = entry.getKey();
+
+                Map<String, String> tagmap = entry.getValue();
+                if (!tagmap.keySet().contains("place") || !tagmap.keySet().contains("is_in")) {
+                    continue;
+                }
+
+                switch(tagmap.get("place")){
+                    case "town":
+                    case "village":
+                    case "hamlet":
+                    case "isolated_dwelling":
+                    case "allotments":
+                        break;
+                    default:
+                        continue;
+                }
+                Point point = GEOMETRY_FACTORY.createPoint(new Coordinate(poi.lon, poi.lat));
+                if (!point.within(polygon)) {
+                    continue;
+                }
+                if(adminArea == null){
+                    adminArea = new HashMap.SimpleEntry<>(entry.getKey(), entry.getValue());
+                } else {
+                    Point center = polygon.getCentroid();
+                    LatLong centroid = new LatLong(center.getY(), center.getX());
+                    double disOld = centroid.sphericalDistance(new LatLong(adminArea.getKey().lat, adminArea.getKey().lon));
+                    double disNew = centroid.sphericalDistance(new LatLong(entry.getKey().lat, entry.getKey().lon));
+                    if(disNew<disOld){
+                        adminArea = new HashMap.SimpleEntry<>(entry.getKey(), entry.getValue());
+                    }
+                }
+            }
+            String isInTagName = null;
+            if(adminArea != null){
+                isInTagName = adminArea.getValue().get("is_in");
+            }
+            String relationName = writer.getValueOfTag("name", relation.getTags());
+            LOGGER.fine(relationName + ": #Pois found: " + pois.size());
+            for (Map.Entry<Poi, Map<String, String>> entry : pois.entrySet()) {
+                Poi poi = entry.getKey();
+
+                Map<String, String> tagmap = entry.getValue();
+                if (tagmap.keySet().contains("is_in")) {
+                    continue;
+                }
+
+                if (!tagmap.keySet().contains("name")) {
+                    continue;
+                }
+
+                Point point = GEOMETRY_FACTORY.createPoint(new Coordinate(poi.lon, poi.lat));
+                if (!point.within(polygon)) {
+                    continue;
+                }
+
+                //Write surrounding area as parent in "is_in" tag.
+                tagmap.put("is_in", relationName + (isInTagName != null ? ","+isInTagName:""));
+                batchCountRelation++;
+                try {
+                    this.pStmtUpdateData.setString(1, writer.tagsToString(tagmap));
+                    this.pStmtUpdateData.setLong(2, poi.id);
+
+                    this.pStmtUpdateData.addBatch();
+
+                    if (batchCountRelation % BATCH_LIMIT == 0) {
+                        pStmtUpdateData.executeBatch();
+                        pStmtUpdateData.clearBatch();
+                        conn.commit();
+                    }
+                } catch (SQLException e) {
+                    e.printStackTrace();
+                }
+            }
+            LOGGER.fine("Is_in Tags set for relation: " + relationName + "; ");
+        }
+    }
+
+    private class Poi {
+        public long id;
+        public double lat;
+        public double lon;
+
+        public Poi(long id, double lat, double lon) {
+            this.id = id;
+            this.lat = lat;
+            this.lon = lon;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return obj != null && obj instanceof Poi && ((Poi) obj).id == this.id;
+        }
+
+        @Override
+        public int hashCode() {
+            return ((Long) id).hashCode();
+        }
+    }
+
+    private Map<Poi, Map<String, String>> getPoisInsideBounds(BoundingBox bbox) {
+        Map<Poi, Map<String, String>> pois = new HashMap<>();
+        LOGGER.finer("Bbox: minLat: " + bbox.minLatitude + "; minLon: " + bbox.minLongitude
+                + "; maxLat: " + bbox.maxLatitude + "; maxLon: " + bbox.maxLongitude + ";");
+        try {
+
+            this.pStmtNodesInBox.setDouble(1, bbox.maxLatitude); //poi_index.minLat <= ?
+            this.pStmtNodesInBox.setDouble(2, bbox.maxLongitude); //poi_index.minLon <= ?
+            this.pStmtNodesInBox.setDouble(3, bbox.minLatitude); //poi_index.minLat >= ?
+            this.pStmtNodesInBox.setDouble(4, bbox.minLongitude); //poi_index.minLon >= ?
+
+            ResultSet rs = this.pStmtNodesInBox.executeQuery();
+            while (rs.next()) {
+                //poi_index.id, poi_index.minLat, poi_index.minLon, poi_data.data, poi_categories.name
+                long id = rs.getLong(1);
+                double lat = rs.getDouble(2);
+                double lon = rs.getDouble(3);
+                Map<String, String> tagmap = writer.stringToTags(rs.getString(4));
+                int categ = rs.getInt(5);
+                pois.put(new Poi(id, lat, lon), tagmap);
+                LOGGER.finest("Bbox: InnerNode-Id: " + id + "; Lat: " + lat + "; Lon: " + lon + ";");
+//                if (categname.equals("Cities") || categname.equals("Towns")
+//                        || categname.equals("Villages")
+//                        || categname.equals("Hamlets")) {
+//                    places.put(id, tagmap);
+//                }
+            }
+            rs.close();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return pois;
+    }
+
+    public void commit(){
+        try {
+            pStmtInsertWayNodes.executeBatch();
+            pStmtUpdateData.executeBatch();
+            pStmtInsertWayNodes.clearBatch();
+            pStmtUpdateData.clearBatch();
+            conn.commit();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/mapsforge-poi-writer/src/main/java/org/mapsforge/poi/writer/PoiWriter.java
+++ b/mapsforge-poi-writer/src/main/java/org/mapsforge/poi/writer/PoiWriter.java
@@ -33,6 +33,7 @@ import org.mapsforge.poi.writer.model.PoiWriterConfiguration;
 import org.openstreetmap.osmosis.core.container.v0_6.EntityContainer;
 import org.openstreetmap.osmosis.core.domain.v0_6.Entity;
 import org.openstreetmap.osmosis.core.domain.v0_6.Node;
+import org.openstreetmap.osmosis.core.domain.v0_6.Relation;
 import org.openstreetmap.osmosis.core.domain.v0_6.Tag;
 import org.openstreetmap.osmosis.core.domain.v0_6.Way;
 import org.openstreetmap.osmosis.core.domain.v0_6.WayNode;
@@ -45,6 +46,10 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
 import java.text.NumberFormat;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Stack;
@@ -69,9 +74,9 @@ public final class PoiWriter {
         return new PoiWriter(configuration, progressManager);
     }
 
-    private static final Logger LOGGER = LoggerWrapper.getLogger(PoiWriter.class.getName());
+    public static final Logger LOGGER = LoggerWrapper.getLogger(PoiWriter.class.getName());
 
-    private static final int BATCH_LIMIT = 1024;
+    public static final int BATCH_LIMIT = 1024;
 
     /**
      * The minimum amount of nodes required for a valid closed polygon.
@@ -94,9 +99,13 @@ public final class PoiWriter {
     // Accepted categories
     private final PoiCategoryFilter categoryFilter;
 
+    // GeoTagging
+    private final GeoTagger geoTagger;
+
     // Statistics
     private int nNodes = 0;
     private int nWays = 0;
+    private int nRelations = 0;
     private int poiAdded = 0;
 
     // Database
@@ -105,6 +114,8 @@ public final class PoiWriter {
     private PreparedStatement pStmtIndex = null;
     private PreparedStatement pStmtNodesC = null;
     private PreparedStatement pStmtNodesR = null;
+    private PreparedStatement pStmtFindWayNodes = null;
+
 
     private PoiWriter(PoiWriterConfiguration configuration, ProgressManager progressManager) {
         this.configuration = configuration;
@@ -138,6 +149,9 @@ public final class PoiWriter {
         LOGGER.info("Creating POI database...");
         this.progressManager.initProgressBar(0, 0);
         this.progressManager.setMessage("Creating POI database");
+
+        // Set GeoTagger (note that database has to be set before initializing geotagger)
+        this.geoTagger = new GeoTagger(this);
     }
 
     /**
@@ -148,6 +162,9 @@ public final class PoiWriter {
         this.progressManager.setMessage("Committing...");
         this.pStmtIndex.executeBatch();
         this.pStmtData.executeBatch();
+        if (configuration.isAutoGeoTags()) {
+            geoTagger.commit();
+        }
         this.conn.commit();
     }
 
@@ -223,14 +240,35 @@ public final class PoiWriter {
             if (rs.next()) {
                 double lat = rs.getDouble(1);
                 double lon = rs.getDouble(2);
-
                 return new LatLong(lat, lon);
             }
             rs.close();
         } catch (SQLException e) {
             e.printStackTrace();
         }
+        return null;
+    }
 
+    /**
+     * Find its NodeIDs by a wayID.
+     */
+    public List<Long> findWayNodesByWayID(long id) {
+        try {
+            this.pStmtFindWayNodes.setLong(1, id);
+
+            ResultSet rs = this.pStmtFindWayNodes.executeQuery();
+            TreeMap<Integer, Long> nodeList = new TreeMap<>();
+            while (rs.next()) {
+                //way, node, position
+                Long nodeID = rs.getLong(1);
+                Integer pos = rs.getInt(2);
+                nodeList.put(pos, nodeID);
+            }
+            rs.close();
+            return new ArrayList<>((Collection<Long>) nodeList.values());
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
         return null;
     }
 
@@ -242,6 +280,8 @@ public final class PoiWriter {
 
         this.conn = DriverManager.getConnection("jdbc:sqlite:" + this.configuration.getOutputFile().getAbsolutePath());
         this.conn.createStatement().execute(DbConstants.DROP_NODES_STATEMENT);
+        this.conn.createStatement().execute(DbConstants.DROP_WAYNODES_STATEMENT);
+        this.conn.createStatement().execute(DbConstants.DROP_WAYS_STATEMENT);
         this.conn.close();
 
         this.conn = DriverManager.getConnection("jdbc:sqlite:" + this.configuration.getOutputFile().getAbsolutePath());
@@ -265,17 +305,22 @@ public final class PoiWriter {
         stmt.execute(DbConstants.DROP_INDEX_STATEMENT);
         stmt.execute(DbConstants.DROP_DATA_STATEMENT);
         stmt.execute(DbConstants.DROP_CATEGORIES_STATEMENT);
+        stmt.execute(DbConstants.DROP_WAYS_STATEMENT);
+        stmt.execute(DbConstants.DROP_WAYNODES_STATEMENT);
         stmt.execute(DbConstants.CREATE_CATEGORIES_STATEMENT);
         stmt.execute(DbConstants.CREATE_DATA_STATEMENT);
         stmt.execute(DbConstants.CREATE_INDEX_STATEMENT);
         stmt.execute(DbConstants.CREATE_METADATA_STATEMENT);
         stmt.execute(DbConstants.CREATE_NODES_STATEMENT);
+        stmt.execute(DbConstants.CREATE_WAYS_STATEMENT);
+        stmt.execute(DbConstants.CREATE_WAYNODES_STATEMENT);
 
         this.pStmtData = this.conn.prepareStatement(DbConstants.INSERT_DATA_STATEMENT);
         this.pStmtIndex = this.conn.prepareStatement(DbConstants.INSERT_INDEX_STATEMENT);
 
         this.pStmtNodesC = this.conn.prepareStatement(DbConstants.INSERT_NODES_STATEMENT);
         this.pStmtNodesR = this.conn.prepareStatement(DbConstants.FIND_NODES_STATEMENT);
+        this.pStmtFindWayNodes = this.conn.prepareStatement(DbConstants.FIND_WAY_NODES_BY_WAY_ID_STATEMENT);
 
         // Insert categories
         PreparedStatement pStmt = this.conn.prepareStatement(DbConstants.INSERT_CATEGORIES_STATEMENT);
@@ -336,10 +381,41 @@ public final class PoiWriter {
                     processWay(way);
                 }
                 break;
+            case Relation:
+                if (this.configuration.isAutoGeoTags() && this.configuration.isWays()) {
+                    Relation relation = (Relation) entity;
+                    if (this.nRelations == 0) {
+                        geoTagger.commit();
+                        LOGGER.info("Processing relations...");
+                    }
+                    geoTagger.filterBoundaries(relation);
+                    ++this.nRelations;
+                }
+                break;
+            default:
+                break;
         }
 
         // Hint to GC
         entity = null;
+    }
+
+    /**
+     * Returns value of given tag in a set of tags
+     *
+     * @param tagkey Tag key
+     * @param tags   Collection of tags
+     * @return Tag value or null if not exists
+     */
+    public String getValueOfTag(String tagkey, Collection<Tag> tags) {
+        String name = null;
+        for (Tag tag : tags) {
+            if (tag.getKey() != null && tag.getKey().equalsIgnoreCase(tagkey)) {
+                name = tag.getValue();
+                break;
+            }
+        }
+        return name;
     }
 
     /**
@@ -394,14 +470,12 @@ public final class PoiWriter {
      * Process a <code>Way</code> (only polygons).
      */
     private void processWay(Way way) {
-        // The first and the last way node are the same
-        if (!way.isClosed()) {
-            return;
-        }
+        //Delete way isClosed restriction, to laod all ways.
 
         // The way has at least 4 way nodes
-        if (way.getWayNodes().size() < MIN_NODES_POLYGON) {
-            LOGGER.finer("Found closed polygon with fewer than 4 way nodes. Way id: " + way.getId());
+        // MIN_NODES_POLYGON moved to polygon handling
+        if (way.getWayNodes().size() < 2) {
+            LOGGER.finer("Found closed polygon with fewer than 2 way nodes. Way id: " + way.getId());
             return;
         }
 
@@ -430,22 +504,40 @@ public final class PoiWriter {
             LatLong wayNode = wayNodes[j];
             coordinates[j] = new Coordinate(wayNode.longitude, wayNode.latitude);
         }
-        Polygon polygon = GEOMETRY_FACTORY.createPolygon(GEOMETRY_FACTORY.createLinearRing(coordinates), null);
 
-        // Compute the centroid of the polygon
-        Point centroid = polygon.getCentroid();
-        if (centroid == null) {
+        //Calculate center of polygon dependent on way form
+        LatLong centroid;
+        if (way.isClosed() && way.getWayNodes().size() >= MIN_NODES_POLYGON) {
+            Polygon polygon = GEOMETRY_FACTORY.createPolygon(GEOMETRY_FACTORY.createLinearRing(coordinates), null);
+
+            // Compute the centroid of the polygon
+            Point center = polygon.getCentroid();
+            centroid = new LatLong(center.getY(), center.getX());
+
+        } else {
+            //MultiPoint multi = GEOMETRY_FACTORY.createMultiPoint(coordinates);
+            centroid = wayNodes[(wayNodes.length - 1) / 2];
+        }
+
+        if (configuration.isAutoGeoTags()) {
+            geoTagger.storeAdministrativeBoundaries(way);
+        }
+
+        //Name not valid
+        String name = getValueOfTag("name", way.getTags());
+        if (name == null || name.isEmpty()) {
             return;
         }
 
         // Process the way
-        processEntity(way, centroid.getY(), centroid.getX());
+        processEntity(way, centroid.getLatitude(), centroid.getLongitude());
     }
+
 
     /**
      * Convert tags to a string representation using '\r' delimiter.
      */
-    private String tagsToString(Map<String, String> tagMap) {
+    public String tagsToString(Map<String, String> tagMap) {
         StringBuilder sb = new StringBuilder();
         for (String key : tagMap.keySet()) {
             // Skip some tags
@@ -458,6 +550,22 @@ public final class PoiWriter {
             sb.append(key).append('=').append(tagMap.get(key));
         }
         return sb.toString();
+    }
+
+    /**
+     * Convert string representation back to tags map.
+     */
+    public Map<String, String> stringToTags(String tagsmapstring) {
+        String[] sb = tagsmapstring.split("\\r");
+        Map<String, String> map = new HashMap<String, String>();
+        for (String key : sb) {
+            if (key.contains("=")) {
+                String[] set = key.split("=");
+                if (set.length == 2)
+                    map.put(set[0], set[1]);
+            }
+        }
+        return map;
     }
 
     /**
@@ -599,5 +707,9 @@ public final class PoiWriter {
         } catch (SQLException e) {
             e.printStackTrace();
         }
+    }
+
+    public Connection getConnection(){
+        return this.conn;
     }
 }

--- a/mapsforge-poi-writer/src/main/java/org/mapsforge/poi/writer/PoiWriter.java
+++ b/mapsforge-poi-writer/src/main/java/org/mapsforge/poi/writer/PoiWriter.java
@@ -172,6 +172,9 @@ public final class PoiWriter {
      * Complete task.
      */
     public void complete() {
+        if(geoTagger != null){
+            geoTagger.processBoundaries();
+        }
         NumberFormat nfMegabyte = NumberFormat.getInstance();
         NumberFormat nfCounts = NumberFormat.getInstance();
         nfCounts.setGroupingUsed(true);

--- a/mapsforge-poi-writer/src/main/java/org/mapsforge/poi/writer/model/PoiWriterConfiguration.java
+++ b/mapsforge-poi-writer/src/main/java/org/mapsforge/poi/writer/model/PoiWriterConfiguration.java
@@ -35,6 +35,7 @@ public class PoiWriterConfiguration {
     private URL tagMapping;
     private boolean ways;
     private String writerVersion;
+    private boolean autoGeoTags;
 
     /**
      * Convenience method.
@@ -138,6 +139,14 @@ public class PoiWriterConfiguration {
     }
 
     /**
+     * Add additional tags to data, to resolve geolocation
+     * @return boolean, if it's enabled
+     */
+    public boolean isAutoGeoTags() {
+        return autoGeoTags;
+    }
+
+    /**
      * Convenience method.
      *
      * @param file the path to the tag mapping
@@ -230,5 +239,13 @@ public class PoiWriterConfiguration {
      */
     public void setWriterVersion(String writerVersion) {
         this.writerVersion = writerVersion;
+    }
+
+    /**
+     * Sets configuration for autoGeoTags
+     * @param autoGeoTags true: enable geoTags, else false
+     */
+    public void setAutoGeoTags(boolean autoGeoTags) {
+        this.autoGeoTags = autoGeoTags;
     }
 }

--- a/mapsforge-poi-writer/src/main/java/org/mapsforge/poi/writer/osmosis/PoiWriterFactory.java
+++ b/mapsforge-poi-writer/src/main/java/org/mapsforge/poi/writer/osmosis/PoiWriterFactory.java
@@ -39,6 +39,7 @@ public class PoiWriterFactory extends TaskManagerFactory {
     private static final String PARAM_PREFERRED_LANGUAGE = "preferred-language";
     private static final String PARAM_TAG_MAPPING_FILE = "tag-conf-file";
     private static final String PARAM_WAYS = "ways";
+    private static final String PARAM_GEO_TAGS = "geo-tags";
 
     @Override
     protected TaskManager createTaskManagerImpl(TaskConfiguration taskConfig) {
@@ -51,6 +52,7 @@ public class PoiWriterFactory extends TaskManagerFactory {
         configuration.setPreferredLanguage(getStringArgument(taskConfig, PARAM_PREFERRED_LANGUAGE, null));
         configuration.loadTagMappingFile(getStringArgument(taskConfig, PARAM_TAG_MAPPING_FILE, null));
         configuration.setWays(getBooleanArgument(taskConfig, PARAM_WAYS, true));
+        configuration.setAutoGeoTags(getBooleanArgument(taskConfig, PARAM_GEO_TAGS, false));
 
         // If set to true, progress messages will be forwarded to a GUI message handler
         // boolean guiMode = getBooleanArgument(taskConfig, "gui-mode", false);

--- a/mapsforge-poi/src/main/java/org/mapsforge/poi/storage/DbConstants.java
+++ b/mapsforge-poi/src/main/java/org/mapsforge/poi/storage/DbConstants.java
@@ -24,6 +24,9 @@ public final class DbConstants {
     public static final String CREATE_METADATA_STATEMENT = "CREATE TABLE metadata (name TEXT, value TEXT);";
     public static final String CREATE_NODES_STATEMENT = "CREATE TABLE nodes (id INTEGER, lat REAL, lon REAL, PRIMARY KEY (id));";
 
+    public static final String CREATE_WAYS_STATEMENT = "CREATE TABLE ways (id INTEGER, name String, PRIMARY KEY (id));";
+    public static final String CREATE_WAYNODES_STATEMENT = "CREATE TABLE waynodes (way INTEGER not null, node INTEGER not null, position INTEGER, PRIMARY KEY (way, node, position));";
+
     public static final String DELETE_DATA_STATEMENT = "DELETE FROM poi_data WHERE id = ?;";
     public static final String DELETE_INDEX_STATEMENT = "DELETE FROM poi_index WHERE id = ?;";
 
@@ -32,6 +35,8 @@ public final class DbConstants {
     public static final String DROP_INDEX_STATEMENT = "DROP TABLE IF EXISTS poi_index;";
     public static final String DROP_METADATA_STATEMENT = "DROP TABLE IF EXISTS metadata;";
     public static final String DROP_NODES_STATEMENT = "DROP TABLE IF EXISTS nodes;";
+    public static final String DROP_WAYS_STATEMENT = "DROP TABLE IF EXISTS ways;";
+    public static final String DROP_WAYNODES_STATEMENT = "DROP TABLE IF EXISTS waynodes;";
 
     public static final String FIND_BY_DATA_CLAUSE = " AND poi_data.data LIKE ?";
     public static final String FIND_BY_ID_STATEMENT =
@@ -48,15 +53,24 @@ public final class DbConstants {
                     + "minLat <= ? AND "
                     + "minLon <= ? AND "
                     + "minLat >= ? AND "
-                    + "minLon >= ?";
+                    + "minLon >= ?;";
     public static final String FIND_METADATA_STATEMENT = "SELECT name, value FROM metadata;";
     public static final String FIND_NODES_STATEMENT = "SELECT lat, lon FROM nodes WHERE id = ?;";
+    public static final String FIND_WAY_BY_ID_STATEMENT = "SELECT name FROM ways WHERE id = ?;";
+    public static final String FIND_WAY_NODES_BY_WAY_ID_STATEMENT =
+            "SELECT node, position FROM waynodes WHERE way = ?;";
 
     public static final String INSERT_CATEGORIES_STATEMENT = "INSERT INTO poi_categories VALUES (?, ?, ?);";
     public static final String INSERT_DATA_STATEMENT = "INSERT INTO poi_data VALUES (?, ?, ?);";
     public static final String INSERT_INDEX_STATEMENT = "INSERT INTO poi_index VALUES (?, ?, ?, ?, ?);";
     public static final String INSERT_METADATA_STATEMENT = "INSERT INTO metadata VALUES (?, ?);";
     public static final String INSERT_NODES_STATEMENT = "INSERT INTO nodes VALUES (?, ?, ?);";
+    public static final String INSERT_WAYS_STATEMENT = "INSERT INTO ways VALUES (?, ?);";
+    public static final String INSERT_WAYNODES_STATEMENT = "INSERT INTO waynodes VALUES (?, ?, ?);";
+
+    public static final String UPDATE_DATA_STATEMENT = "UPDATE poi_data "
+            + "SET data = ? "
+            + "WHERE id = ?;";
 
     public static final String METADATA_BOUNDS = "bounds";
     public static final String METADATA_COMMENT = "comment";


### PR DESCRIPTION
Provide highways, to potentially extend to simple address search. The main reason to leaving out highways was the size, but it's marginal noticeable. Further you can exclude them via filters.

Added a tool to automatically tag POIs with "is_in" values (if doesn't already exists), to link POI with its region. 
Usually there's no simple way to get info about location, after conversion to POI-database. (Now, only administration level 9 is considered, furthers will follow). 