### PR TITLE
Refactored MapFile to use and accept FileChannels (#982)

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2,6 +2,7 @@
 
 ## New since 0.8.0
 
+- MapFile supports FileChannel as input [#982](https://github.com/mapsforge/mapsforge/issues/982)
 - Map frame buffer improvements [#977](https://github.com/mapsforge/mapsforge/issues/977)
 - XmlPullParser different implementations [#974](https://github.com/mapsforge/mapsforge/issues/974)
 - Desktop: fix blurred map view [#978](https://github.com/mapsforge/mapsforge/issues/978)


### PR DESCRIPTION
The modified MapFile uses a FileChannel instead of a RandomAccessFile. External API stays the same except for the addition of a new constructor that accepts a FileChannel. 