### PR TITLE
POI: m to n relationship among Categories and POIs

### DIFF
--- a/mapsforge-poi-android/src/main/java/org/mapsforge/poi/android/storage/AndroidPoiPersistenceManager.java
+++ b/mapsforge-poi-android/src/main/java/org/mapsforge/poi/android/storage/AndroidPoiPersistenceManager.java
@@ -18,18 +18,21 @@
 package org.mapsforge.poi.android.storage;
 
 import org.mapsforge.core.model.BoundingBox;
+import org.mapsforge.core.model.LatLong;
 import org.mapsforge.core.model.Tag;
 import org.mapsforge.poi.storage.AbstractPoiPersistenceManager;
 import org.mapsforge.poi.storage.DbConstants;
+import org.mapsforge.poi.storage.PoiCategory;
 import org.mapsforge.poi.storage.PoiCategoryFilter;
 import org.mapsforge.poi.storage.PoiFileInfo;
 import org.mapsforge.poi.storage.PoiFileInfoBuilder;
 import org.mapsforge.poi.storage.PoiPersistenceManager;
 import org.mapsforge.poi.storage.PointOfInterest;
-import org.mapsforge.poi.storage.UnknownPoiCategoryException;
 
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -47,11 +50,15 @@ class AndroidPoiPersistenceManager extends AbstractPoiPersistenceManager {
 
     private Database db = null;
 
-    private Stmt findByIDStatement = null;
-    private Stmt insertPoiStatement1 = null;
-    private Stmt insertPoiStatement2 = null;
-    private Stmt deletePoiStatement1 = null;
-    private Stmt deletePoiStatement2 = null;
+    private Stmt findCatByIDStatement = null;
+    private Stmt findDataByIDStatement = null;
+    private Stmt findLocByIDStatement = null;
+    private Stmt insertPoiStatementLoc = null;
+    private Stmt insertPoiStatementCat = null;
+    private Stmt insertPoiStatementData = null;
+    private Stmt deletePoiStatementLoc = null;
+    private Stmt deletePoiStatementCat = null;
+    private Stmt deletePoiStatementData = null;
     private Stmt isValidDBStatement = null;
     private Stmt metadataStatement = null;
 
@@ -70,16 +77,22 @@ class AndroidPoiPersistenceManager extends AbstractPoiPersistenceManager {
 
         // Queries
         try {
-            // Finds a POI by its unique ID
-            this.findByIDStatement = this.db.prepare(DbConstants.FIND_BY_ID_STATEMENT);
+            // Finds a POI-Location by its unique ID
+            this.findLocByIDStatement = this.db.prepare(DbConstants.FIND_LOCATION_BY_ID_STATEMENT);
+            // Finds a POI-Data by its unique ID
+            this.findCatByIDStatement = this.db.prepare(DbConstants.FIND_CATEGORIES_BY_ID_STATEMENT);
+            // Finds a POI-Categories by its unique ID
+            this.findDataByIDStatement = this.db.prepare(DbConstants.FIND_DATA_BY_ID_STATEMENT);
 
             // Inserts a POI into index and adds its data
-            this.insertPoiStatement1 = this.db.prepare(DbConstants.INSERT_INDEX_STATEMENT);
-            this.insertPoiStatement2 = this.db.prepare(DbConstants.INSERT_DATA_STATEMENT);
+            this.insertPoiStatementLoc = this.db.prepare(DbConstants.INSERT_INDEX_STATEMENT);
+            this.insertPoiStatementData = this.db.prepare(DbConstants.INSERT_DATA_STATEMENT);
+            this.insertPoiStatementCat = this.db.prepare(DbConstants.INSERT_CATEGORYMAP_STATEMENT);
 
             // Deletes a POI given by its ID
-            this.deletePoiStatement1 = this.db.prepare(DbConstants.DELETE_INDEX_STATEMENT);
-            this.deletePoiStatement2 = this.db.prepare(DbConstants.DELETE_DATA_STATEMENT);
+            this.deletePoiStatementLoc = this.db.prepare(DbConstants.DELETE_INDEX_STATEMENT);
+            this.deletePoiStatementData = this.db.prepare(DbConstants.DELETE_DATA_STATEMENT);
+            this.deletePoiStatementCat = this.db.prepare(DbConstants.DELETE_CATEGORYMAP_STATEMENT);
 
             // Metadata
             this.metadataStatement = this.db.prepare(DbConstants.FIND_METADATA_STATEMENT);
@@ -99,41 +112,73 @@ class AndroidPoiPersistenceManager extends AbstractPoiPersistenceManager {
 
         // Close statements
 
-        if (this.findByIDStatement != null) {
+        if (this.findLocByIDStatement != null) {
             try {
-                this.findByIDStatement.close();
+                this.findLocByIDStatement.close();
             } catch (Exception e) {
                 LOGGER.log(Level.SEVERE, e.getMessage(), e);
             }
         }
 
-        if (this.insertPoiStatement1 != null) {
+        if (this.findCatByIDStatement != null) {
             try {
-                this.insertPoiStatement1.close();
+                this.findCatByIDStatement.close();
             } catch (Exception e) {
                 LOGGER.log(Level.SEVERE, e.getMessage(), e);
             }
         }
 
-        if (this.insertPoiStatement2 != null) {
+        if (this.findDataByIDStatement != null) {
             try {
-                this.insertPoiStatement2.close();
+                this.findDataByIDStatement.close();
             } catch (Exception e) {
                 LOGGER.log(Level.SEVERE, e.getMessage(), e);
             }
         }
 
-        if (this.deletePoiStatement1 != null) {
+        if (this.insertPoiStatementLoc != null) {
             try {
-                this.deletePoiStatement1.close();
+                this.insertPoiStatementLoc.close();
             } catch (Exception e) {
                 LOGGER.log(Level.SEVERE, e.getMessage(), e);
             }
         }
 
-        if (this.deletePoiStatement2 != null) {
+        if (this.insertPoiStatementData != null) {
             try {
-                this.deletePoiStatement2.close();
+                this.insertPoiStatementData.close();
+            } catch (Exception e) {
+                LOGGER.log(Level.SEVERE, e.getMessage(), e);
+            }
+        }
+
+        if (this.insertPoiStatementCat != null) {
+            try {
+                this.insertPoiStatementCat.close();
+            } catch (Exception e) {
+                LOGGER.log(Level.SEVERE, e.getMessage(), e);
+            }
+        }
+
+        if (this.deletePoiStatementLoc != null) {
+            try {
+                this.deletePoiStatementLoc.close();
+            } catch (Exception e) {
+                LOGGER.log(Level.SEVERE, e.getMessage(), e);
+            }
+        }
+
+        if (this.deletePoiStatementCat != null) {
+            try {
+                this.deletePoiStatementCat.close();
+            } catch (Exception e) {
+                LOGGER.log(Level.SEVERE, e.getMessage(), e);
+            }
+        }
+
+        if (this.deletePoiStatementData != null) {
+            try {
+                this.deletePoiStatementData.close();
             } catch (Exception e) {
                 LOGGER.log(Level.SEVERE, e.getMessage(), e);
             }
@@ -198,12 +243,77 @@ class AndroidPoiPersistenceManager extends AbstractPoiPersistenceManager {
         this.db.exec(DbConstants.DROP_METADATA_STATEMENT, null);
         this.db.exec(DbConstants.DROP_INDEX_STATEMENT, null);
         this.db.exec(DbConstants.DROP_DATA_STATEMENT, null);
+        this.db.exec(DbConstants.DROP_CATEGORYMAP_STATEMENT, null);
         this.db.exec(DbConstants.DROP_CATEGORIES_STATEMENT, null);
 
         this.db.exec(DbConstants.CREATE_CATEGORIES_STATEMENT, null);
+        this.db.exec(DbConstants.CREATE_CATEGORYMAP_STATEMENT, null);
         this.db.exec(DbConstants.CREATE_DATA_STATEMENT, null);
         this.db.exec(DbConstants.CREATE_INDEX_STATEMENT, null);
         this.db.exec(DbConstants.CREATE_METADATA_STATEMENT, null);
+    }
+
+    /**
+     * @param poiID Id of POI
+     * @return Set of PoiCategories
+     */
+    private Set<PoiCategory> findCategoriesByID(long poiID) {
+        try {
+            this.findCatByIDStatement.reset();
+            this.findCatByIDStatement.clear_bindings();
+            this.findCatByIDStatement.bind(1, poiID);
+
+            Set<PoiCategory> cats = new HashSet<>();
+            while (findCatByIDStatement.step()) {
+                cats.add(this.categoryManager.getPoiCategoryByID(
+                        findCatByIDStatement.column_int(1)));
+            }
+            return cats;
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, e.getMessage(), e);
+        } // Statements are closed in close()-Method
+        return null;
+    }
+
+    /**
+     * @param poiID Id of POI
+     * @return Set of Tags
+     */
+    private Set<Tag> findTagsByID(long poiID) {
+        try {
+            this.findDataByIDStatement.reset();
+            this.findDataByIDStatement.clear_bindings();
+            this.findDataByIDStatement.bind(1, poiID);
+
+            Set<Tag> tags = new HashSet<>();
+            while (findDataByIDStatement.step()) {
+                String data = findDataByIDStatement.column_string(1);
+                tags.addAll(stringToTags(data));
+            }
+            return tags;
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, e.getMessage(), e);
+        } // Statements are closed in close()-Method
+        return null;
+    }
+
+    /**
+     * @param poiID Id of POI
+     * @return Latitude and longitude values of POI
+     */
+    private LatLong findLocationByID(long poiID) {
+        try {
+            this.findLocByIDStatement.reset();
+            this.findLocByIDStatement.clear_bindings();
+            this.findLocByIDStatement.bind(1, poiID);
+
+            if (!this.findLocByIDStatement.step()) return null;
+            return new LatLong(this.findLocByIDStatement.column_double(1),
+                    this.findLocByIDStatement.column_double(2));
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, e.getMessage(), e);
+        } // Statements are closed in close()-Method
+        return null;
     }
 
     /**
@@ -247,15 +357,9 @@ class AndroidPoiPersistenceManager extends AbstractPoiPersistenceManager {
                 long id = stmt.column_long(0);
                 double lat = stmt.column_double(1);
                 double lon = stmt.column_double(2);
-                String data = stmt.column_string(3);
-                int categoryID = stmt.column_int(4);
 
-                try {
-                    this.poi = new PointOfInterest(id, lat, lon, data, this.categoryManager.getPoiCategoryByID(categoryID));
-                    this.ret.add(this.poi);
-                } catch (UnknownPoiCategoryException e) {
-                    LOGGER.log(Level.SEVERE, e.getMessage(), e);
-                }
+                this.poi = new PointOfInterest(id, lat, lon, findTagsByID(id), findCategoriesByID(id));
+                this.ret.add(this.poi);
             }
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, e.getMessage(), e);
@@ -281,27 +385,10 @@ class AndroidPoiPersistenceManager extends AbstractPoiPersistenceManager {
         this.poi = null;
 
         // Query
-        try {
-            this.findByIDStatement.reset();
-            this.findByIDStatement.clear_bindings();
-
-            this.findByIDStatement.bind(1, poiID);
-
-            if (this.findByIDStatement.step()) {
-                long id = this.findByIDStatement.column_long(0);
-                double lat = this.findByIDStatement.column_double(1);
-                double lon = this.findByIDStatement.column_double(2);
-                String data = this.findByIDStatement.column_string(3);
-                int categoryID = this.findByIDStatement.column_int(4);
-
-                try {
-                    this.poi = new PointOfInterest(id, lat, lon, data, this.categoryManager.getPoiCategoryByID(categoryID));
-                } catch (UnknownPoiCategoryException e) {
-                    LOGGER.log(Level.SEVERE, e.getMessage(), e);
-                }
-            }
-        } catch (Exception e) {
-            LOGGER.log(Level.SEVERE, e.getMessage(), e);
+        LatLong latlong = findLocationByID(poiID);
+        if (latlong != null) {
+            this.poi = new PointOfInterest(poiID, latlong.getLatitude(), latlong.getLongitude(),
+                    findTagsByID(poiID), findCategoriesByID(poiID));
         }
 
         return this.poi;
@@ -358,31 +445,9 @@ class AndroidPoiPersistenceManager extends AbstractPoiPersistenceManager {
      */
     @Override
     public void insertPointOfInterest(PointOfInterest poi) {
-        try {
-            this.insertPoiStatement1.reset();
-            this.insertPoiStatement1.clear_bindings();
-            this.insertPoiStatement2.reset();
-            this.insertPoiStatement2.clear_bindings();
-
-            this.db.exec("BEGIN;", null);
-
-            this.insertPoiStatement1.bind(1, poi.getId());
-            this.insertPoiStatement1.bind(2, poi.getLatitude());
-            this.insertPoiStatement1.bind(3, poi.getLatitude());
-            this.insertPoiStatement1.bind(4, poi.getLongitude());
-            this.insertPoiStatement1.bind(5, poi.getLongitude());
-
-            this.insertPoiStatement2.bind(1, poi.getId());
-            this.insertPoiStatement2.bind(2, poi.getData());
-            this.insertPoiStatement2.bind(3, poi.getCategory().getID());
-
-            this.insertPoiStatement1.step();
-            this.insertPoiStatement2.step();
-
-            this.db.exec("COMMIT;", null);
-        } catch (Exception e) {
-            LOGGER.log(Level.SEVERE, e.getMessage(), e);
-        }
+        Collection<PointOfInterest> c = new HashSet<>();
+        c.add(poi);
+        insertPointsOfInterest(c);
     }
 
     /**
@@ -394,23 +459,35 @@ class AndroidPoiPersistenceManager extends AbstractPoiPersistenceManager {
             this.db.exec("BEGIN;", null);
 
             for (PointOfInterest poi : pois) {
-                this.insertPoiStatement1.reset();
-                this.insertPoiStatement1.clear_bindings();
-                this.insertPoiStatement2.reset();
-                this.insertPoiStatement2.clear_bindings();
+                //Set poi location
+                this.insertPoiStatementLoc.reset();
+                this.insertPoiStatementLoc.clear_bindings();
 
-                this.insertPoiStatement1.bind(1, poi.getId());
-                this.insertPoiStatement1.bind(2, poi.getLatitude());
-                this.insertPoiStatement1.bind(3, poi.getLatitude());
-                this.insertPoiStatement1.bind(4, poi.getLongitude());
-                this.insertPoiStatement1.bind(5, poi.getLongitude());
+                this.insertPoiStatementLoc.bind(1, poi.getId());
+                this.insertPoiStatementLoc.bind(2, poi.getLatitude());
+                this.insertPoiStatementLoc.bind(3, poi.getLatitude());
+                this.insertPoiStatementLoc.bind(4, poi.getLongitude());
+                this.insertPoiStatementLoc.bind(5, poi.getLongitude());
 
-                this.insertPoiStatement2.bind(1, poi.getId());
-                this.insertPoiStatement2.bind(2, poi.getData());
-                this.insertPoiStatement2.bind(3, poi.getCategory().getID());
+                //Set poi tags
+                this.insertPoiStatementData.reset();
+                this.insertPoiStatementData.clear_bindings();
+                String data = tagsToString(poi.getTags());
+                this.insertPoiStatementData.bind(1, poi.getId());
+                this.insertPoiStatementData.bind(2, data);
 
-                this.insertPoiStatement1.step();
-                this.insertPoiStatement2.step();
+                //Set multiple poi categories
+                for (PoiCategory cat : poi.getCategories()) {
+                    this.insertPoiStatementCat.reset();
+                    this.insertPoiStatementCat.clear_bindings();
+
+                    this.insertPoiStatementCat.bind(1, poi.getId());
+                    this.insertPoiStatementCat.bind(2, cat.getID());
+                    this.insertPoiStatementCat.step();
+                }
+
+                this.insertPoiStatementData.step();
+                this.insertPoiStatementLoc.step();
             }
 
             this.db.exec("COMMIT;", null);
@@ -458,22 +535,56 @@ class AndroidPoiPersistenceManager extends AbstractPoiPersistenceManager {
     @Override
     public void removePointOfInterest(PointOfInterest poi) {
         try {
-            this.deletePoiStatement1.reset();
-            this.deletePoiStatement1.clear_bindings();
-            this.deletePoiStatement2.reset();
-            this.deletePoiStatement2.clear_bindings();
+            this.deletePoiStatementLoc.reset();
+            this.deletePoiStatementLoc.clear_bindings();
+            this.deletePoiStatementCat.reset();
+            this.deletePoiStatementCat.clear_bindings();
+            this.deletePoiStatementData.reset();
+            this.deletePoiStatementData.clear_bindings();
 
             this.db.exec("BEGIN;", null);
 
-            this.deletePoiStatement1.bind(1, poi.getId());
-            this.deletePoiStatement2.bind(1, poi.getId());
+            this.deletePoiStatementLoc.bind(1, poi.getId());
+            this.deletePoiStatementCat.bind(1, poi.getId());
+            this.deletePoiStatementData.bind(1, poi.getId());
 
-            this.deletePoiStatement1.step();
-            this.deletePoiStatement2.step();
+            this.deletePoiStatementLoc.step();
+            this.deletePoiStatementCat.step();
+            this.deletePoiStatementData.step();
 
             this.db.exec("COMMIT;", null);
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, e.getMessage(), e);
         }
+    }
+
+    /**
+     * Convert string representation back to tags list.
+     */
+    private Set<Tag> stringToTags(String tagsmapstring) {
+        String[] sb = tagsmapstring.split("\\r");
+        Set<Tag> map = new HashSet<>();
+        for (String key : sb) {
+            if (key.contains("=")) {
+                String[] set = key.split("=");
+                if (set.length == 2)
+                    map.add(new Tag(set[0], set[1]));
+            }
+        }
+        return map;
+    }
+
+    /**
+     * Convert tags to a string representation using '\r' delimiter.
+     */
+    private String tagsToString(Set<Tag> tagMap) {
+        StringBuilder sb = new StringBuilder();
+        for (Tag tag : tagMap) {
+            if (sb.length() > 0) {
+                sb.append('\r');
+            }
+            sb.append(tag.key).append('=').append(tag.value);
+        }
+        return sb.toString();
     }
 }

--- a/mapsforge-poi-awt/src/main/java/org/mapsforge/poi/awt/storage/AwtPoiPersistenceManager.java
+++ b/mapsforge-poi-awt/src/main/java/org/mapsforge/poi/awt/storage/AwtPoiPersistenceManager.java
@@ -16,9 +16,11 @@
 package org.mapsforge.poi.awt.storage;
 
 import org.mapsforge.core.model.BoundingBox;
+import org.mapsforge.core.model.LatLong;
 import org.mapsforge.core.model.Tag;
 import org.mapsforge.poi.storage.AbstractPoiPersistenceManager;
 import org.mapsforge.poi.storage.DbConstants;
+import org.mapsforge.poi.storage.PoiCategory;
 import org.mapsforge.poi.storage.PoiCategoryFilter;
 import org.mapsforge.poi.storage.PoiFileInfo;
 import org.mapsforge.poi.storage.PoiFileInfoBuilder;
@@ -34,7 +36,9 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -48,11 +52,15 @@ class AwtPoiPersistenceManager extends AbstractPoiPersistenceManager {
 
     private Connection conn = null;
 
-    private PreparedStatement findByIDStatement = null;
-    private PreparedStatement insertPoiStatement1 = null;
-    private PreparedStatement insertPoiStatement2 = null;
-    private PreparedStatement deletePoiStatement1 = null;
-    private PreparedStatement deletePoiStatement2 = null;
+    private PreparedStatement findCatByIDStatement = null;
+    private PreparedStatement findDataByIDStatement = null;
+    private PreparedStatement findLocByIDStatement = null;
+    private PreparedStatement insertPoiStatementLoc = null;
+    private PreparedStatement insertPoiStatementCat = null;
+    private PreparedStatement insertPoiStatementData = null;
+    private PreparedStatement deletePoiStatementLoc = null;
+    private PreparedStatement deletePoiStatementCat = null;
+    private PreparedStatement deletePoiStatementData = null;
     private PreparedStatement isValidDBStatement = null;
     private PreparedStatement metadataStatement = null;
 
@@ -71,16 +79,22 @@ class AwtPoiPersistenceManager extends AbstractPoiPersistenceManager {
 
         // Queries
         try {
-            // Finds a POI by its unique ID
-            this.findByIDStatement = this.conn.prepareStatement(DbConstants.FIND_BY_ID_STATEMENT);
+            // Finds a POI-Location by its unique ID
+            this.findLocByIDStatement = this.conn.prepareStatement(DbConstants.FIND_LOCATION_BY_ID_STATEMENT);
+            // Finds a POI-Data by its unique ID
+            this.findCatByIDStatement = this.conn.prepareStatement(DbConstants.FIND_CATEGORIES_BY_ID_STATEMENT);
+            // Finds a POI-Categories by its unique ID
+            this.findDataByIDStatement = this.conn.prepareStatement(DbConstants.FIND_DATA_BY_ID_STATEMENT);
 
             // Inserts a POI into index and adds its data
-            this.insertPoiStatement1 = this.conn.prepareStatement(DbConstants.INSERT_INDEX_STATEMENT);
-            this.insertPoiStatement2 = this.conn.prepareStatement(DbConstants.INSERT_DATA_STATEMENT);
+            this.insertPoiStatementLoc = this.conn.prepareStatement(DbConstants.INSERT_INDEX_STATEMENT);
+            this.insertPoiStatementData = this.conn.prepareStatement(DbConstants.INSERT_DATA_STATEMENT);
+            this.insertPoiStatementCat = this.conn.prepareStatement(DbConstants.INSERT_CATEGORYMAP_STATEMENT);
 
             // Deletes a POI given by its ID
-            this.deletePoiStatement1 = this.conn.prepareStatement(DbConstants.DELETE_INDEX_STATEMENT);
-            this.deletePoiStatement2 = this.conn.prepareStatement(DbConstants.DELETE_DATA_STATEMENT);
+            this.deletePoiStatementLoc = this.conn.prepareStatement(DbConstants.DELETE_INDEX_STATEMENT);
+            this.deletePoiStatementData = this.conn.prepareStatement(DbConstants.DELETE_DATA_STATEMENT);
+            this.deletePoiStatementCat = this.conn.prepareStatement(DbConstants.DELETE_CATEGORYMAP_STATEMENT);
 
             // Metadata
             this.metadataStatement = this.conn.prepareStatement(DbConstants.FIND_METADATA_STATEMENT);
@@ -100,41 +114,73 @@ class AwtPoiPersistenceManager extends AbstractPoiPersistenceManager {
 
         // Close statements
 
-        if (this.findByIDStatement != null) {
+        if (this.findLocByIDStatement != null) {
             try {
-                this.findByIDStatement.close();
+                this.findLocByIDStatement.close();
             } catch (SQLException e) {
                 LOGGER.log(Level.SEVERE, e.getMessage(), e);
             }
         }
 
-        if (this.insertPoiStatement1 != null) {
+        if (this.findCatByIDStatement != null) {
             try {
-                this.insertPoiStatement1.close();
+                this.findCatByIDStatement.close();
             } catch (SQLException e) {
                 LOGGER.log(Level.SEVERE, e.getMessage(), e);
             }
         }
 
-        if (this.insertPoiStatement2 != null) {
+        if (this.findDataByIDStatement != null) {
             try {
-                this.insertPoiStatement2.close();
+                this.findDataByIDStatement.close();
             } catch (SQLException e) {
                 LOGGER.log(Level.SEVERE, e.getMessage(), e);
             }
         }
 
-        if (this.deletePoiStatement1 != null) {
+        if (this.insertPoiStatementLoc != null) {
             try {
-                this.deletePoiStatement1.close();
+                this.insertPoiStatementLoc.close();
             } catch (SQLException e) {
                 LOGGER.log(Level.SEVERE, e.getMessage(), e);
             }
         }
 
-        if (this.deletePoiStatement2 != null) {
+        if (this.insertPoiStatementData != null) {
             try {
-                this.deletePoiStatement2.close();
+                this.insertPoiStatementData.close();
+            } catch (SQLException e) {
+                LOGGER.log(Level.SEVERE, e.getMessage(), e);
+            }
+        }
+
+        if (this.insertPoiStatementCat != null) {
+            try {
+                this.insertPoiStatementCat.close();
+            } catch (SQLException e) {
+                LOGGER.log(Level.SEVERE, e.getMessage(), e);
+            }
+        }
+
+        if (this.deletePoiStatementLoc != null) {
+            try {
+                this.deletePoiStatementLoc.close();
+            } catch (SQLException e) {
+                LOGGER.log(Level.SEVERE, e.getMessage(), e);
+            }
+        }
+
+        if (this.deletePoiStatementCat != null) {
+            try {
+                this.deletePoiStatementCat.close();
+            } catch (SQLException e) {
+                LOGGER.log(Level.SEVERE, e.getMessage(), e);
+            }
+        }
+
+        if (this.deletePoiStatementData != null) {
+            try {
+                this.deletePoiStatementData.close();
             } catch (SQLException e) {
                 LOGGER.log(Level.SEVERE, e.getMessage(), e);
             }
@@ -204,14 +250,105 @@ class AwtPoiPersistenceManager extends AbstractPoiPersistenceManager {
         stmt.execute(DbConstants.DROP_METADATA_STATEMENT);
         stmt.execute(DbConstants.DROP_INDEX_STATEMENT);
         stmt.execute(DbConstants.DROP_DATA_STATEMENT);
+        stmt.execute(DbConstants.DROP_CATEGORYMAP_STATEMENT);
         stmt.execute(DbConstants.DROP_CATEGORIES_STATEMENT);
 
         stmt.execute(DbConstants.CREATE_CATEGORIES_STATEMENT);
+        stmt.execute(DbConstants.CREATE_CATEGORYMAP_STATEMENT);
         stmt.execute(DbConstants.CREATE_DATA_STATEMENT);
         stmt.execute(DbConstants.CREATE_INDEX_STATEMENT);
         stmt.execute(DbConstants.CREATE_METADATA_STATEMENT);
 
         stmt.close();
+    }
+
+    /**
+     * @param poiID Id of POI
+     * @return Set of PoiCategories
+     */
+    private Set<PoiCategory> findCategoriesByID(long poiID) {
+        ResultSet rs = null;
+        try {
+            this.findCatByIDStatement.clearParameters();
+            this.findCatByIDStatement.setLong(1, poiID);
+
+            Set<PoiCategory> cats = new HashSet<>();
+            rs = this.findCatByIDStatement.executeQuery();
+            if (rs.next()) {
+                long id = rs.getLong(2);
+                cats.add(this.categoryManager.getPoiCategoryByID(
+                        (int) id));
+            }
+            return cats;
+        } catch (SQLException | UnknownPoiCategoryException e) {
+            LOGGER.log(Level.SEVERE, e.getMessage(), e);
+        } finally {
+            try {
+                if (rs != null) rs.close();
+                // Statements are closed in close()-Method
+            } catch (SQLException e) {
+                LOGGER.log(Level.SEVERE, e.getMessage(), e);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @param poiID Id of POI
+     * @return Set of Tags
+     */
+    private Set<Tag> findTagsByID(long poiID) {
+        ResultSet rs = null;
+        try {
+            this.findDataByIDStatement.clearParameters();
+            this.findDataByIDStatement.setLong(1, poiID);
+
+            Set<Tag> tags = new HashSet<>();
+            rs = this.findDataByIDStatement.executeQuery();
+            while (rs.next()) {
+                String data = rs.getString(2);
+                tags.addAll(stringToTags(data));
+            }
+            return tags;
+        } catch (SQLException e) {
+            LOGGER.log(Level.SEVERE, e.getMessage(), e);
+        } finally {
+            try {
+                if (rs != null) rs.close();
+                // Statements are closed in close()-Method
+            } catch (SQLException e) {
+                LOGGER.log(Level.SEVERE, e.getMessage(), e);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @param poiID Id of POI
+     * @return Latitude and longitude values of POI
+     */
+    private LatLong findLocationByID(long poiID) {
+        ResultSet rs = null;
+        try {
+            this.findLocByIDStatement.clearParameters();
+
+            this.findLocByIDStatement.setLong(1, poiID);
+
+            rs = this.findLocByIDStatement.executeQuery();
+            if (rs.next()) {
+                return new LatLong(rs.getDouble(2), rs.getDouble(3));
+            }
+        } catch (SQLException e) {
+            LOGGER.log(Level.SEVERE, e.getMessage(), e);
+        } finally {
+            try {
+                if (rs != null) rs.close();
+                // Statements are closed in close()-Method
+            } catch (SQLException e) {
+                LOGGER.log(Level.SEVERE, e.getMessage(), e);
+            }
+        }
+        return null;
     }
 
     /**
@@ -256,15 +393,9 @@ class AwtPoiPersistenceManager extends AbstractPoiPersistenceManager {
                 long id = rs.getLong(1);
                 double lat = rs.getDouble(2);
                 double lon = rs.getDouble(3);
-                String data = rs.getString(4);
-                int categoryID = rs.getInt(5);
 
-                try {
-                    this.poi = new PointOfInterest(id, lat, lon, data, this.categoryManager.getPoiCategoryByID(categoryID));
-                    this.ret.add(this.poi);
-                } catch (UnknownPoiCategoryException e) {
-                    LOGGER.log(Level.SEVERE, e.getMessage(), e);
-                }
+                this.poi = new PointOfInterest(id, lat, lon, findTagsByID(id), findCategoriesByID(id));
+                this.ret.add(this.poi);
             }
         } catch (SQLException e) {
             LOGGER.log(Level.SEVERE, e.getMessage(), e);
@@ -293,28 +424,10 @@ class AwtPoiPersistenceManager extends AbstractPoiPersistenceManager {
         this.poi = null;
 
         // Query
-        try {
-            this.findByIDStatement.clearParameters();
-
-            this.findByIDStatement.setLong(1, poiID);
-
-            ResultSet rs = this.findByIDStatement.executeQuery();
-            if (rs.next()) {
-                long id = rs.getLong(1);
-                double lat = rs.getDouble(2);
-                double lon = rs.getDouble(3);
-                String data = rs.getString(4);
-                int categoryID = rs.getInt(5);
-
-                try {
-                    this.poi = new PointOfInterest(id, lat, lon, data, this.categoryManager.getPoiCategoryByID(categoryID));
-                } catch (UnknownPoiCategoryException e) {
-                    LOGGER.log(Level.SEVERE, e.getMessage(), e);
-                }
-            }
-            rs.close();
-        } catch (SQLException e) {
-            LOGGER.log(Level.SEVERE, e.getMessage(), e);
+        LatLong latlong = findLocationByID(poiID);
+        if (latlong != null) {
+            this.poi = new PointOfInterest(poiID, latlong.getLatitude(), latlong.getLongitude(),
+                    findTagsByID(poiID), findCategoriesByID(poiID));
         }
 
         return this.poi;
@@ -373,31 +486,9 @@ class AwtPoiPersistenceManager extends AbstractPoiPersistenceManager {
      */
     @Override
     public void insertPointOfInterest(PointOfInterest poi) {
-        try {
-            this.insertPoiStatement1.clearParameters();
-            this.insertPoiStatement2.clearParameters();
-
-            Statement stmt = this.conn.createStatement();
-            stmt.execute("BEGIN;");
-
-            this.insertPoiStatement1.setLong(1, poi.getId());
-            this.insertPoiStatement1.setDouble(2, poi.getLatitude());
-            this.insertPoiStatement1.setDouble(3, poi.getLatitude());
-            this.insertPoiStatement1.setDouble(4, poi.getLongitude());
-            this.insertPoiStatement1.setDouble(5, poi.getLongitude());
-
-            this.insertPoiStatement2.setLong(1, poi.getId());
-            this.insertPoiStatement2.setString(2, poi.getData());
-            this.insertPoiStatement2.setInt(3, poi.getCategory().getID());
-
-            this.insertPoiStatement1.executeUpdate();
-            this.insertPoiStatement2.executeUpdate();
-
-            stmt.execute("COMMIT;");
-            stmt.close();
-        } catch (SQLException e) {
-            LOGGER.log(Level.SEVERE, e.getMessage(), e);
-        }
+        Collection<PointOfInterest> c = new HashSet<>();
+        c.add(poi);
+        insertPointsOfInterest(c);
     }
 
     /**
@@ -406,25 +497,35 @@ class AwtPoiPersistenceManager extends AbstractPoiPersistenceManager {
     @Override
     public void insertPointsOfInterest(Collection<PointOfInterest> pois) {
         try {
-            this.insertPoiStatement1.clearParameters();
-            this.insertPoiStatement2.clearParameters();
+            this.insertPoiStatementLoc.clearParameters();
+            this.insertPoiStatementCat.clearParameters();
+            this.insertPoiStatementData.clearParameters();
 
             Statement stmt = this.conn.createStatement();
             stmt.execute("BEGIN;");
 
             for (PointOfInterest poi : pois) {
-                this.insertPoiStatement1.setLong(1, poi.getId());
-                this.insertPoiStatement1.setDouble(2, poi.getLatitude());
-                this.insertPoiStatement1.setDouble(3, poi.getLatitude());
-                this.insertPoiStatement1.setDouble(4, poi.getLongitude());
-                this.insertPoiStatement1.setDouble(5, poi.getLongitude());
+                this.insertPoiStatementLoc.setLong(1, poi.getId());
+                this.insertPoiStatementLoc.setDouble(2, poi.getLatitude());
+                this.insertPoiStatementLoc.setDouble(3, poi.getLatitude());
+                this.insertPoiStatementLoc.setDouble(4, poi.getLongitude());
+                this.insertPoiStatementLoc.setDouble(5, poi.getLongitude());
 
-                this.insertPoiStatement2.setLong(1, poi.getId());
-                this.insertPoiStatement2.setString(2, poi.getData());
-                this.insertPoiStatement2.setInt(3, poi.getCategory().getID());
+                //Set poi tags
+                String data = tagsToString(poi.getTags());
+                this.insertPoiStatementData.setLong(1, poi.getId());
+                this.insertPoiStatementData.setString(2, data);
 
-                this.insertPoiStatement1.executeUpdate();
-                this.insertPoiStatement2.executeUpdate();
+                //Set multiple poi categories
+                for (PoiCategory cat : poi.getCategories()) {
+
+                    this.insertPoiStatementCat.setLong(1, poi.getId());
+                    this.insertPoiStatementCat.setLong(2, cat.getID());
+                    this.insertPoiStatementCat.executeUpdate();
+                }
+
+                this.insertPoiStatementData.executeUpdate();
+                this.insertPoiStatementLoc.executeUpdate();
             }
 
             stmt.execute("COMMIT;");
@@ -475,22 +576,55 @@ class AwtPoiPersistenceManager extends AbstractPoiPersistenceManager {
     @Override
     public void removePointOfInterest(PointOfInterest poi) {
         try {
-            this.deletePoiStatement1.clearParameters();
-            this.deletePoiStatement2.clearParameters();
+            this.deletePoiStatementLoc.clearParameters();
+            this.deletePoiStatementData.clearParameters();
+            this.deletePoiStatementCat.clearParameters();
 
             Statement stmt = this.conn.createStatement();
             stmt.execute("BEGIN;");
 
-            this.deletePoiStatement1.setLong(1, poi.getId());
-            this.deletePoiStatement2.setLong(1, poi.getId());
+            this.deletePoiStatementLoc.setLong(1, poi.getId());
+            this.deletePoiStatementData.setLong(1, poi.getId());
+            this.deletePoiStatementCat.setLong(1, poi.getId());
 
-            this.deletePoiStatement1.executeUpdate();
-            this.deletePoiStatement2.executeUpdate();
+            this.deletePoiStatementLoc.executeUpdate();
+            this.deletePoiStatementData.executeUpdate();
+            this.deletePoiStatementCat.executeUpdate();
 
             stmt.execute("COMMIT;");
             stmt.close();
         } catch (SQLException e) {
             LOGGER.log(Level.SEVERE, e.getMessage(), e);
         }
+    }
+
+    /**
+     * Convert string representation back to tags list.
+     */
+    private Set<Tag> stringToTags(String tagsmapstring) {
+        String[] sb = tagsmapstring.split("\\r");
+        Set<Tag> map = new HashSet<>();
+        for (String key : sb) {
+            if (key.contains("=")) {
+                String[] set = key.split("=");
+                if (set.length == 2)
+                    map.add(new Tag(set[0], set[1]));
+            }
+        }
+        return map;
+    }
+
+    /**
+     * Convert tags to a string representation using '\r' delimiter.
+     */
+    private String tagsToString(Set<Tag> tagMap) {
+        StringBuilder sb = new StringBuilder();
+        for (Tag tag : tagMap) {
+            if (sb.length() > 0) {
+                sb.append('\r');
+            }
+            sb.append(tag.key).append('=').append(tag.value);
+        }
+        return sb.toString();
     }
 }

--- a/mapsforge-poi-writer/src/main/config/mapsforge-poi.properties
+++ b/mapsforge-poi-writer/src/main/config/mapsforge-poi.properties
@@ -1,2 +1,2 @@
-poi.specification.version=1
+poi.specification.version=2
 poi.writer.version=${poi.writer.version}

--- a/mapsforge-poi/src/main/java/org/mapsforge/poi/storage/AbstractPoiPersistenceManager.java
+++ b/mapsforge-poi/src/main/java/org/mapsforge/poi/storage/AbstractPoiPersistenceManager.java
@@ -31,6 +31,7 @@ import java.util.List;
 public abstract class AbstractPoiPersistenceManager implements PoiPersistenceManager {
     protected PoiCategoryManager categoryManager = null;
     protected String poiFile;
+    protected PoiFileInfo poiFileInfo;
 
     // Containers for return values
     protected final List<PointOfInterest> ret;
@@ -72,15 +73,33 @@ public abstract class AbstractPoiPersistenceManager implements PoiPersistenceMan
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public PoiFileInfo getPoiFileInfo() {
+        // Update File info only if its null to avoid frequent requests.
+        if (poiFileInfo == null) {
+            updatePoiFileInfo();
+        }
+        return poiFileInfo;
+    }
+
+    /**
+     * Updates the metadata for the current POI file.
+     */
+    public abstract void updatePoiFileInfo();
+
+    /**
      * Gets the SQL query that looks up POI entries.
      *
      * @param filter The filter object for determining all wanted categories (may be null).
      * @param count  Count of patterns to search in points of interest data (may be 0).
+     * @param version The version of poi-specification.
      * @return The SQL query.
      */
-    protected static String getSQLSelectString(PoiCategoryFilter filter, int count) {
+    protected static String getSQLSelectString(PoiCategoryFilter filter, int count, int version) {
         if (filter != null) {
-            return PoiCategoryRangeQueryGenerator.getSQLSelectString(filter, count);
+            return PoiCategoryRangeQueryGenerator.getSQLSelectString(filter, count, version);
         }
         StringBuilder query = new StringBuilder();
         query.append(DbConstants.FIND_IN_BOX_CLAUSE_SELECT);

--- a/mapsforge-poi/src/main/java/org/mapsforge/poi/storage/AbstractPoiPersistenceManager.java
+++ b/mapsforge-poi/src/main/java/org/mapsforge/poi/storage/AbstractPoiPersistenceManager.java
@@ -82,11 +82,16 @@ public abstract class AbstractPoiPersistenceManager implements PoiPersistenceMan
         if (filter != null) {
             return PoiCategoryRangeQueryGenerator.getSQLSelectString(filter, count);
         }
-        String query = DbConstants.FIND_IN_BOX_STATEMENT;
-        for (int i = 0; i < count; i++) {
-            query += DbConstants.FIND_BY_DATA_CLAUSE;
+        StringBuilder query = new StringBuilder();
+        query.append(DbConstants.FIND_IN_BOX_CLAUSE_SELECT);
+        if (count > 0) {
+            query.append(DbConstants.JOIN_DATA_CLAUSE);
         }
-        return query + " LIMIT ?;";
+        query.append(DbConstants.FIND_IN_BOX_CLAUSE_WHERE);
+        for (int i = 0; i < count; i++) {
+            query.append(DbConstants.FIND_BY_DATA_CLAUSE);
+        }
+        return query.append(" LIMIT ?;").toString();
     }
 
     /**

--- a/mapsforge-poi/src/main/java/org/mapsforge/poi/storage/DbConstants.java
+++ b/mapsforge-poi/src/main/java/org/mapsforge/poi/storage/DbConstants.java
@@ -66,7 +66,7 @@ public final class DbConstants {
                     + "minLon <= ? AND "
                     + "minLat >= ? AND "
                     + "minLon >= ?";
-
+    public static final String FIND_IN_BOX_CLAUSE_WHERE_CATEGORY_IN = "poi_cmap.category IN (";
     public static final String FIND_IN_BOX_STATEMENT = FIND_IN_BOX_CLAUSE_SELECT + FIND_IN_BOX_CLAUSE_WHERE;
 
     public static final String FIND_METADATA_STATEMENT = "SELECT name, value FROM metadata;";
@@ -98,6 +98,23 @@ public final class DbConstants {
             + "FROM sqlite_master "
             + "WHERE name IN "
             + "('metadata', 'poi_categories', 'poi_data', 'poi_index', 'poi_cmap');";
+
+    // V1 Statements
+    public static final String FIND_CATEGORIES_BY_ID_STATEMENT_V1 =
+            "SELECT poi_data.id, poi_data.category "
+                    + "FROM poi_data "
+                    + "WHERE poi_data.id = ?;";
+
+    public static final int NUMBER_OF_TABLES_V1 = 4;
+
+    public static final String VALID_DB_STATEMENT_V1 = "SELECT count(name) "
+            + "FROM sqlite_master "
+            + "WHERE name IN "
+            + "('metadata', 'poi_categories', 'poi_data', 'poi_index', 'poi_cmap');";
+
+    public static final String FIND_IN_BOX_CLAUSE_WHERE_CATEGORY_IN_V1 = "poi_data.category IN (";
+    // V1 Statements end
+
 
     private DbConstants() {
         throw new IllegalStateException();

--- a/mapsforge-poi/src/main/java/org/mapsforge/poi/storage/DbConstants.java
+++ b/mapsforge-poi/src/main/java/org/mapsforge/poi/storage/DbConstants.java
@@ -20,7 +20,9 @@ package org.mapsforge.poi.storage;
  */
 public final class DbConstants {
     public static final String CREATE_CATEGORIES_STATEMENT = "CREATE TABLE poi_categories (id INTEGER, name TEXT, parent INTEGER, PRIMARY KEY (id));";
-    public static final String CREATE_DATA_STATEMENT = "CREATE TABLE poi_data (id INTEGER, data TEXT, category INTEGER, PRIMARY KEY (id));";
+    public static final String CREATE_DATA_STATEMENT = "CREATE TABLE poi_data (id INTEGER, data TEXT, PRIMARY KEY (id));";
+    public static final String CREATE_CATEGORYMAP_STATEMENT =
+            "CREATE TABLE poi_cmap (id INTEGER, category INTEGER not null, PRIMARY KEY (id, category)); ";
     public static final String CREATE_INDEX_STATEMENT = "CREATE VIRTUAL TABLE poi_index USING rtree(id, minLat, maxLat, minLon, maxLon);";
     public static final String CREATE_METADATA_STATEMENT = "CREATE TABLE metadata (name TEXT, value TEXT);";
     public static final String CREATE_NODES_STATEMENT = "CREATE TABLE nodes (id INTEGER, lat REAL, lon REAL, PRIMARY KEY (id));";
@@ -28,36 +30,52 @@ public final class DbConstants {
 
     public static final String DELETE_DATA_STATEMENT = "DELETE FROM poi_data WHERE id = ?;";
     public static final String DELETE_INDEX_STATEMENT = "DELETE FROM poi_index WHERE id = ?;";
+    public static final String DELETE_CATEGORYMAP_STATEMENT = "DELETE FROM poi_cmap WHERE id = ?;";
 
     public static final String DROP_CATEGORIES_STATEMENT = "DROP TABLE IF EXISTS poi_categories;";
     public static final String DROP_DATA_STATEMENT = "DROP TABLE IF EXISTS poi_data;";
     public static final String DROP_INDEX_STATEMENT = "DROP TABLE IF EXISTS poi_index;";
+    public static final String DROP_CATEGORYMAP_STATEMENT = "DROP TABLE IF EXISTS poi_cmap;";
     public static final String DROP_METADATA_STATEMENT = "DROP TABLE IF EXISTS metadata;";
     public static final String DROP_NODES_STATEMENT = "DROP TABLE IF EXISTS nodes;";
     public static final String DROP_WAYNODES_STATEMENT = "DROP TABLE IF EXISTS waynodes;";
 
     public static final String FIND_BY_DATA_CLAUSE = " AND poi_data.data LIKE ?";
-    public static final String FIND_BY_ID_STATEMENT =
-            "SELECT poi_index.id, poi_index.minLat, poi_index.minLon, poi_data.data, poi_data.category "
+    public static final String JOIN_DATA_CLAUSE = "JOIN poi_data ON poi_index.id = poi_data.id ";
+    public static final String JOIN_CATEGORY_CLAUSE = "JOIN poi_cmap ON poi_index.id = poi_cmap.id ";
+
+    public static final String FIND_LOCATION_BY_ID_STATEMENT =
+            "SELECT poi_index.id, poi_index.minLat, poi_index.minLon "
                     + "FROM poi_index "
-                    + "JOIN poi_data ON poi_index.id = poi_data.id "
-                    + "WHERE "
-                    + "poi_index.id = ?;";
-    public static final String FIND_IN_BOX_STATEMENT =
-            "SELECT poi_index.id, poi_index.minLat, poi_index.minLon, poi_data.data, poi_data.category "
-                    + "FROM poi_index "
-                    + "JOIN poi_data ON poi_index.id = poi_data.id "
-                    + "WHERE "
+                    + "WHERE poi_index.id = ?;";
+    public static final String FIND_CATEGORIES_BY_ID_STATEMENT =
+            "SELECT poi_cmap.id, poi_cmap.category "
+                    + "FROM poi_cmap "
+                    + "WHERE poi_cmap.id = ?;";
+    public static final String FIND_DATA_BY_ID_STATEMENT =
+            "SELECT poi_data.id, poi_data.data "
+                    + "FROM poi_data "
+                    + "WHERE poi_data.id = ?;";
+
+    public static final String FIND_IN_BOX_CLAUSE_SELECT =
+            "SELECT poi_index.id, poi_index.minLat, poi_index.minLon "
+                    + "FROM poi_index ";
+    public static final String FIND_IN_BOX_CLAUSE_WHERE =
+            "WHERE "
                     + "minLat <= ? AND "
                     + "minLon <= ? AND "
                     + "minLat >= ? AND "
                     + "minLon >= ?";
+
+    public static final String FIND_IN_BOX_STATEMENT = FIND_IN_BOX_CLAUSE_SELECT + FIND_IN_BOX_CLAUSE_WHERE;
+
     public static final String FIND_METADATA_STATEMENT = "SELECT name, value FROM metadata;";
     public static final String FIND_NODES_STATEMENT = "SELECT lat, lon FROM nodes WHERE id = ?;";
     public static final String FIND_WAYNODES_BY_ID_STATEMENT = "SELECT node, position FROM waynodes WHERE way = ?;";
 
     public static final String INSERT_CATEGORIES_STATEMENT = "INSERT INTO poi_categories VALUES (?, ?, ?);";
-    public static final String INSERT_DATA_STATEMENT = "INSERT INTO poi_data VALUES (?, ?, ?);";
+    public static final String INSERT_DATA_STATEMENT = "INSERT INTO poi_data VALUES (?, ?);";
+    public static final String INSERT_CATEGORYMAP_STATEMENT = "INSERT INTO poi_cmap VALUES (?, ?);";
     public static final String INSERT_INDEX_STATEMENT = "INSERT INTO poi_index VALUES (?, ?, ?, ?, ?);";
     public static final String INSERT_METADATA_STATEMENT = "INSERT INTO metadata VALUES (?, ?);";
     public static final String INSERT_NODES_STATEMENT = "INSERT INTO nodes VALUES (?, ?, ?);";
@@ -74,12 +92,12 @@ public final class DbConstants {
     public static final String METADATA_WRITER = "writer";
 
     // Number of tables needed for DB verification
-    public static final int NUMBER_OF_TABLES = 4;
+    public static final int NUMBER_OF_TABLES = 5;
 
     public static final String VALID_DB_STATEMENT = "SELECT count(name) "
             + "FROM sqlite_master "
             + "WHERE name IN "
-            + "('metadata', 'poi_categories', 'poi_data', 'poi_index');";
+            + "('metadata', 'poi_categories', 'poi_data', 'poi_index', 'poi_cmap');";
 
     private DbConstants() {
         throw new IllegalStateException();

--- a/mapsforge-poi/src/main/java/org/mapsforge/poi/storage/PoiCategoryRangeQueryGenerator.java
+++ b/mapsforge-poi/src/main/java/org/mapsforge/poi/storage/PoiCategoryRangeQueryGenerator.java
@@ -37,11 +37,17 @@ public final class PoiCategoryRangeQueryGenerator {
      * @return The SQL query.
      */
     public static String getSQLSelectString(PoiCategoryFilter filter, int count) {
-        String query = DbConstants.FIND_IN_BOX_STATEMENT + getSQLWhereClauseString(filter);
-        for (int i = 0; i < count; i++) {
-            query += DbConstants.FIND_BY_DATA_CLAUSE;
+        StringBuilder query = new StringBuilder();
+        query.append(DbConstants.FIND_IN_BOX_CLAUSE_SELECT
+                + DbConstants.JOIN_CATEGORY_CLAUSE);
+        if (count > 0) {
+            query.append(DbConstants.JOIN_DATA_CLAUSE);
         }
-        return query + " LIMIT ?;";
+        query.append(DbConstants.FIND_IN_BOX_CLAUSE_WHERE).append(getSQLWhereClauseString(filter));
+        for (int i = 0; i < count; i++) {
+            query.append(DbConstants.FIND_BY_DATA_CLAUSE);
+        }
+        return (query.append(" LIMIT ?;").toString());
     }
 
     /**
@@ -68,7 +74,7 @@ public final class PoiCategoryRangeQueryGenerator {
             // Don't forget the super category itself in the search!
             categories.add(superCat);
 
-            sb.append("poi_data.category IN (");
+            sb.append("poi_cmap.category IN (");
             // for each category
             for (Iterator<PoiCategory> catIter = categories.iterator(); catIter.hasNext(); ) {
                 PoiCategory cat = catIter.next();

--- a/mapsforge-poi/src/main/java/org/mapsforge/poi/storage/PoiCategoryRangeQueryGenerator.java
+++ b/mapsforge-poi/src/main/java/org/mapsforge/poi/storage/PoiCategoryRangeQueryGenerator.java
@@ -34,16 +34,24 @@ public final class PoiCategoryRangeQueryGenerator {
      *
      * @param filter The filter object for determining all wanted categories.
      * @param count  Count of patterns to search in points of interest names (may be 0).
+     * @param version The version of poi-specification.
      * @return The SQL query.
      */
-    public static String getSQLSelectString(PoiCategoryFilter filter, int count) {
+    public static String getSQLSelectString(PoiCategoryFilter filter, int count, int version) {
         StringBuilder query = new StringBuilder();
-        query.append(DbConstants.FIND_IN_BOX_CLAUSE_SELECT
-                + DbConstants.JOIN_CATEGORY_CLAUSE);
-        if (count > 0) {
+        query.append(DbConstants.FIND_IN_BOX_CLAUSE_SELECT);
+
+        if (version <= 1) {
             query.append(DbConstants.JOIN_DATA_CLAUSE);
+        } else {
+            query.append(DbConstants.JOIN_CATEGORY_CLAUSE);
+            if (count > 0) {
+                query.append(DbConstants.JOIN_DATA_CLAUSE);
+            }
         }
-        query.append(DbConstants.FIND_IN_BOX_CLAUSE_WHERE).append(getSQLWhereClauseString(filter));
+
+        query.append(DbConstants.FIND_IN_BOX_CLAUSE_WHERE).append(
+                getSQLWhereClauseString(filter, version));
         for (int i = 0; i < count; i++) {
             query.append(DbConstants.FIND_BY_DATA_CLAUSE);
         }
@@ -54,9 +62,10 @@ public final class PoiCategoryRangeQueryGenerator {
      * Gets the WHERE clause for the SQL query that looks up POI entries.
      *
      * @param filter The filter object for determining all wanted categories.
+     * @param version The version of poi-specification.
      * @return The WHERE clause.
      */
-    private static String getSQLWhereClauseString(PoiCategoryFilter filter) {
+    private static String getSQLWhereClauseString(PoiCategoryFilter filter, int version) {
         Collection<PoiCategory> superCategories = filter.getAcceptedSuperCategories();
 
         if (superCategories.isEmpty()) {
@@ -74,7 +83,12 @@ public final class PoiCategoryRangeQueryGenerator {
             // Don't forget the super category itself in the search!
             categories.add(superCat);
 
-            sb.append("poi_cmap.category IN (");
+            // Version compatibility
+            if (version <= 1) {
+                sb.append(DbConstants.FIND_IN_BOX_CLAUSE_WHERE_CATEGORY_IN_V1);
+            } else {
+                sb.append(DbConstants.FIND_IN_BOX_CLAUSE_WHERE_CATEGORY_IN);
+            }
             // for each category
             for (Iterator<PoiCategory> catIter = categories.iterator(); catIter.hasNext(); ) {
                 PoiCategory cat = catIter.next();

--- a/mapsforge-poi/src/main/java/org/mapsforge/poi/storage/PointOfInterest.java
+++ b/mapsforge-poi/src/main/java/org/mapsforge/poi/storage/PointOfInterest.java
@@ -18,9 +18,10 @@ package org.mapsforge.poi.storage;
 import org.mapsforge.core.model.LatLong;
 import org.mapsforge.core.model.Tag;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Locale;
+import java.util.Set;
 
 /**
  * This class represents a point of interest. Every POI should be uniquely identifiable by its id,
@@ -30,15 +31,20 @@ public class PointOfInterest {
     private final long id;
     private final double latitude;
     private final double longitude;
-    private final String data;
-    private final PoiCategory category;
+    private final Set<Tag> tags;
+    private final Set<PoiCategory> categories;
 
-    public PointOfInterest(long id, double latitude, double longitude, String data, PoiCategory category) {
+    public PointOfInterest(long id, double latitude, double longitude, String name, PoiCategory categories) {
+        this(id, latitude, longitude, new HashSet<>(Collections.singletonList(new Tag("name", name))),
+                new HashSet<>(Collections.singletonList(categories)));
+    }
+
+    public PointOfInterest(long id, double latitude, double longitude, Set<Tag> tags, Set<PoiCategory> categories) {
         this.id = id;
         this.latitude = latitude;
         this.longitude = longitude;
-        this.data = data;
-        this.category = category;
+        this.tags = (tags == null) ? new HashSet<Tag>() : tags;
+        this.categories = (categories == null) ? new HashSet<PoiCategory>() : categories;
     }
 
     @Override
@@ -53,17 +59,25 @@ public class PointOfInterest {
     }
 
     /**
-     * @return category of this point of interest.
+     * @return all categories of this point of interest.
      */
-    public PoiCategory getCategory() {
-        return this.category;
+    public Set<PoiCategory> getCategories() {
+        return this.categories;
     }
 
     /**
-     * @return data of this point of interest.
+     * @return category of this point of interest.
      */
-    public String getData() {
-        return this.data;
+    public PoiCategory getCategory() {
+        if (!categories.isEmpty()) {
+            if (categories.size() == 1)
+                return categories.toArray(new PoiCategory[categories.size()])[0];
+            else {
+                //TODO return the highest cat.-level of all its categories together
+                return categories.toArray(new PoiCategory[categories.size()])[0];
+            }
+        }
+        return null;
     }
 
     /**
@@ -105,7 +119,6 @@ public class PointOfInterest {
      * @return name of this point of interest at preferred language
      */
     public String getName(String language) {
-        List<Tag> tags = getTags();
 
         if (language != null && language.trim().length() > 0) {
             // Exact match
@@ -133,32 +146,22 @@ public class PointOfInterest {
             }
         }
 
-        if (tags.isEmpty()) {
-            return data;
-        }
-
         return null;
     }
 
     /**
      * @return tags of this point of interest.
      */
-    public List<Tag> getTags() {
-        List<Tag> tags = new ArrayList<>();
-        if (this.data != null && this.data.trim().length() > 0) {
-            String[] split = this.data.split("\r");
-            for (String s : split) {
-                if (s.indexOf(Tag.KEY_VALUE_SEPARATOR) > -1) {
-                    tags.add(new Tag(s));
-                }
-            }
-        }
+    public Set<Tag> getTags() {
         return tags;
     }
 
     @Override
     public String toString() {
-        return "POI: (" + this.latitude + ',' + this.longitude + ") " + this.data + ' '
-                + this.category.getID();
+        String builder = "POI: (" + this.latitude + ',' + this.longitude + ") " + this.tags.toString() + ' ';
+        for (PoiCategory category : categories) {
+            builder += category.getID() + ' ';
+        }
+        return builder;
     }
 }

--- a/mapsforge-poi/src/test/java/org/mapsforge/poi/storage/PoiCategoryRangeQueryGeneratorTest.java
+++ b/mapsforge-poi/src/test/java/org/mapsforge/poi/storage/PoiCategoryRangeQueryGeneratorTest.java
@@ -27,6 +27,8 @@ public class PoiCategoryRangeQueryGeneratorTest {
     private PoiCategoryManager flatCm;
     private PoiCategoryManager balancedCm;
 
+    private final static int POI_SPECIFICATION_VERSION = 2;
+
     @Before
     public void init() {
         this.flatRoot = CategoryTreeBuilder.createAndGetFlatConfiguration();
@@ -48,7 +50,8 @@ public class PoiCategoryRangeQueryGeneratorTest {
         PoiCategoryFilter filter = new WhitelistPoiCategoryFilter();
         filter.addCategory(this.flatRoot);
 
-        String query = PoiCategoryRangeQueryGenerator.getSQLSelectString(filter, 0);
+        String query = PoiCategoryRangeQueryGenerator.getSQLSelectString(
+                filter, 0, POI_SPECIFICATION_VERSION);
 
         System.out.println("Query: " + query);
 
@@ -66,7 +69,8 @@ public class PoiCategoryRangeQueryGeneratorTest {
         filter.addCategory(this.balancedCm.getPoiCategoryByTitle("l1_1"));
         filter.addCategory(this.balancedCm.getPoiCategoryByTitle("l1_2"));
 
-        String query = PoiCategoryRangeQueryGenerator.getSQLSelectString(filter, 0);
+        String query = PoiCategoryRangeQueryGenerator.getSQLSelectString(
+                filter, 0, POI_SPECIFICATION_VERSION);
         System.out.println("Query: " + query);
 
         // TODO add assertions


### PR DESCRIPTION
Refers to #950
- split db-queries to location, tag-data and categories 
- improve getSQLSelectString, to dynamically join data 
- PointOfInterest supports multiple categories and minor improvements (Set instead of List)
- adapt PoiPersistenceManager (multiple categories) 
- adapt PoiWriter (multiple categories)

If this pull request has too much changes in one step, i try to split them. But it doesn't make sense to separate the minor changes (as preparation for the m:n relation of categories) from the grand pull-request.
If there are any questions, i'll try to explain my thoughts / or improve my code.