### PR TITLE
ZoomButton deprecated in Android 8.0 (O) 

### DIFF
--- a/mapsforge-map-android/res/layout/zoom_controls.xml
+++ b/mapsforge-map-android/res/layout/zoom_controls.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+        <!--
+        /*
+        **
+        ** Copyright 2008, The Android Open Source Project
+        **
+        ** Licensed under the Apache License, Version 2.0 (the "License");
+        ** you may not use this file except in compliance with the License.
+        ** You may obtain a copy of the License at
+        **
+        **     http://www.apache.org/licenses/LICENSE-2.0
+        **
+        ** Unless required by applicable law or agreed to in writing, software
+        ** distributed under the License is distributed on an "AS IS" BASIS,
+        ** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        ** See the License for the specific language governing permissions and
+        ** limitations under the License.
+        */
+        -->
+<merge xmlns:android="http://schemas.android.com/apk/res/android">
+    <ZoomButton android:id="@+id/zoomOut"
+                android:background="@android:drawable/btn_plus"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+    />
+    <ZoomButton android:id="@+id/zoomIn"
+                android:background="@android:drawable/btn_minus"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+    />
+</merge>

--- a/mapsforge-map-android/src/main/java/org/mapsforge/map/android/input/MapZoomControls.java
+++ b/mapsforge-map-android/src/main/java/org/mapsforge/map/android/input/MapZoomControls.java
@@ -24,9 +24,7 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewConfiguration;
 import android.view.animation.AlphaAnimation;
-import android.widget.LinearLayout;
-import android.widget.ZoomButton;
-import android.widget.ZoomControls;
+import android.widget.*;
 
 import org.mapsforge.map.android.util.AndroidUtil;
 import org.mapsforge.map.android.view.MapView;
@@ -110,12 +108,13 @@ public class MapZoomControls extends LinearLayout implements Observer {
     private static final long ZOOM_CONTROLS_TIMEOUT = ViewConfiguration.getZoomControlsTimeout();
 
     private boolean autoHide;
-    private final ZoomButton buttonZoomIn, buttonZoomOut;
+    private final ImageButton buttonZoomIn, buttonZoomOut;
     private final MapView mapView;
     private boolean showMapZoomControls;
     private int zoomControlsGravity;
     private final Handler zoomControlsHideHandler;
     private byte zoomLevelMax, zoomLevelMin;
+    private long zoomSpeed;
 
     public MapZoomControls(Context context, MapView mapView) {
         super(context);
@@ -138,8 +137,8 @@ public class MapZoomControls extends LinearLayout implements Observer {
 
         // Hack to get default zoom buttons
         ZoomControls defaultZoomControls = new ZoomControls(context);
-        buttonZoomIn = (ZoomButton) defaultZoomControls.getChildAt(1);
-        buttonZoomOut = (ZoomButton) defaultZoomControls.getChildAt(0);
+        buttonZoomIn = (ImageButton) defaultZoomControls.getChildAt(1);
+        buttonZoomOut = (ImageButton) defaultZoomControls.getChildAt(0);
         defaultZoomControls.removeAllViews();
         setOrientation(defaultZoomControls.getOrientation());
         setZoomInFirst(false);
@@ -148,13 +147,28 @@ public class MapZoomControls extends LinearLayout implements Observer {
         buttonZoomIn.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View view) {
-                MapZoomControls.this.mapView.getModel().mapViewPosition.zoomIn();
+                // Add delay on zoom clicks
+                final Handler handler = new Handler();
+                handler.postDelayed(new Runnable() {
+                    @Override
+                    public void run() {
+                        MapZoomControls.this.mapView.getModel().mapViewPosition.zoomIn();
+                    }
+                }, zoomSpeed);
+
             }
         });
         buttonZoomOut.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View view) {
-                MapZoomControls.this.mapView.getModel().mapViewPosition.zoomOut();
+                // Add delay on zoom clicks
+                final Handler handler = new Handler();
+                handler.postDelayed(new Runnable() {
+                    @Override
+                    public void run() {
+                        MapZoomControls.this.mapView.getModel().mapViewPosition.zoomOut();
+                    }
+                }, zoomSpeed);
             }
         });
 
