### PR TITLE
POI: Allow multiple patterns in filtered search

### DIFF
--- a/docs/POI.md
+++ b/docs/POI.md
@@ -79,9 +79,12 @@ Please consult the XML-Schema documentation of https://github.com/mapsforge/maps
 
 ### Filtered Search
 
-The API supports POI search inside a specified rectangle, near a given position or by a data pattern.
+The API supports POI search inside a specified rectangle, near a given position or by a tag-data pattern.
 You can also use category filters for filtering the results based on the categories added to them.
-And lastly you can search by OSM tags, e.g. persistenceManager.findInRect(bbox, categoryFilter, "%name=Pergamonmuseum%", 1)
+And lastly you can search by OSM tags. With '*' you can search through all tags, 
+e.g. `Tag tag1 = new Tag("*", Pergamonmuseum);` 
+Then you add them to a list `tagList.add(new Tag("addr:street", "Bodestraße"))` and call
+`persistenceManager.findInRect(bbox, categoryFilter, tagList, 1)`
 
 ### POI DB Schema
 

--- a/mapsforge-poi-android/src/main/java/org/mapsforge/poi/android/storage/AndroidPoiPersistenceManager.java
+++ b/mapsforge-poi-android/src/main/java/org/mapsforge/poi/android/storage/AndroidPoiPersistenceManager.java
@@ -17,6 +17,7 @@
 package org.mapsforge.poi.android.storage;
 
 import org.mapsforge.core.model.BoundingBox;
+import org.mapsforge.core.model.Tag;
 import org.mapsforge.poi.storage.AbstractPoiPersistenceManager;
 import org.mapsforge.poi.storage.DbConstants;
 import org.mapsforge.poi.storage.PoiCategoryFilter;
