### PR TITLE
Fix and improve FrameBufferHA2

### DIFF
--- a/mapsforge-map/src/main/java/org/mapsforge/map/controller/FrameBufferController.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/controller/FrameBufferController.java
@@ -32,7 +32,7 @@ public final class FrameBufferController implements Observer {
     /**
      * If true the {@link FrameBufferHA2} will be used instead of default {@link FrameBufferHA}.
      */
-    public static boolean FRAME_BUFFER_HA2 = false;
+    public static boolean FRAME_BUFFER_HA2 = true;
 
     private static float maxAspectRatio = 2;
 

--- a/mapsforge-map/src/main/java/org/mapsforge/map/controller/FrameBufferController.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/controller/FrameBufferController.java
@@ -32,7 +32,7 @@ public final class FrameBufferController implements Observer {
     /**
      * If true the {@link FrameBufferHA2} will be used instead of default {@link FrameBufferHA}.
      */
-    public static boolean FRAME_BUFFER_HA2 = true;
+    public static boolean FRAME_BUFFER_HA2 = false;
 
     private static float maxAspectRatio = 2;
 

--- a/mapsforge-map/src/main/java/org/mapsforge/map/view/FrameBufferBitmap.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/view/FrameBufferBitmap.java
@@ -21,88 +21,16 @@ import org.mapsforge.core.model.Dimension;
 import java.util.logging.Logger;
 
 public class FrameBufferBitmap {
-
-    private static class BitmapRequest {
-        private final GraphicFactory factory;
-        private final Dimension dimension;
-        private final boolean transparent;
-
-        public BitmapRequest(GraphicFactory factory, Dimension dimension, boolean transparent) {
-            this.factory = factory;
-            this.dimension = dimension;
-            this.transparent = transparent;
-        }
-
-        public Bitmap create() {
-            if (dimension.width > 0 && dimension.height > 0)
-                return factory.createBitmap(dimension.width, dimension.height, transparent);
-            return null;
-        }
-    }
-
-    private static class Lock {
-        private boolean enabled = false;
-
-        public synchronized void disable() {
-            enabled = false;
-            notifyAll();
-        }
-
-        public synchronized void enable() {
-            enabled = true;
-        }
-
-        public boolean isEnabled() {
-            return enabled;
-        }
-
-        public synchronized void waitDisabled() {
-            try {
-                while (enabled) {
-                    wait();
-                }
-            } catch (InterruptedException e) {
-                LOGGER.warning("FrameBufferHA interrupted");
-            }
-        }
-    }
-
     private static final Logger LOGGER = Logger.getLogger(FrameBufferBitmap.class.getName());
 
-    private final Lock allowSwap = new Lock();
     private final Lock frameLock = new Lock();
 
     private Bitmap bitmap = null;
+
     private BitmapRequest bitmapRequest = null;
+    private final Object bitmapRequestSync = new Object();
 
-    public void create(GraphicFactory factory, Dimension dimension, boolean transparent) {
-        bitmapRequest = new BitmapRequest(factory, dimension, transparent);
-    }
 
-    private void createBitmapIfRequested() {
-        if (bitmapRequest != null) {
-            destroyBitmap();
-            bitmap = bitmapRequest.create();
-            bitmapRequest = null;
-        }
-    }
-
-    public void destroy() {
-        synchronized (frameLock) {
-            if (bitmap != null) {
-                frameLock.waitDisabled();
-                destroyBitmap();
-            }
-        }
-        allowSwap.disable();
-    }
-
-    private void destroyBitmap() {
-        if (bitmap != null) {
-            bitmap.decrementRefCount();
-            bitmap = null;
-        }
-    }
 
     public Bitmap lock() {
         synchronized (frameLock) {
@@ -115,30 +43,119 @@ public class FrameBufferBitmap {
         }
     }
 
-    public Bitmap lockWhenSwapped() {
-        allowSwap.waitDisabled();
-        return lock();
-    }
+    private void createBitmapIfRequested() {
+        synchronized(bitmapRequestSync) {
+            if (bitmapRequest != null) {
 
-    public void releaseAndAllowSwap() {
-        frameLock.disable();
-        synchronized (frameLock) {
-            if (bitmap != null)
-                allowSwap.enable();
+                destroyBitmap();
+                bitmap = bitmapRequest.create();
+
+                bitmapRequest = null;
+            }
         }
     }
 
-    public static boolean swap(FrameBufferBitmap a, FrameBufferBitmap b) {
-        if (a.allowSwap.isEnabled() && b.allowSwap.isEnabled()) {
-            Bitmap t = a.bitmap;
-            a.bitmap = b.bitmap;
-            b.bitmap = t;
 
-            a.allowSwap.disable();
-            b.allowSwap.disable();
-            return true;
-
+    public void release() {
+        synchronized(frameLock) {
+            frameLock.disable();
         }
-        return false;
+    }
+
+
+    public void create(GraphicFactory factory, Dimension dimension, int color, boolean isTransparent) {
+        synchronized(bitmapRequestSync) {
+            bitmapRequest = new BitmapRequest(factory, dimension, color, isTransparent);
+        }
+    }
+
+
+    public void destroy()  {
+        synchronized(frameLock) {
+            if (bitmap != null) {
+                frameLock.waitDisabled();
+                destroyBitmap();
+            }
+        }
+
+    }
+
+
+    private void destroyBitmap() {
+        if (bitmap != null) {
+            bitmap.decrementRefCount();
+            bitmap = null;
+        }
+    }
+
+
+    public static void swap(FrameBufferBitmap a, FrameBufferBitmap b) {
+        Bitmap t = a.bitmap;
+        a.bitmap = b.bitmap;
+        b.bitmap = t;
+
+        BitmapRequest r = a.bitmapRequest;
+        a.bitmapRequest = b.bitmapRequest;
+        b.bitmapRequest = r;
+    }
+
+
+    public static class Lock {
+        private boolean enabled = false;
+
+
+        public synchronized void disable() {
+            enabled = false;
+            notifyAll();
+        }
+
+        public synchronized void enable() {
+            enabled = true;
+        }
+
+
+
+        public synchronized void waitDisabled() {
+            try {
+                while (enabled) {
+                    wait();
+                }
+            } catch (InterruptedException e) {
+                LOGGER.warning("FrameBufferHA interrupted");
+            }
+        }
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+    }
+
+
+    private static class BitmapRequest {
+        private final GraphicFactory factory;
+        private final Dimension dimension;
+        private final boolean transparent;
+        private final int color;
+
+
+        public BitmapRequest(GraphicFactory f, Dimension d, int c, boolean t) {
+            factory = f;
+            dimension = d;
+            transparent = t;
+            color = c;
+        }
+
+        public Bitmap create() {
+            if (dimension.width > 0 && dimension.height > 0) {
+                Bitmap b = factory.createBitmap(
+                        dimension.width,
+                        dimension.height,
+                        transparent);
+
+                b.setBackgroundColor(color);
+                return b;
+            }
+            return null;
+        }
     }
 }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/view/FrameBufferHA2.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/view/FrameBufferHA2.java
@@ -20,7 +20,6 @@ package org.mapsforge.map.view;
 import org.mapsforge.core.graphics.Bitmap;
 import org.mapsforge.core.graphics.GraphicContext;
 import org.mapsforge.core.graphics.GraphicFactory;
-import org.mapsforge.core.graphics.Matrix;
 import org.mapsforge.core.model.Dimension;
 import org.mapsforge.core.model.MapPosition;
 import org.mapsforge.core.model.Point;
@@ -44,23 +43,10 @@ public class FrameBufferHA2 extends FrameBuffer {
 
     private final FrameBufferBitmap.Lock allowSwap = new FrameBufferBitmap.Lock();
 
-    private Dimension dimension;
-    private final Matrix matrix;
-
-    private final DisplayModel displayModel;
-    private final FrameBufferModel frameBufferModel;
-    private final GraphicFactory graphicFactory;
-
 
     public FrameBufferHA2(FrameBufferModel frameBufferModel, DisplayModel displayModel,
                            GraphicFactory graphicFactory) {
         super(frameBufferModel, displayModel, graphicFactory);
-
-        this.frameBufferModel = frameBufferModel;
-        this.displayModel = displayModel;
-
-        this.graphicFactory = graphicFactory;
-        this.matrix = graphicFactory.createMatrix();
 
         this.allowSwap.disable();
     }


### PR DESCRIPTION
Let's give it another try!

Changes:
- Swap not only bitmaps but also bitmap requests (fixes #977)
- Move <code>allowSwap</code> from <code>FrameBufferBitmap</code> to <code>FrameBufferHA2</code>
- Reset background of newly created bitmap to background color. This fixes an issue where Android map view did display a recycled bitmap. 
