### PR TITLE
POI: add geo tags

### DIFF
--- a/mapsforge-poi-writer/build.gradle
+++ b/mapsforge-poi-writer/build.gradle
@@ -2,6 +2,7 @@ dependencies {
     compile project(":mapsforge-poi")
     compile 'com.vividsolutions:jts-core:1.14.0'
     compile 'org.xerial:sqlite-jdbc:3.16.1'
+    compile 'com.google.guava:guava:20.0'
     compileOnly 'org.openstreetmap.osmosis:osmosis-core:0.45'
 }
 

--- a/mapsforge-poi-writer/src/main/java/org/mapsforge/poi/writer/GeoTagger.java
+++ b/mapsforge-poi-writer/src/main/java/org/mapsforge/poi/writer/GeoTagger.java
@@ -182,9 +182,18 @@ class GeoTagger {
         Map<Poi, Map<String, String>> pois = getPoisInsideBounds(bbox);
 
         if(isPostCode){
-            String value = writer.getValueOfTag("postal_code", relation.getTags());
-            if(value != null || !value.isEmpty()){
-                updateTagData(pois, polygon,"addr:postcode", value);
+            String postcode = writer.getValueOfTag("postal_code", relation.getTags());
+            if(postcode != null && !postcode.isEmpty()){
+                updateTagData(pois, polygon,"addr:postcode", postcode);
+
+                String city = writer.getValueOfTag("note", relation.getTags());
+                if(city != null && !city.isEmpty()){
+                    int i = city.indexOf(postcode);
+                    if(i>=0){
+                        city = city.substring(0,i) + city.substring(postcode.length(), city.length()).trim();
+                        updateTagData(pois, polygon,"addr:city", city);
+                    }
+                }
             }
         } else {
             Map.Entry<Poi, Map<String, String>> adminArea = null;

--- a/mapsforge-poi-writer/src/main/java/org/mapsforge/poi/writer/GeoTagger.java
+++ b/mapsforge-poi-writer/src/main/java/org/mapsforge/poi/writer/GeoTagger.java
@@ -1,0 +1,471 @@
+package org.mapsforge.poi.writer;
+
+import com.google.common.collect.Lists;
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.GeometryFactory;
+import com.vividsolutions.jts.geom.Point;
+import com.vividsolutions.jts.geom.Polygon;
+
+import org.mapsforge.core.model.BoundingBox;
+import org.mapsforge.core.model.LatLong;
+import org.mapsforge.poi.storage.DbConstants;
+import org.openstreetmap.osmosis.core.domain.v0_6.EntityType;
+import org.openstreetmap.osmosis.core.domain.v0_6.Relation;
+import org.openstreetmap.osmosis.core.domain.v0_6.RelationMember;
+import org.openstreetmap.osmosis.core.domain.v0_6.Tag;
+import org.openstreetmap.osmosis.core.domain.v0_6.Way;
+import org.openstreetmap.osmosis.core.domain.v0_6.WayNode;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mapsforge.poi.writer.PoiWriter.LOGGER;
+
+/**
+ * GeoTagger provides location Tags from OSM-Data in Poi-Tags (especially is_in and address tags)
+ * Created by gustl on 03.04.17.
+ */
+
+class GeoTagger {
+    private PoiWriter writer;
+    private Connection conn = null;
+    private final int BATCH_LIMIT;
+    private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory();
+    private PreparedStatement pStmtInsertWayNodes = null;
+    private PreparedStatement pStmtUpdateData = null;
+    private PreparedStatement pStmtNodesInBox = null;
+
+    GeoTagger(PoiWriter writer){
+        this.writer = writer;
+        conn = writer.getConnection();
+        BATCH_LIMIT = PoiWriter.BATCH_LIMIT;
+        try {
+            this.pStmtInsertWayNodes = conn.prepareStatement(DbConstants.INSERT_WAYNODES_STATEMENT);
+            this.pStmtUpdateData = this.conn.prepareStatement(DbConstants.UPDATE_DATA_STATEMENT);
+            this.pStmtNodesInBox = this.conn.prepareStatement(DbConstants.FIND_IN_BOX_STATEMENT);
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+
+        //Init Relation list
+        administrativeBoundaries = new ArrayList<>();
+        for(int i=0; i<12; i++){
+            administrativeBoundaries.add(new ArrayList<Relation>());
+        }
+    }
+
+    private int batchCountWays = 0;
+    void storeAdministrativeBoundaries(Way way) {
+
+        Collection<Tag> tags = way.getTags();
+        for (Tag tag : tags) {
+            switch (tag.getKey()) {
+                case "building":
+                case "highway":
+                case "landuse":
+                case "leisure":
+                case "amenity":
+                case "sport":
+                case "waterway":
+                case "barrier":
+                case "railway":
+                case "foot":
+//                    //"natural is no nonBound-case"
+                    return;
+                //TODO Add more cases for other nonboundaries
+                case "boundary":
+                    // This case is simpler than exclude all non valid cases.
+                    // But it will not get all bound results, some have no tags set and exist only as
+                    // relation; it's better to exclude them and
+                    // then add possible boundaries to database
+                    if (tag.getValue().equalsIgnoreCase("administrative")) {
+                        storeWay(way);
+                    }
+                    return;
+            }
+        }
+        //No tags occured that speek against a boundary
+        storeWay(way);
+    }
+
+    private void storeWay(Way way){
+        int i = 0;
+        try {
+            for (WayNode wayNode : way.getWayNodes()) {
+                pStmtInsertWayNodes.setLong(1, way.getId());
+                pStmtInsertWayNodes.setLong(2, wayNode.getNodeId());
+                pStmtInsertWayNodes.setInt(3, i);
+                pStmtInsertWayNodes.addBatch();
+
+                i++;
+            }
+            batchCountWays++;
+            if (batchCountWays % BATCH_LIMIT == 0) {
+                pStmtInsertWayNodes.executeBatch();
+                pStmtInsertWayNodes.clearBatch();
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    //List of Administrative Boundaries Relations
+    private List<List<Relation>> administrativeBoundaries;
+    private int batchCountRelation = 0;
+
+    void filterBoundaries(Relation relation) {
+        if (!("boundary".equalsIgnoreCase(writer.getValueOfTag("type", relation.getTags()))
+                && "administrative".equalsIgnoreCase(writer.getValueOfTag("boundary", relation.getTags())))) {
+            return;
+        }
+        String adminLevelValue = writer.getValueOfTag("admin_level", relation.getTags());
+        if(adminLevelValue == null) return;
+        switch(adminLevelValue.trim()){
+            //TODO Specify cultural/regional diffs for admin_levels,
+            // which should be the lowest level of administrative boundary, tagged with is_in
+            case "7":
+                administrativeBoundaries.get(6).add(relation);
+                return;
+            case "8":
+                administrativeBoundaries.get(7).add(relation);
+                return;
+            case "9":
+                administrativeBoundaries.get(8).add(relation);
+                return;
+            case "10":
+                administrativeBoundaries.get(9).add(relation);
+                return;
+            default:
+        }
+    }
+    
+    void processBoundaries(){
+        for (int i = administrativeBoundaries.size()-1; i>=0; i--) {
+            List<Relation> administrativeBoundary = administrativeBoundaries.get(i);
+            for (Relation relation : administrativeBoundary) {
+                processBoundary(relation);
+            }
+
+        }
+
+    }
+
+    private void processBoundary(Relation relation){
+        List<List<Long>> bounds = new ArrayList<>();
+        for (RelationMember relationMember : relation.getMembers()) {
+            if (relationMember.getMemberType().equals(EntityType.Way)
+                    && "outer".equalsIgnoreCase(relationMember.getMemberRole())) {
+                List<Long> waynodes = writer.findWayNodesByWayID(relationMember.getMemberId());
+                if (waynodes != null && !waynodes.isEmpty()) {
+                    bounds.add(waynodes);
+                    continue;
+                }
+                LOGGER.finer("\n---> Member not found | Membertype= " + relationMember.getMemberType().name()
+                        + ", Memberrole= " + relationMember.getMemberRole() + "\n");
+                continue;
+            }
+            LOGGER.finer("\n---> Member not accepted | Membertype= " + relationMember.getMemberType().name()
+                    + ", Memberrole= " + relationMember.getMemberRole() + "\n");
+        }
+        //Merge bound nodes (There's may a simpler method)
+        if (!bounds.isEmpty()) {
+            LOGGER.fine("Administrative: " + writer.getValueOfTag("name", relation.getTags())
+                    + " #Members: " + relation.getMembers().size()
+                    + " #Segments: " + bounds.size());
+            //Iterate through given list
+
+            //Debug
+            int counter = bounds.size();
+            if (counter < 6) {
+                String builder2 = "Bound nodes: ";
+                for (int j = 0; j < bounds.size(); j++) {
+                    //LOGGER.info("j: "+ j+"; i: "+i);
+                    List<Long> J = bounds.get(j);
+                    LatLong Ja = writer.findNodeByID(J.get(0));
+                    LatLong Jb = writer.findNodeByID(J.get(J.size() - 1));
+                    builder2 += ("\nJa coord: " + Ja.latitude + ", " + Ja.longitude
+                            + "\nJb coord: " + Jb.latitude + ", " + Jb.longitude);
+                }
+                builder2 += "\n++++++++++++++++++++++++++++++";
+                LOGGER.finer(builder2);
+            }
+            //Debugend
+
+            final double threshold = 20; //In meters;
+            for (int i = 1; i < bounds.size(); i++) {
+                //Create second list, to compare values
+                List<Long> I = bounds.get(i);
+                List<Long> check = I;
+                long nIa = I.get(0);
+                long nIb = I.get(I.size() - 1);
+                LatLong Ia = writer.findNodeByID(I.get(0));
+                LatLong Ib = writer.findNodeByID(I.get(I.size() - 1));
+                boolean isMerged = false;
+                for (int j = 0; j < bounds.size(); j++) {
+                    if (i == j) continue;
+                    //LOGGER.info("j: "+ j+"; i: "+i);
+                    List<Long> J = bounds.get(j);
+                    long nJa = J.get(0);
+                    long nJb = J.get(J.size() - 1);
+                    LatLong Ja = writer.findNodeByID(J.get(0));
+                    LatLong Jb = writer.findNodeByID(J.get(J.size() - 1));
+                    if (Ia == null || Ib == null || Ja == null || Jb == null) return;
+                    //If first of I and last of J matches: merge
+                    if (Ia.sphericalDistance(Jb) < threshold) {
+                        I.remove(0);
+                        J.addAll(I);
+                        bounds.set(j, J);
+                        bounds.remove(i);
+                        i--;
+                        isMerged = true;
+                        LOGGER.finest("matches: " + Ia.latitude + ", " + Ia.longitude
+                                + "; Ids: " + nIa + ", " + nJb);
+                        break;
+                    } else if (Ib.sphericalDistance(Jb) < threshold) {
+                        //If list I is reversed
+                        I = Lists.reverse(I);
+                        I.remove(0);
+                        J.addAll(I);
+                        bounds.set(j, J);
+                        bounds.remove(i);
+                        i--;
+                        isMerged = true;
+                        LOGGER.finest("reverse I matches: " + Ib.latitude + ", " + Ib.longitude
+                                + "; Ids: " + nIb + ", " + nJb);
+                        break;
+                    } else if (Ia.sphericalDistance(Ja) < threshold) {
+                        //If list J is reversed
+                        J = Lists.reverse(J);
+                        I.remove(0);
+                        J.addAll(I);
+                        bounds.set(j, J);
+                        bounds.remove(i);
+                        i--;
+                        isMerged = true;
+                        LOGGER.finest("reverse J matches: " + Ia.latitude + ", " + Ia.longitude
+                                + "; Ids: " + nIa + ", " + nJb);
+                        break;
+                    } else if (Ib.sphericalDistance(Ja) < threshold) {
+                        //If both are reversed
+                        J = Lists.reverse(J);
+                        I = Lists.reverse(I);
+                        I.remove(0);
+                        J.addAll(I);
+                        bounds.set(j, J);
+                        bounds.remove(i);
+                        i--;
+                        isMerged = true;
+                        LOGGER.finest("reverse Both matches: " + Ib.latitude + ", " + Ib.longitude
+                                + "; Ids: " + nIb + ", " + nJa);
+                        break;
+                    }
+                }
+                //One path does'not match, so return
+                if (bounds.contains(check) && bounds.size() > 1) {
+                    if (counter > 6) continue;
+                    String builder = "Bound merging failed; Merged: " + isMerged
+                            + "\nIa coord: " + Ia.latitude + ", " + Ia.longitude
+                            + "\nIb coord: " + Ib.latitude + ", " + Ib.longitude + "\n";
+                    for (int j = 0; j < bounds.size(); j++) {
+                        if (i == j) continue;
+                        //LOGGER.info("j: "+ j+"; i: "+i);
+                        List<Long> J = bounds.get(j);
+                        LatLong Ja = writer.findNodeByID(J.get(0));
+                        LatLong Jb = writer.findNodeByID(J.get(J.size() - 1));
+                        builder += ("\nJa coord: " + Ja.latitude + ", " + Ja.longitude
+                                + "\nJb coord: " + Jb.latitude + ", " + Jb.longitude);
+                    }
+                    builder += "\n-------------------------------\n\n";
+                    LOGGER.fine(builder);
+                }
+            }
+            LOGGER.finer("Bound merging finished; Size= " + bounds.size());
+            //Check the result
+            //TODO Calculate areas which have more than 1 circle bound. (Simple cover func.)
+            if (bounds.size() != 1) {
+                return;
+            }
+            LOGGER.finer("Bound has right size; ");
+
+            Long[] area = bounds.get(0).toArray(new Long[bounds.get(0).size()]);
+            LatLong node = writer.findNodeByID(area[0]);
+            if (node == null || node.sphericalDistance(writer.findNodeByID(area[area.length - 1])) >= threshold) {
+                return;
+            }
+            area[0] = area[area.length - 1];
+            LOGGER.finer("Last node is first node; ");
+            // Convert the way to a JTS polygon
+            Coordinate[] coordinates = new Coordinate[area.length];
+            for (int j = 0; j < area.length; j++) {
+                LatLong wayNode = writer.findNodeByID(area[j]);
+                if (wayNode == null) return;
+                coordinates[j] = new Coordinate(wayNode.longitude, wayNode.latitude);
+            }
+
+            LOGGER.finer("Polygon created; ");
+            Polygon polygon = GEOMETRY_FACTORY.createPolygon(GEOMETRY_FACTORY.createLinearRing(coordinates), null);
+            double minLat = coordinates[0].y;
+            double minLon = coordinates[0].x;
+            BoundingBox bbox = new BoundingBox(minLat, minLon, minLat, minLon);
+            for (Coordinate coord : coordinates) {
+                bbox = bbox.extendCoordinates(coord.y, coord.x);
+            }
+
+            //Get pois in bounds
+            Map<Poi, Map<String, String>> pois = getPoisInsideBounds(bbox);
+
+            Map.Entry<Poi, Map<String, String>> adminArea = null;
+            for (Map.Entry<Poi, Map<String, String>> entry : pois.entrySet()) {
+                Poi poi = entry.getKey();
+
+                Map<String, String> tagmap = entry.getValue();
+                if (!tagmap.keySet().contains("place") || !tagmap.keySet().contains("is_in")) {
+                    continue;
+                }
+
+                switch(tagmap.get("place")){
+                    case "town":
+                    case "village":
+                    case "hamlet":
+                    case "isolated_dwelling":
+                    case "allotments":
+                        break;
+                    default:
+                        continue;
+                }
+                Point point = GEOMETRY_FACTORY.createPoint(new Coordinate(poi.lon, poi.lat));
+                if (!point.within(polygon)) {
+                    continue;
+                }
+                if(adminArea == null){
+                    adminArea = new HashMap.SimpleEntry<>(entry.getKey(), entry.getValue());
+                } else {
+                    Point center = polygon.getCentroid();
+                    LatLong centroid = new LatLong(center.getY(), center.getX());
+                    double disOld = centroid.sphericalDistance(new LatLong(adminArea.getKey().lat, adminArea.getKey().lon));
+                    double disNew = centroid.sphericalDistance(new LatLong(entry.getKey().lat, entry.getKey().lon));
+                    if(disNew<disOld){
+                        adminArea = new HashMap.SimpleEntry<>(entry.getKey(), entry.getValue());
+                    }
+                }
+            }
+            String isInTagName = null;
+            if(adminArea != null){
+                isInTagName = adminArea.getValue().get("is_in");
+            }
+            String relationName = writer.getValueOfTag("name", relation.getTags());
+            LOGGER.fine(relationName + ": #Pois found: " + pois.size());
+            for (Map.Entry<Poi, Map<String, String>> entry : pois.entrySet()) {
+                Poi poi = entry.getKey();
+
+                Map<String, String> tagmap = entry.getValue();
+                if (tagmap.keySet().contains("is_in")) {
+                    continue;
+                }
+
+                if (!tagmap.keySet().contains("name")) {
+                    continue;
+                }
+
+                Point point = GEOMETRY_FACTORY.createPoint(new Coordinate(poi.lon, poi.lat));
+                if (!point.within(polygon)) {
+                    continue;
+                }
+
+                //Write surrounding area as parent in "is_in" tag.
+                tagmap.put("is_in", relationName + (isInTagName != null ? ","+isInTagName:""));
+                batchCountRelation++;
+                try {
+                    this.pStmtUpdateData.setString(1, writer.tagsToString(tagmap));
+                    this.pStmtUpdateData.setLong(2, poi.id);
+
+                    this.pStmtUpdateData.addBatch();
+
+                    if (batchCountRelation % BATCH_LIMIT == 0) {
+                        pStmtUpdateData.executeBatch();
+                        pStmtUpdateData.clearBatch();
+                        conn.commit();
+                    }
+                } catch (SQLException e) {
+                    e.printStackTrace();
+                }
+            }
+            LOGGER.fine("Is_in Tags set for relation: " + relationName + "; ");
+        }
+    }
+    
+    private class Poi {
+        long id;
+        double lat;
+        double lon;
+
+        Poi(long id, double lat, double lon) {
+            this.id = id;
+            this.lat = lat;
+            this.lon = lon;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return obj != null && obj instanceof Poi && ((Poi) obj).id == this.id;
+        }
+
+        @Override
+        public int hashCode() {
+            return ((Long) id).hashCode();
+        }
+    }
+
+    private Map<Poi, Map<String, String>> getPoisInsideBounds(BoundingBox bbox) {
+        Map<Poi, Map<String, String>> pois = new HashMap<>();
+        LOGGER.finer("Bbox: minLat: " + bbox.minLatitude + "; minLon: " + bbox.minLongitude
+                + "; maxLat: " + bbox.maxLatitude + "; maxLon: " + bbox.maxLongitude + ";");
+        try {
+
+            this.pStmtNodesInBox.setDouble(1, bbox.maxLatitude); //poi_index.minLat <= ?
+            this.pStmtNodesInBox.setDouble(2, bbox.maxLongitude); //poi_index.minLon <= ?
+            this.pStmtNodesInBox.setDouble(3, bbox.minLatitude); //poi_index.minLat >= ?
+            this.pStmtNodesInBox.setDouble(4, bbox.minLongitude); //poi_index.minLon >= ?
+
+            ResultSet rs = this.pStmtNodesInBox.executeQuery();
+            while (rs.next()) {
+                //poi_index.id, poi_index.minLat, poi_index.minLon, poi_data.data, poi_categories.name
+                long id = rs.getLong(1);
+                double lat = rs.getDouble(2);
+                double lon = rs.getDouble(3);
+                Map<String, String> tagmap = writer.stringToTags(rs.getString(4));
+                int categ = rs.getInt(5);
+                pois.put(new Poi(id, lat, lon), tagmap);
+                LOGGER.finest("Bbox: InnerNode-Id: " + id + "; Lat: " + lat + "; Lon: " + lon + ";");
+//                if (categname.equals("Cities") || categname.equals("Towns")
+//                        || categname.equals("Villages")
+//                        || categname.equals("Hamlets")) {
+//                    places.put(id, tagmap);
+//                }
+            }
+            rs.close();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return pois;
+    }
+
+    void commit(){
+        try {
+            pStmtInsertWayNodes.executeBatch();
+            pStmtUpdateData.executeBatch();
+            pStmtInsertWayNodes.clearBatch();
+            pStmtUpdateData.clearBatch();
+            conn.commit();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/mapsforge-poi-writer/src/main/java/org/mapsforge/poi/writer/GeoTagger.java
+++ b/mapsforge-poi-writer/src/main/java/org/mapsforge/poi/writer/GeoTagger.java
@@ -23,6 +23,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -248,7 +249,12 @@ class GeoTagger {
 
     private Map<Poi,Map<String,String>> removeDoublePois(Map<Poi, Map<String, String>> pois) {
         Map<String, Poi> uniqueHighways = new HashMap<>();
-        for (Map.Entry<Poi, Map<String, String>> entry : pois.entrySet()) {
+
+        Iterator it = pois.entrySet().iterator();
+        while (it.hasNext())
+        {
+            Map.Entry<Poi, Map<String, String>> entry = (Map.Entry<Poi, Map<String, String>>) it.next();
+
             Map<String, String> tags = entry.getValue();
             //Only double highways are removed, you can remove second part if you want.
             if(tags.containsKey("name") && tags.containsKey("highway")){
@@ -265,7 +271,7 @@ class GeoTagger {
                     } catch (SQLException e) {
                         e.printStackTrace();
                     }
-                    pois.remove(entry.getKey());
+                    it.remove();
                 } else {
                     uniqueHighways.put(name, entry.getKey());
                 }

--- a/mapsforge-poi-writer/src/main/java/org/mapsforge/poi/writer/GeoTagger.java
+++ b/mapsforge-poi-writer/src/main/java/org/mapsforge/poi/writer/GeoTagger.java
@@ -154,12 +154,14 @@ class GeoTagger {
         for (Relation postalBoundary : postalBoundaries) {
             processBoundary(postalBoundary, true);
         }
+        commit();
 
         for (int i = administrativeBoundaries.size() - 1; i >= 0; i--) {
             List<Relation> administrativeBoundary = administrativeBoundaries.get(i);
             for (Relation relation : administrativeBoundary) {
                 processBoundary(relation, false);
             }
+            commit();
         }
     }
 
@@ -245,6 +247,7 @@ class GeoTagger {
     private void updateTagData(Map<Poi, Map<String, String>> pois,Polygon polygon, String key, String value){
         for (Map.Entry<Poi, Map<String, String>> entry : pois.entrySet()) {
             Poi poi = entry.getKey();
+            String tmpValue = value;
 
             Map<String, String> tagmap = entry.getValue();
             if (tagmap.keySet().contains(key)) {
@@ -255,8 +258,8 @@ class GeoTagger {
                 if(prev.contains(",") || prev.contains(";")){
                     continue;
                 }
-                if(value.contains(",") || value.contains(";")){
-                    value = prev+","+value;
+                if(tmpValue.contains(",") || tmpValue.contains(";")){
+                    tmpValue = (prev + "," + tmpValue);
                 }
             }
 
@@ -270,7 +273,7 @@ class GeoTagger {
             }
 
             //Write surrounding area as parent in "is_in" tag.
-            tagmap.put(key, value);
+            tagmap.put(key, tmpValue);
             batchCountRelation++;
             try {
                 this.pStmtUpdateData.setString(1, writer.tagsToString(tagmap));

--- a/mapsforge-poi-writer/src/main/java/org/mapsforge/poi/writer/GeoTagger.java
+++ b/mapsforge-poi-writer/src/main/java/org/mapsforge/poi/writer/GeoTagger.java
@@ -91,9 +91,7 @@ class GeoTagger {
                     // But it will not get all bound results, some have no tags set and exist only as
                     // relation; it's better to exclude them and
                     // then add possible boundaries to database
-                    if (tag.getValue().equalsIgnoreCase("administrative")) {
-                        storeWay(way);
-                    }
+                    storeWay(way);
                     return;
             }
         }
@@ -378,6 +376,7 @@ class GeoTagger {
             }
             //One path does'not match, so return
             if (bounds.contains(check) && bounds.size() > 1) {
+                LOGGER.finer("Merging failed");
                 return null; //continue if you want to add all calculatated boundary parts.
             }
         }

--- a/mapsforge-poi-writer/src/main/java/org/mapsforge/poi/writer/GeoTagger.java
+++ b/mapsforge-poi-writer/src/main/java/org/mapsforge/poi/writer/GeoTagger.java
@@ -200,6 +200,7 @@ class GeoTagger {
                     case "hamlet":
                     case "isolated_dwelling":
                     case "allotments":
+                    case "suburb":
                         break;
                     default:
                         continue;
@@ -247,7 +248,16 @@ class GeoTagger {
 
             Map<String, String> tagmap = entry.getValue();
             if (tagmap.keySet().contains(key)) {
-                continue;
+                if(!key.equals("is_in")){
+                    continue;
+                }
+                String prev = tagmap.get(key);
+                if(prev.contains(",") || prev.contains(";")){
+                    continue;
+                }
+                if(value.contains(",") || value.contains(";")){
+                    value = prev+","+value;
+                }
             }
 
             if (!tagmap.keySet().contains("name")) {

--- a/mapsforge-poi-writer/src/main/java/org/mapsforge/poi/writer/PoiWriter.java
+++ b/mapsforge-poi-writer/src/main/java/org/mapsforge/poi/writer/PoiWriter.java
@@ -490,6 +490,11 @@ public final class PoiWriter {
             return;
         }
 
+        // The first and the last way node are the same
+        if (!way.isClosed()) {
+            return;
+        }
+
         // Retrieve way nodes
         boolean validWay = true;
         LatLong[] wayNodes = new LatLong[way.getWayNodes().size()];
@@ -520,11 +525,6 @@ public final class PoiWriter {
         // Compute the centroid of the polygon
         Point centroid = polygon.getCentroid();
         if (centroid == null) {
-            return;
-        }
-
-        // The first and the last way node are the same
-        if (!way.isClosed()) {
             return;
         }
 

--- a/mapsforge-poi-writer/src/main/java/org/mapsforge/poi/writer/model/PoiWriterConfiguration.java
+++ b/mapsforge-poi-writer/src/main/java/org/mapsforge/poi/writer/model/PoiWriterConfiguration.java
@@ -35,6 +35,7 @@ public class PoiWriterConfiguration {
     private URL tagMapping;
     private boolean ways;
     private String writerVersion;
+    private boolean autoGeoTags;
 
     /**
      * Convenience method.
@@ -138,6 +139,14 @@ public class PoiWriterConfiguration {
     }
 
     /**
+     * Add additional tags to data, to resolve geolocation
+     * @return boolean, if it's enabled
+     */
+    public boolean isAutoGeoTags() {
+        return autoGeoTags;
+    }
+
+    /**
      * Convenience method.
      *
      * @param file the path to the tag mapping
@@ -230,5 +239,13 @@ public class PoiWriterConfiguration {
      */
     public void setWriterVersion(String writerVersion) {
         this.writerVersion = writerVersion;
+    }
+
+    /**
+     * Sets configuration for autoGeoTags
+     * @param autoGeoTags true: enable geoTags, else false
+     */
+    public void setAutoGeoTags(boolean autoGeoTags) {
+        this.autoGeoTags = autoGeoTags;
     }
 }

--- a/mapsforge-poi-writer/src/main/java/org/mapsforge/poi/writer/osmosis/PoiWriterFactory.java
+++ b/mapsforge-poi-writer/src/main/java/org/mapsforge/poi/writer/osmosis/PoiWriterFactory.java
@@ -39,6 +39,7 @@ public class PoiWriterFactory extends TaskManagerFactory {
     private static final String PARAM_PREFERRED_LANGUAGE = "preferred-language";
     private static final String PARAM_TAG_MAPPING_FILE = "tag-conf-file";
     private static final String PARAM_WAYS = "ways";
+    private static final String PARAM_GEO_TAGS = "geo-tags";
 
     @Override
     protected TaskManager createTaskManagerImpl(TaskConfiguration taskConfig) {
@@ -51,6 +52,7 @@ public class PoiWriterFactory extends TaskManagerFactory {
         configuration.setPreferredLanguage(getStringArgument(taskConfig, PARAM_PREFERRED_LANGUAGE, null));
         configuration.loadTagMappingFile(getStringArgument(taskConfig, PARAM_TAG_MAPPING_FILE, null));
         configuration.setWays(getBooleanArgument(taskConfig, PARAM_WAYS, true));
+        configuration.setAutoGeoTags(getBooleanArgument(taskConfig, PARAM_GEO_TAGS, false));
 
         // If set to true, progress messages will be forwarded to a GUI message handler
         // boolean guiMode = getBooleanArgument(taskConfig, "gui-mode", false);

--- a/mapsforge-poi/src/main/java/org/mapsforge/poi/storage/DbConstants.java
+++ b/mapsforge-poi/src/main/java/org/mapsforge/poi/storage/DbConstants.java
@@ -24,6 +24,9 @@ public final class DbConstants {
     public static final String CREATE_METADATA_STATEMENT = "CREATE TABLE metadata (name TEXT, value TEXT);";
     public static final String CREATE_NODES_STATEMENT = "CREATE TABLE nodes (id INTEGER, lat REAL, lon REAL, PRIMARY KEY (id));";
 
+    public static final String CREATE_WAYS_STATEMENT = "CREATE TABLE ways (id INTEGER, name String, PRIMARY KEY (id));";
+    public static final String CREATE_WAYNODES_STATEMENT = "CREATE TABLE waynodes (way INTEGER not null, node INTEGER not null, position INTEGER, PRIMARY KEY (way, node, position));";
+
     public static final String DELETE_DATA_STATEMENT = "DELETE FROM poi_data WHERE id = ?;";
     public static final String DELETE_INDEX_STATEMENT = "DELETE FROM poi_index WHERE id = ?;";
 
@@ -32,6 +35,8 @@ public final class DbConstants {
     public static final String DROP_INDEX_STATEMENT = "DROP TABLE IF EXISTS poi_index;";
     public static final String DROP_METADATA_STATEMENT = "DROP TABLE IF EXISTS metadata;";
     public static final String DROP_NODES_STATEMENT = "DROP TABLE IF EXISTS nodes;";
+    public static final String DROP_WAYS_STATEMENT = "DROP TABLE IF EXISTS ways;";
+    public static final String DROP_WAYNODES_STATEMENT = "DROP TABLE IF EXISTS waynodes;";
 
     public static final String FIND_BY_DATA_CLAUSE = " AND poi_data.data LIKE ?";
     public static final String FIND_BY_ID_STATEMENT =
@@ -48,15 +53,24 @@ public final class DbConstants {
                     + "minLat <= ? AND "
                     + "minLon <= ? AND "
                     + "minLat >= ? AND "
-                    + "minLon >= ?";
+                    + "minLon >= ?;";
     public static final String FIND_METADATA_STATEMENT = "SELECT name, value FROM metadata;";
     public static final String FIND_NODES_STATEMENT = "SELECT lat, lon FROM nodes WHERE id = ?;";
+    public static final String FIND_WAY_BY_ID_STATEMENT = "SELECT name FROM ways WHERE id = ?;";
+    public static final String FIND_WAY_NODES_BY_WAY_ID_STATEMENT =
+            "SELECT node, position FROM waynodes WHERE way = ?;";
 
     public static final String INSERT_CATEGORIES_STATEMENT = "INSERT INTO poi_categories VALUES (?, ?, ?);";
     public static final String INSERT_DATA_STATEMENT = "INSERT INTO poi_data VALUES (?, ?, ?);";
     public static final String INSERT_INDEX_STATEMENT = "INSERT INTO poi_index VALUES (?, ?, ?, ?, ?);";
     public static final String INSERT_METADATA_STATEMENT = "INSERT INTO metadata VALUES (?, ?);";
     public static final String INSERT_NODES_STATEMENT = "INSERT INTO nodes VALUES (?, ?, ?);";
+    public static final String INSERT_WAYS_STATEMENT = "INSERT INTO ways VALUES (?, ?);";
+    public static final String INSERT_WAYNODES_STATEMENT = "INSERT INTO waynodes VALUES (?, ?, ?);";
+
+    public static final String UPDATE_DATA_STATEMENT = "UPDATE poi_data "
+            + "SET data = ? "
+            + "WHERE id = ?;";
 
     public static final String METADATA_BOUNDS = "bounds";
     public static final String METADATA_COMMENT = "comment";


### PR DESCRIPTION
Added a tool, which automatically tag POIs with `is_in` values (if it doesn't already exists), to link POI with its region.
Usually there's no simple way to get info about location, after conversion to POI-database (no geo-coding info available). This will solve the problem. Administration boundary levels 7 to 10 are considered. Furthers can easily attached, but they will cause much overhead for POIs, which are already tagged by higher levels. Tool is may extendible to address tags.
To turn tool on add `geo-tags=true` in command line.