### PR TITLE
POI: insert method isClosed:boolean into PoiPersistenceManager

### DIFF
--- a/mapsforge-poi/src/main/java/org/mapsforge/poi/storage/PoiPersistenceManager.java
+++ b/mapsforge-poi/src/main/java/org/mapsforge/poi/storage/PoiPersistenceManager.java
@@ -40,6 +40,11 @@ public interface PoiPersistenceManager {
     void close();
 
     /**
+     * @return true if the manager is already closed.
+     */
+    boolean isClosed();
+
+    /**
      * Find all {@link PointOfInterest} in a rectangle specified by the given {@link BoundingBox}.
      * Only the POIs that are allowed by the {@link PoiCategoryFilter} object and matching the data
      * pattern will be returned.


### PR DESCRIPTION
Check if PoiPersistenceManager is already closed
Improvements:
- Close Statements after sql(ite)-Exception
- Close ResultSets after SQL-Exception
- Check if closed, before closing it twice (android/awt)
- added synchronized to close() to avoid overall access on statements while closing