@@ -376,8 +390,7 @@ public class MapZoomControls extends LinearLayout implements Observer {
      * @param ms delay in ms.
      */
     public void setZoomSpeed(long ms) {
-        buttonZoomIn.setZoomSpeed(ms);
-        buttonZoomOut.setZoomSpeed(ms);
+        this.zoomSpeed = ms;
     }
 
     public void show() {

--- a/mapsforge-map-android/src/main/java/org/mapsforge/map/android/input/MapZoomControls.java
+++ b/mapsforge-map-android/src/main/java/org/mapsforge/map/android/input/MapZoomControls.java
@@ -108,13 +108,12 @@ public class MapZoomControls extends LinearLayout implements Observer {
     private static final long ZOOM_CONTROLS_TIMEOUT = ViewConfiguration.getZoomControlsTimeout();
 
     private boolean autoHide;
-    private final ImageButton buttonZoomIn, buttonZoomOut;
+    private final ZoomButton buttonZoomIn, buttonZoomOut;
     private final MapView mapView;
     private boolean showMapZoomControls;
     private int zoomControlsGravity;
     private final Handler zoomControlsHideHandler;
     private byte zoomLevelMax, zoomLevelMin;
-    private long zoomSpeed;
 
     public MapZoomControls(Context context, MapView mapView) {
         super(context);
@@ -137,8 +136,9 @@ public class MapZoomControls extends LinearLayout implements Observer {
 
         // Hack to get default zoom buttons
         ZoomControls defaultZoomControls = new ZoomControls(context);
-        buttonZoomIn = (ImageButton) defaultZoomControls.getChildAt(1);
-        buttonZoomOut = (ImageButton) defaultZoomControls.getChildAt(0);
+
+        buttonZoomIn = new ZoomButton(getContext());
+        buttonZoomOut = new ZoomButton(getContext());
         defaultZoomControls.removeAllViews();
         setOrientation(defaultZoomControls.getOrientation());
         setZoomInFirst(false);
@@ -147,28 +147,13 @@ public class MapZoomControls extends LinearLayout implements Observer {
         buttonZoomIn.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View view) {
-                // Add delay on zoom clicks
-                final Handler handler = new Handler();
-                handler.postDelayed(new Runnable() {
-                    @Override
-                    public void run() {
-                        MapZoomControls.this.mapView.getModel().mapViewPosition.zoomIn();
-                    }
-                }, zoomSpeed);
-
+                MapZoomControls.this.mapView.getModel().mapViewPosition.zoomIn();
             }
         });
         buttonZoomOut.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View view) {
-                // Add delay on zoom clicks
-                final Handler handler = new Handler();
-                handler.postDelayed(new Runnable() {
-                    @Override
-                    public void run() {
-                        MapZoomControls.this.mapView.getModel().mapViewPosition.zoomOut();
-                    }
-                }, zoomSpeed);
+                MapZoomControls.this.mapView.getModel().mapViewPosition.zoomOut();
             }
         });
 
@@ -390,7 +375,8 @@ public class MapZoomControls extends LinearLayout implements Observer {
      * @param ms delay in ms.
      */
     public void setZoomSpeed(long ms) {
-        this.zoomSpeed = ms;
+        buttonZoomIn.setZoomSpeed(ms);
+        buttonZoomOut.setZoomSpeed(ms);
     }
 
     public void show() {

--- a/mapsforge-map-android/src/main/java/org/mapsforge/map/android/input/ZoomButton.java
+++ b/mapsforge-map-android/src/main/java/org/mapsforge/map/android/input/ZoomButton.java
@@ -1,0 +1,105 @@
+package org.mapsforge.map.android.input;
+
+/*
+ * Copyright (C) 2008 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.KeyEvent;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.View.OnLongClickListener;
+import android.widget.ImageButton;
+
+public class ZoomButton extends ImageButton implements OnLongClickListener {
+    private final Runnable mRunnable = new Runnable() {
+        public void run() {
+            if (hasOnClickListeners() && mIsInLongpress && isEnabled()) {
+                callOnClick();
+                postDelayed(this, mZoomSpeed);
+            }
+        }
+    };
+
+    private long mZoomSpeed = 1000;
+    private boolean mIsInLongpress;
+
+    public ZoomButton(Context context) {
+        this(context, null);
+    }
+
+    public ZoomButton(Context context, AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public ZoomButton(Context context, AttributeSet attrs, int defStyleAttr) {
+        this(context, attrs, defStyleAttr, 0);
+    }
+
+    public ZoomButton(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+        setOnLongClickListener(this);
+    }
+
+    @Override
+    public boolean onTouchEvent(MotionEvent event) {
+        if ((event.getAction() == MotionEvent.ACTION_CANCEL)
+                || (event.getAction() == MotionEvent.ACTION_UP)) {
+            mIsInLongpress = false;
+        }
+        return super.onTouchEvent(event);
+    }
+
+    public void setZoomSpeed(long speed) {
+        mZoomSpeed = speed;
+    }
+
+    public boolean onLongClick(View v) {
+        mIsInLongpress = true;
+        post(mRunnable);
+        return true;
+    }
+
+    @Override
+    public boolean onKeyUp(int keyCode, KeyEvent event) {
+        mIsInLongpress = false;
+        return super.onKeyUp(keyCode, event);
+    }
+
+    @Override
+    public void setEnabled(boolean enabled) {
+        if (!enabled) {
+
+            /* If we're being disabled reset the state back to unpressed
+             * as disabled views don't get events and therefore we won't
+             * get the up event to reset the state.
+             */
+            setPressed(false);
+        }
+        super.setEnabled(enabled);
+    }
+
+    @Override
+    public boolean dispatchUnhandledMove(View focused, int direction) {
+        clearFocus();
+        return super.dispatchUnhandledMove(focused, direction);
+    }
+
+    @Override
+    public CharSequence getAccessibilityClassName() {
+        return ZoomButton.class.getName();
+    }
+}

