### PR TITLE
POI-Writer: add bounds to metadata, if not set in parameters

### DIFF
--- a/mapsforge-poi-writer/src/main/java/org/mapsforge/poi/writer/PoiWriter.java
+++ b/mapsforge-poi-writer/src/main/java/org/mapsforge/poi/writer/PoiWriter.java
@@ -608,6 +608,18 @@ public final class PoiWriter {
         // Bounds
         pStmtMetadata.setString(1, DbConstants.METADATA_BOUNDS);
         BoundingBox bb = this.configuration.getBboxConfiguration();
+        if (bb == null) {
+            // This may produce implausible bounds, but this depends on the source map.
+            String FIND_MAX_BOUND = "SELECT MIN(minLat), MIN(minLon), MAX(maxLat), MAX(maxLon) FROM poi_index";
+
+            Statement maxBoundStmt = this.conn.createStatement();
+            ResultSet rs = maxBoundStmt.executeQuery(FIND_MAX_BOUND);
+            if (rs.next()) {
+                bb = new BoundingBox(rs.getDouble(1), rs.getDouble(2), rs.getDouble(3), rs.getDouble(4));
+            }
+            rs.close();
+            maxBoundStmt.close();
+        }
         if (bb != null) {
             pStmtMetadata.setString(2, bb.minLatitude + "," + bb.minLongitude + "," + bb.maxLatitude + "," + bb.maxLongitude);
         } else {


### PR DESCRIPTION
This is useful to check/complete the bounds of your POI file, even if no bounds were given by the parameters while POI writing. This highly depends on the converted PBF file and its inherited nodes.
First I tried to reach a similar result with `initialize(Map<String, Object> metadata)` in `MapFileWriterTask` but metadata was always empty.