@@ -27,6 +28,7 @@ import org.mapsforge.poi.storage.PointOfInterest;
 import org.mapsforge.poi.storage.UnknownPoiCategoryException;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -204,13 +206,14 @@ class AndroidPoiPersistenceManager extends AbstractPoiPersistenceManager {
      */
     @Override
     public Collection<PointOfInterest> findInRect(BoundingBox bb, PoiCategoryFilter filter,
-                                                  String pattern, int limit) {
+                                                  List<Tag> patterns, int limit) {
         // Clear previous results
         this.ret.clear();
 
         // Query
         try {
-            Stmt stmt = this.db.prepare(AbstractPoiPersistenceManager.getSQLSelectString(filter, pattern));
+            int pSize = patterns == null ? 0 : patterns.size();
+            Stmt stmt = this.db.prepare(AbstractPoiPersistenceManager.getSQLSelectString(filter, pSize));
 
             stmt.reset();
             stmt.clear_bindings();
@@ -219,10 +222,18 @@ class AndroidPoiPersistenceManager extends AbstractPoiPersistenceManager {
             stmt.bind(2, bb.maxLongitude);
             stmt.bind(3, bb.minLatitude);
             stmt.bind(4, bb.minLongitude);
-            if (pattern != null) {
-                stmt.bind(5, pattern);
+
+            int i = 0; //i is only counted if pattern is not null
+            if (pSize > 0) {
+                for (Tag tag : patterns) {
+                    if (tag == null) continue;
+                    stmt.bind(5 + i, "%"
+                            + (tag.key.equals("*") ? "" : (tag.key + "="))
+                            + tag.value + "%");
+                    i++;
+                }
             }
-            stmt.bind(pattern != null ? 6 : 5, limit);
+            stmt.bind(5 + i, limit);
 
             while (stmt.step()) {
                 long id = stmt.column_long(0);

--- a/mapsforge-poi-awt/src/main/java/org/mapsforge/poi/awt/storage/AwtPoiPersistenceManager.java
+++ b/mapsforge-poi-awt/src/main/java/org/mapsforge/poi/awt/storage/AwtPoiPersistenceManager.java
@@ -15,6 +15,7 @@
 package org.mapsforge.poi.awt.storage;
 
 import org.mapsforge.core.model.BoundingBox;
+import org.mapsforge.core.model.Tag;
 import org.mapsforge.poi.storage.AbstractPoiPersistenceManager;
 import org.mapsforge.poi.storage.DbConstants;
 import org.mapsforge.poi.storage.PoiCategoryFilter;
@@ -32,6 +33,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Collection;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -212,13 +214,14 @@ class AwtPoiPersistenceManager extends AbstractPoiPersistenceManager {
      */
     @Override
     public Collection<PointOfInterest> findInRect(BoundingBox bb, PoiCategoryFilter filter,
-                                                  String pattern, int limit) {
+                                                  List<Tag> patterns, int limit) {
         // Clear previous results
         this.ret.clear();
 
         // Query
         try {
-            PreparedStatement stmt = this.conn.prepareStatement(AbstractPoiPersistenceManager.getSQLSelectString(filter, pattern));
+            int pSize = patterns == null ? 0 : patterns.size();
+            PreparedStatement stmt = this.conn.prepareStatement(AbstractPoiPersistenceManager.getSQLSelectString(filter, pSize));
 
             stmt.clearParameters();
 
@@ -226,10 +229,18 @@ class AwtPoiPersistenceManager extends AbstractPoiPersistenceManager {
             stmt.setDouble(2, bb.maxLongitude);
             stmt.setDouble(3, bb.minLatitude);
             stmt.setDouble(4, bb.minLongitude);
-            if (pattern != null) {
-                stmt.setString(5, pattern);
+
+            int i = 0; //i is only counted, if pattern is not null
+            if (pSize > 0) {
+                for (Tag tag : patterns) {
+                    if (tag == null) continue;
+                    stmt.setString(5 + i, "%"
+                            + (tag.key.equals("*") ? "" : (tag.key + "="))
+                            + tag.value + "%");
+                    i++;
+                }
             }
-            stmt.setInt(pattern != null ? 6 : 5, limit);
+            stmt.setInt(5 + i, limit);
 
             ResultSet rs = stmt.executeQuery();
             while (rs.next()) {

--- a/mapsforge-poi/src/main/java/org/mapsforge/poi/storage/AbstractPoiPersistenceManager.java
+++ b/mapsforge-poi/src/main/java/org/mapsforge/poi/storage/AbstractPoiPersistenceManager.java
@@ -16,6 +16,7 @@ package org.mapsforge.poi.storage;
 
 import org.mapsforge.core.model.BoundingBox;
 import org.mapsforge.core.model.LatLong;
+import org.mapsforge.core.model.Tag;
 import org.mapsforge.core.util.LatLongUtils;
 
 import java.util.ArrayList;
@@ -43,14 +44,14 @@ public abstract class AbstractPoiPersistenceManager implements PoiPersistenceMan
      */
     @Override
     public Collection<PointOfInterest> findNearPosition(LatLong point, int distance,
-                                                        PoiCategoryFilter filter, String pattern,
+                                                        PoiCategoryFilter filter, List<Tag> patterns,
                                                         int limit) {
         double minLat = point.latitude - LatLongUtils.latitudeDistance(distance);
         double minLon = point.longitude - LatLongUtils.longitudeDistance(distance, point.latitude);
         double maxLat = point.latitude + LatLongUtils.latitudeDistance(distance);
         double maxLon = point.longitude + LatLongUtils.longitudeDistance(distance, point.latitude);
 
-        return findInRect(new BoundingBox(minLat, minLon, maxLat, maxLon), filter, pattern, limit);
+        return findInRect(new BoundingBox(minLat, minLon, maxLat, maxLon), filter, patterns, limit);
     }
 
     /**
@@ -72,15 +73,19 @@ public abstract class AbstractPoiPersistenceManager implements PoiPersistenceMan
     /**
      * Gets the SQL query that looks up POI entries.
      *
-     * @param filter  The filter object for determining all wanted categories (may be null).
-     * @param pattern the pattern to search in points of interest data (may be null).
+     * @param filter The filter object for determining all wanted categories (may be null).
+     * @param count  Count of patterns to search in points of interest data (may be 0).
      * @return The SQL query.
      */
-    protected static String getSQLSelectString(PoiCategoryFilter filter, String pattern) {
+    protected static String getSQLSelectString(PoiCategoryFilter filter, int count) {
         if (filter != null) {
-            return PoiCategoryRangeQueryGenerator.getSQLSelectString(filter, pattern);
+            return PoiCategoryRangeQueryGenerator.getSQLSelectString(filter, count);
         }
-        return DbConstants.FIND_IN_BOX_STATEMENT + (pattern != null ? DbConstants.FIND_BY_DATA_CLAUSE : "") + " LIMIT ?;";
+        String query = DbConstants.FIND_IN_BOX_STATEMENT;
+        for (int i = 0; i < count; i++) {
+            query += (DbConstants.FIND_BY_DATA_CLAUSE);
+        }
+        return query + " LIMIT ?;";
     }
 
     /**

--- a/mapsforge-poi/src/main/java/org/mapsforge/poi/storage/PoiCategoryRangeQueryGenerator.java
+++ b/mapsforge-poi/src/main/java/org/mapsforge/poi/storage/PoiCategoryRangeQueryGenerator.java
@@ -31,14 +31,16 @@ public final class PoiCategoryRangeQueryGenerator {
     /**
      * Gets the SQL query that looks up POI entries.
      *
-     * @param filter  The filter object for determining all wanted categories.
-     * @param pattern the pattern to search in points of interest names (may be null).
+     * @param filter The filter object for determining all wanted categories.
+     * @param count  Count of patterns to search in points of interest names (may be 0).
      * @return The SQL query.
      */
-    public static String getSQLSelectString(PoiCategoryFilter filter, String pattern) {
-        return DbConstants.FIND_IN_BOX_STATEMENT + getSQLWhereClauseString(filter)
-                + (pattern != null ? DbConstants.FIND_BY_DATA_CLAUSE : "")
-                + " LIMIT ?;";
+    public static String getSQLSelectString(PoiCategoryFilter filter, int count) {
+        String query = DbConstants.FIND_IN_BOX_STATEMENT + getSQLWhereClauseString(filter);
+        for (int i = 0; i < count; i++) {
+            query += DbConstants.FIND_BY_DATA_CLAUSE;
+        }
+        return (query + " LIMIT ?;");
     }
 
     /**

--- a/mapsforge-poi/src/main/java/org/mapsforge/poi/storage/PoiPersistenceManager.java
+++ b/mapsforge-poi/src/main/java/org/mapsforge/poi/storage/PoiPersistenceManager.java
@@ -19,8 +19,10 @@ package org.mapsforge.poi.storage;
 
 import org.mapsforge.core.model.BoundingBox;
 import org.mapsforge.core.model.LatLong;
+import org.mapsforge.core.model.Tag;
 
 import java.util.Collection;
+import java.util.List;
 
 /**
  * Abstracts from an underlying Storage/DB by providing methods for inserting / deleting / searching
@@ -44,13 +46,13 @@ public interface PoiPersistenceManager {
      * @param bb      {@link BoundingBox} specifying the rectangle.
      * @param filter  POI category filter object that helps determining whether a POI should be added to
      *                the set or not (may be null).
-     * @param pattern the pattern to search in points of interest data (may be null).
+     * @param patterns the patterns to search in points of interest data (may be null).
      * @param limit   max number of {@link PointOfInterest} to be returned.
      * @return {@link Collection} of {@link PointOfInterest} matching a given
      * {@link PoiCategoryFilter} and data pattern contained in the rectangle specified by
      * the given {@link BoundingBox}.
      */
-    Collection<PointOfInterest> findInRect(BoundingBox bb, PoiCategoryFilter filter, String pattern,
+    Collection<PointOfInterest> findInRect(BoundingBox bb, PoiCategoryFilter filter, List<Tag> patterns,
                                            int limit);
 
     /**
@@ -62,13 +64,13 @@ public interface PoiPersistenceManager {
      * @param distance in meters
      * @param filter   POI category filter object that helps determining whether a POI should be added to
      *                 the set or not (may be null).
-     * @param pattern  the pattern to search in points of interest data (may be null).
+     * @param patterns  the patterns to search in points of interest data (may be null).
      * @param limit    max number of {@link PointOfInterest} to be returned.
      * @return {@link Collection} of {@link PointOfInterest} matching a given
      * {@link PoiCategoryFilter} and data pattern near the given position.
      */
     Collection<PointOfInterest> findNearPosition(LatLong point, int distance,
-                                                 PoiCategoryFilter filter, String pattern,
+                                                 PoiCategoryFilter filter, List<Tag> patterns,
                                                  int limit);
 
     /**

--- a/mapsforge-poi/src/test/java/org/mapsforge/poi/storage/PoiCategoryRangeQueryGeneratorTest.java
+++ b/mapsforge-poi/src/test/java/org/mapsforge/poi/storage/PoiCategoryRangeQueryGeneratorTest.java
@@ -48,7 +48,7 @@ public class PoiCategoryRangeQueryGeneratorTest {
         PoiCategoryFilter filter = new WhitelistPoiCategoryFilter();
         filter.addCategory(this.flatRoot);
 
-        String query = PoiCategoryRangeQueryGenerator.getSQLSelectString(filter, null);
+        String query = PoiCategoryRangeQueryGenerator.getSQLSelectString(filter, 0);
 
         System.out.println("Query: " + query);
 
@@ -66,7 +66,7 @@ public class PoiCategoryRangeQueryGeneratorTest {
         filter.addCategory(this.balancedCm.getPoiCategoryByTitle("l1_1"));
         filter.addCategory(this.balancedCm.getPoiCategoryByTitle("l1_2"));
 
-        String query = PoiCategoryRangeQueryGenerator.getSQLSelectString(filter, null);
+        String query = PoiCategoryRangeQueryGenerator.getSQLSelectString(filter, 0);
         System.out.println("Query: " + query);
 
         // TODO add assertions


### PR DESCRIPTION
Refers to PullRequest #953
+ adapt interfaces
+ uses Tag instead of String Data to make it independent of database formats
+ browse all tags with "*"
+ adjust Poi-guidance poi.md