--- a/mapsforge-map-android/src/main/java/org/mapsforge/map/android/input/ZoomControls.java
+++ b/mapsforge-map-android/src/main/java/org/mapsforge/map/android/input/ZoomControls.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2008 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mapsforge.map.android.input;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.LayoutInflater;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.animation.AlphaAnimation;
+import android.widget.LinearLayout;
+
+
+/**
+ * The {@code ZoomControls} class displays a simple set of controls used for zooming and
+ * provides callbacks to register for events. */
+public class ZoomControls extends LinearLayout {
+    private final ZoomButton mZoomIn;
+    private final ZoomButton mZoomOut;
+
+    public ZoomControls(Context context) {
+        this(context, null);
+    }
+    public ZoomControls(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        setFocusable(false);
+
+        LayoutInflater inflater = (LayoutInflater) context
+                .getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+        inflater.inflate(getResources().getIdentifier("zoom_controls", "layout", getContext().getPackageName()), this, // we are the parent
+                true);
+
+        mZoomIn = (ZoomButton) findViewById(getResources().getIdentifier("zoom_controls", "zoomIn", getContext().getPackageName()));
+        mZoomOut = (ZoomButton) findViewById(getResources().getIdentifier("zoom_controls", "zoomOut", getContext().getPackageName()));
+    }
+    public void setOnZoomInClickListener(OnClickListener listener) {
+        mZoomIn.setOnClickListener(listener);
+    }
+
+    public void setOnZoomOutClickListener(OnClickListener listener) {
+        mZoomOut.setOnClickListener(listener);
+    }
+
+    /*
+     * Sets how fast you get zoom events when the user holds down the
+     * zoom in/out buttons.
+     */
+    public void setZoomSpeed(long speed) {
+        mZoomIn.setZoomSpeed(speed);
+        mZoomOut.setZoomSpeed(speed);
+    }
+
+    @Override
+    public boolean onTouchEvent(MotionEvent event) {
+        
+        /* Consume all touch events so they don't get dispatched to the view
+         * beneath this view.
+         */
+        return true;
+    }
+
+    public void show() {
+        fade(View.VISIBLE, 0.0f, 1.0f);
+    }
+
+    public void hide() {
+        fade(View.GONE, 1.0f, 0.0f);
+    }
+
+    private void fade(int visibility, float startAlpha, float endAlpha) {
+        AlphaAnimation anim = new AlphaAnimation(startAlpha, endAlpha);
+        anim.setDuration(500);
+        startAnimation(anim);
+        setVisibility(visibility);
+    }
+
+    public void setIsZoomInEnabled(boolean isEnabled) {
+        mZoomIn.setEnabled(isEnabled);
+    }
+
+    public void setIsZoomOutEnabled(boolean isEnabled) {
+        mZoomOut.setEnabled(isEnabled);
+    }
+
+    @Override
+    public boolean hasFocus() {
+        return mZoomIn.hasFocus() || mZoomOut.hasFocus();
+    }
+    @Override
+    public CharSequence getAccessibilityClassName() {
+        return ZoomControls.class.getName();
+    }
+}


### PR DESCRIPTION
Issue [#964](https://github.com/mapsforge/mapsforge/issues/964) changed to handle functionality without ZoomButton - delay realised using Handler postDelayed within the onClick method. 