### PR TITLE
hillshading update: filtered upscaling on android, smooth tile borders

### DIFF
--- a/mapsforge-core/src/main/java/org/mapsforge/core/graphics/GraphicContext.java
+++ b/mapsforge-core/src/main/java/org/mapsforge/core/graphics/GraphicContext.java
@@ -48,5 +48,6 @@ public interface GraphicContext {
 
     void setClipDifference(int left, int top, int width, int height);
 
+    /** shade whole map tile when tileRect is null (and bitmap, shadeRect are null), shade tileRect neutral if bitmap is null (and shadeRect), shade tileRect with bitmap otherwise */
     void shadeBitmap(Bitmap bitmap, Rectangle shadeRect, Rectangle tileRect, float magnitude);
 }

--- a/mapsforge-core/src/main/java/org/mapsforge/core/graphics/GraphicFactory.java
+++ b/mapsforge-core/src/main/java/org/mapsforge/core/graphics/GraphicFactory.java
@@ -18,6 +18,7 @@ package org.mapsforge.core.graphics;
 
 import org.mapsforge.core.mapelements.PointTextContainer;
 import org.mapsforge.core.mapelements.SymbolContainer;
+import org.mapsforge.core.model.BoundingBox;
 import org.mapsforge.core.model.Point;
 
 import java.io.IOException;
@@ -37,9 +38,9 @@ public interface GraphicFactory {
     Matrix createMatrix();
 
     /**
-     * Create a single channel bitmap, e.g. for hillshading.
+     * Create a single channel bitmap for hillshading, may include a buffer.
      */
-    Bitmap createMonoBitmap(int width, int height, byte[] buffer);
+    HillshadingBitmap createMonoBitmap(int width, int height, byte[] buffer, int padding, BoundingBox area);
 
     Paint createPaint();
 

--- a/mapsforge-core/src/main/java/org/mapsforge/core/graphics/HillshadingBitmap.java
+++ b/mapsforge-core/src/main/java/org/mapsforge/core/graphics/HillshadingBitmap.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 usrusr
+ *
+ * This program is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.mapsforge.core.graphics;
+
+import org.mapsforge.core.model.BoundingBox;
+
+/**
+ * Created by usrusr on 28.02.2017.
+ */
+public interface HillshadingBitmap extends Bitmap {
+    /** optional padding (lies outside of areaRect) */
+    int getPadding();
+
+    /** return geo bounds of the area within the padding */
+    BoundingBox getAreaRect();
+
+    enum Border {
+        WEST(true), NORTH(false), EAST(true), SOUTH(false);
+
+        public final boolean vertical;
+        Border(boolean vertical) {
+            this.vertical = vertical;
+        };
+
+    }
+}

--- a/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidGraphicFactory.java
+++ b/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidGraphicFactory.java
@@ -38,6 +38,7 @@ import org.mapsforge.core.graphics.ResourceBitmap;
 import org.mapsforge.core.graphics.TileBitmap;
 import org.mapsforge.core.mapelements.PointTextContainer;
 import org.mapsforge.core.mapelements.SymbolContainer;
+import org.mapsforge.core.model.BoundingBox;
 import org.mapsforge.core.model.Point;
 import org.mapsforge.map.model.DisplayModel;
 
@@ -225,8 +226,8 @@ public final class AndroidGraphicFactory implements GraphicFactory {
     }
 
     @Override
-    public Bitmap createMonoBitmap(int width, int height, byte[] buffer) {
-        AndroidBitmap androidBitmap = new AndroidBitmap(width, height, MONO_ALPHA_BITMAP);
+    public AndroidHillshadingBitmap createMonoBitmap(int width, int height, byte[] buffer, int padding, BoundingBox area) {
+        AndroidHillshadingBitmap androidBitmap = new AndroidHillshadingBitmap(width+2*padding, height+2*padding, padding, area);
         if (buffer != null) {
             Buffer b = ByteBuffer.wrap(buffer);
             androidBitmap.bitmap.copyPixelsFromBuffer(b);

--- a/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidHillshadingBitmap.java
+++ b/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidHillshadingBitmap.java
@@ -1,0 +1,31 @@
+package org.mapsforge.map.android.graphics;
+
+import org.mapsforge.core.graphics.HillshadingBitmap;
+import org.mapsforge.core.model.BoundingBox;
+
+/**
+ * Created by usrusr on 28.02.2017.
+ */
+public class AndroidHillshadingBitmap extends AndroidBitmap implements HillshadingBitmap{
+    private final int padding;
+    private final BoundingBox areaRect;
+
+    public AndroidHillshadingBitmap(int width, int height, int padding, BoundingBox areaRect) {
+        super(width, height, AndroidGraphicFactory.MONO_ALPHA_BITMAP);
+
+        this.padding = padding;
+        this.areaRect = areaRect;
+    }
+
+    @Override
+    public int getPadding() {
+        return padding;
+    }
+
+    @Override
+    public BoundingBox getAreaRect() {
+        return areaRect;
+    }
+
+
+}

--- a/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/graphics/AwtCanvas.java
+++ b/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/graphics/AwtCanvas.java
@@ -51,6 +51,8 @@ class AwtCanvas implements Canvas {
     private BufferedImage bufferedImage;
     private Graphics2D graphics2D;
     private BufferedImageOp grayscaleOp, invertOp, invertOp4;
+    private AffineTransform transform = new AffineTransform();
+    private final static java.awt.Color neutralHills = new java.awt.Color(127, 127, 127);
 
     private static Map.Entry<Float, Composite> sizeOneShadingCompositeCache = null;
 
@@ -81,8 +83,8 @@ class AwtCanvas implements Canvas {
      * might be a bit slow and/or inconsistent with the android implementation)
      */
     private static Composite selectHillShadingComposite(float magnitude) {
-        return new AwtLuminanceShadingComposite(magnitude);
-        // return AlphaComposite.getInstance(AlphaComposite.SRC_ATOP, magnitude);
+//        return new AwtLuminanceShadingComposite(magnitude);
+         return AlphaComposite.getInstance(AlphaComposite.SRC_ATOP, magnitude);
     }
 
     AwtCanvas() {
@@ -350,14 +352,43 @@ class AwtCanvas implements Canvas {
     public void shadeBitmap(Bitmap bitmap, Rectangle shadeRect, Rectangle tileRect, float magnitude) {
         Composite oldComposite = this.graphics2D.getComposite();
         Composite composite = getHillshadingComposite(magnitude);
-
         this.graphics2D.setComposite(composite);
-        BufferedImage bufferedImage = AwtGraphicFactory.getBitmap(bitmap);
 
-        this.graphics2D.drawImage(bufferedImage,
-                (int) tileRect.left, (int) tileRect.top, (int) tileRect.right, (int) tileRect.bottom,
-                (int) shadeRect.left, (int) shadeRect.top, (int) shadeRect.right, (int) shadeRect.bottom,
-                null);
+        if(bitmap==null){
+            // apply flat shading
+            if(tileRect!=null){
+                this.graphics2D.setClip(
+                        (int)Math.round(tileRect.left), (int)Math.round(tileRect.top),
+                        (int)Math.round(tileRect.right-(int)tileRect.left),(int)Math.round(tileRect.bottom) - (int)Math.round(tileRect.top) // subtract in after rounding to get same error as on neighbor tile
+                );
+            }
+            this.graphics2D.setColor(neutralHills);
+            this.graphics2D.fillRect(0, 0, getWidth(), getHeight());
+            this.graphics2D.setComposite(oldComposite);
+            this.graphics2D.setClip(null);
+            return;
+        }
+
+
+
+
+
+        BufferedImage bufferedImage = AwtGraphicFactory.getBitmap(bitmap);
+        transform.setToIdentity();
+
+        double horizontalScale = tileRect.getWidth() / shadeRect.getWidth();
+        double verticalScale = tileRect.getHeight() / shadeRect.getHeight();
+
+        transform.translate(tileRect.left, tileRect.top);
+        transform.scale(horizontalScale, verticalScale);
+        transform.translate(-shadeRect.left, -shadeRect.top);
+
+        this.graphics2D.setClip(
+                (int)Math.round(tileRect.left), (int)Math.round(tileRect.top),
+                (int)Math.round(tileRect.right-(int)tileRect.left),(int)Math.round(tileRect.bottom) - (int)Math.round(tileRect.top) // subtract in after rounding to get same error as on neighbor tile
+        );
+        this.graphics2D.drawRenderedImage(bufferedImage,transform);
+        this.graphics2D.setClip(null);
 
         this.graphics2D.setComposite(oldComposite);
     }

--- a/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/graphics/AwtGraphicFactory.java
+++ b/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/graphics/AwtGraphicFactory.java
@@ -35,6 +35,7 @@ import org.mapsforge.core.graphics.ResourceBitmap;
 import org.mapsforge.core.graphics.TileBitmap;
 import org.mapsforge.core.mapelements.PointTextContainer;
 import org.mapsforge.core.mapelements.SymbolContainer;
+import org.mapsforge.core.model.BoundingBox;
 import org.mapsforge.core.model.Point;
 
 import java.awt.Graphics;
@@ -64,7 +65,6 @@ public class AwtGraphicFactory implements GraphicFactory {
          **/
         byte[] linear = new byte[256];
         for (int i = 0; i < 256; i++) {
-            linear[i] = (byte) (i + Byte.MIN_VALUE);
             linear[i] = (byte) (255 - i);
         }
         monoColorModel = new IndexColorModel(8, 256, linear, linear, linear);
@@ -161,14 +161,14 @@ public class AwtGraphicFactory implements GraphicFactory {
     }
 
     @Override
-    public Bitmap createMonoBitmap(int width, int height, byte[] buffer) {
+    public AwtHillshadingBitmap createMonoBitmap(int width, int height, byte[] buffer, int padding, BoundingBox area) {
         DataBuffer dataBuffer = new DataBufferByte(buffer, buffer.length);
 
-        SampleModel singleByteSampleModel = monoColorModel.createCompatibleSampleModel(width, height);
+        SampleModel singleByteSampleModel = monoColorModel.createCompatibleSampleModel(width+2*padding, height+2*padding);
         WritableRaster writableRaster = Raster.createWritableRaster(singleByteSampleModel, dataBuffer, null);
         BufferedImage bufferedImage = new BufferedImage(monoColorModel, writableRaster, false, null);
 
-        return new AwtBitmap(bufferedImage);
+        return new AwtHillshadingBitmap(bufferedImage, padding, area);
     }
 
     @Override

--- a/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/graphics/AwtHillshadingBitmap.java
+++ b/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/graphics/AwtHillshadingBitmap.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 usrusr
+ *
+ * This program is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.mapsforge.map.awt.graphics;
+
+import org.mapsforge.core.graphics.HillshadingBitmap;
+import org.mapsforge.core.model.BoundingBox;
+
+import java.awt.image.BufferedImage;
+
+/**
+ * Created by usrusr on 16.03.2017.
+ */
+public class AwtHillshadingBitmap  extends AwtBitmap implements HillshadingBitmap {
+    private final int padding;
+    private final BoundingBox areaRect;
+
+    public AwtHillshadingBitmap(BufferedImage bufferedImage, int padding, BoundingBox areaRect) {
+        super(bufferedImage);
+
+        this.padding = padding;
+        this.areaRect = areaRect;
+    }
+
+    @Override
+    public int getPadding() {
+        return padding;
+    }
+
+    @Override
+    public BoundingBox getAreaRect() {
+        return areaRect;
+    }
+
+
+}

--- a/mapsforge-map-awt/src/test/java/org/mapsforge/map/layer/hills/HgtCacheTest.java
+++ b/mapsforge-map-awt/src/test/java/org/mapsforge/map/layer/hills/HgtCacheTest.java
@@ -1,0 +1,145 @@
+package org.mapsforge.map.layer.hills;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.mapsforge.core.graphics.Canvas;
+import org.mapsforge.core.graphics.HillshadingBitmap;
+import org.mapsforge.core.model.BoundingBox;
+import org.mapsforge.map.awt.graphics.AwtGraphicFactory;
+import org.mapsforge.map.awt.graphics.AwtHillshadingBitmap;
+
+import java.awt.image.BufferedImage;
+import java.awt.image.Raster;
+
+public class HgtCacheTest {
+    @Test public void testMerge(){
+        AwtGraphicFactory factory = new AwtGraphicFactory();
+        byte[] even = new byte[]{
+                0,2,4,6,0,
+                2,2,4,6,6,
+                8,8,10,12,12,
+                14,14,16,18,18,
+                0,14,16,18,0
+        };
+
+
+        byte[] odd = new byte[]{
+                0,1,3,5,0,
+                1,1,3,5,5,
+                7,7,9,11,11,
+                13,13,15,17,17,
+                0,13,15,17,0
+        };
+        AwtHillshadingBitmap evens = factory.createMonoBitmap(3, 3, even, 1, new BoundingBox(0, 1, 0, 1));
+        AwtHillshadingBitmap odds = factory.createMonoBitmap(3, 3, odd, 1, new BoundingBox(0, 1, 0, 1));
+        Canvas canvas = factory.createCanvas();
+
+        HgtCache.mergeSameSized(evens, odds, HillshadingBitmap.Border.EAST, 1, canvas);
+
+        Assert.assertEquals("\n" +
+                "     0:        0   2   4   6   0\n" +
+                "     1:        2   2   4   6   1\n" +
+                "     2:        8   8  10  12   7\n" +
+                "     3:       14  14  16  18  13\n" +
+                "     4:        0  14  16  18   0", logbytes(evens));
+//        Assert.assertEquals("\n" +
+//                "     0:        0   1   3   5   0\n" +
+//                "     1:        6   1   3   5   5\n" +
+//                "     2:       12   7   9  11  11\n" +
+//                "     3:       18  13  15  17  17\n" +
+//                "     4:        0  13  15  17   0", logbytes(odds));
+
+
+
+        HgtCache.mergeSameSized(evens, odds, HillshadingBitmap.Border.NORTH, 1, canvas);
+
+        Assert.assertEquals("\n" +
+                "     0:        0  13  15  17   0\n" +
+                "     1:        2   2   4   6   1\n" +
+                "     2:        8   8  10  12   7\n" +
+                "     3:       14  14  16  18  13\n" +
+                "     4:        0  14  16  18   0", logbytes(evens));
+//        Assert.assertEquals("\n" +
+//                "     0:        0   1   3   5   0\n" +
+//                "     1:        6   1   3   5   5\n" +
+//                "     2:       12   7   9  11  11\n" +
+//                "     3:       18  13  15  17  17\n" +
+//                "     4:        0   2   4   6   0", logbytes(odds));
+
+
+
+
+        HgtCache.mergeSameSized(evens, odds, HillshadingBitmap.Border.WEST, 1, canvas);
+
+        Assert.assertEquals("\n" +
+                "     0:        0  13  15  17   0\n" +
+                "     1:        5   2   4   6   1\n" +
+                "     2:       11   8  10  12   7\n" +
+                "     3:       17  14  16  18  13\n" +
+                "     4:        0  14  16  18   0", logbytes(evens));
+//        Assert.assertEquals("\n" +
+//                "     0:        0   1   3   5   0\n" +
+//                "     1:        6   1   3   5   2\n" +
+//                "     2:       12   7   9  11   8\n" +
+//                "     3:       18  13  15  17  14\n" +
+//                "     4:        0   2   4   6   0", logbytes(odds));
+
+
+
+
+
+        HgtCache.mergeSameSized(evens, odds, HillshadingBitmap.Border.SOUTH, 1, canvas);
+
+        Assert.assertEquals("\n" +
+                "     0:        0  13  15  17   0\n" +
+                "     1:        5   2   4   6   1\n" +
+                "     2:       11   8  10  12   7\n" +
+                "     3:       17  14  16  18  13\n" +
+                "     4:        0   1   3   5   0", logbytes(evens));
+//        Assert.assertEquals("\n" +
+//                "     0:        0  14  16  18   0\n" +
+//                "     1:        6   1   3   5   2\n" +
+//                "     2:       12   7   9  11   8\n" +
+//                "     3:       18  13  15  17  14\n" +
+//                "     4:        0   2   4   6   0", logbytes(odds));
+    }
+
+
+
+    private String logbytes(AwtHillshadingBitmap fresh) {
+//        try {
+//            Class<?> superclass = fresh.getClass().getSuperclass();
+//            Field bufferedImage = superclass.getDeclaredField("bufferedImage");
+//            bufferedImage.setAccessible(true);
+//            BufferedImage bi = (BufferedImage) bufferedImage.get(fresh);
+            BufferedImage bi = AwtGraphicFactory.getBitmap(fresh);
+            Raster data = bi.getData();
+            StringBuilder sb = new StringBuilder();
+            for(int y=0;y<data.getHeight();y+=(y==4 && y<data.getHeight()/2 ? data.getHeight()-8:1)) {
+                if(y==4 && y<data.getHeight()/2 ) {
+                    sb.append("\n");
+                    continue;
+                }
+                sb.append("\n").append(String.format(" %5d", y)).append(":     ");
+                for(int x=0;x<data.getWidth();x+=(x==4 & x<data.getWidth()/2 ?data.getWidth()-8:1)) {
+                    if(x==4 & x<data.getWidth()/2) {
+                        sb.append("   ");
+                        continue;
+                    }
+                    int sample = data.getSample(x, y, 0);
+                    sb.append(String.format(" %3d", sample));
+                }
+
+            }
+
+
+//        } catch (NoSuchFieldException e) {
+//            e.printStackTrace();
+//        } catch (IllegalAccessException e) {
+//            e.printStackTrace();
+//        }
+
+        return sb.toString();
+    }
+}

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/HgtCache.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/HgtCache.java
@@ -1,0 +1,514 @@
+/*
+ * Copyright 2017 usrusr
+ *
+ * This program is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.mapsforge.map.layer.hills;
+
+import org.mapsforge.core.graphics.Canvas;
+import org.mapsforge.core.graphics.GraphicFactory;
+import org.mapsforge.core.graphics.HillshadingBitmap;
+import org.mapsforge.core.model.BoundingBox;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+class HgtCache {
+    final File demFolder;
+    final boolean interpolatorOverlap;
+    final ShadingAlgorithm algorithm;
+    final int mainCacheSize;
+    final int neighborCacheSize;
+
+    private final GraphicFactory graphicsFactory;
+
+    final private Lru secondaryLru;
+    final private Lru mainLru;
+
+    private LazyFuture<Map<TileKey, HgtFileInfo>> hgtFiles;
+
+
+    protected final static class TileKey {
+        final int north;
+        final int east;
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
+
+            TileKey tileKey = (TileKey) o;
+
+            return north == tileKey.north && east == tileKey.east;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = north;
+            result = 31 * result + east;
+            return result;
+        }
+
+        TileKey(int north, int east) {
+            this.east = east;
+            this.north = north;
+        }
+    }
+
+    class Lru {
+        final int size;
+        final private LinkedHashSet<Future<HillshadingBitmap>> lru;
+
+        Lru(int size) {
+            this.size = size;
+            lru = size>0?new LinkedHashSet<Future<HillshadingBitmap>>():null;
+        }
+        /** @param freshlyUsed the entry that should be marked as freshly used
+         * @return the evicted entry, which is freshlyUsed if size is 0
+         */
+        Future<HillshadingBitmap> markUsed(Future<HillshadingBitmap> freshlyUsed){
+            if (size > 0 && freshlyUsed!=null) {
+                synchronized (lru) {
+                    lru.remove(freshlyUsed);
+                    lru.add(freshlyUsed);
+                    if(lru.size()>size){
+                        Iterator<Future<HillshadingBitmap>> iterator = lru.iterator();
+                        Future<HillshadingBitmap> evicted = iterator.next();
+                        iterator.remove();
+                        return evicted;
+                    }
+                    return null;
+                }
+            }
+            return freshlyUsed;
+        }
+        void evict(Future<HillshadingBitmap> loadingFuture){
+            if (size > 0) {
+                synchronized (lru) {
+                    lru.add(loadingFuture);
+                }
+            }
+        }
+    }
+
+    private List<String> problems = new ArrayList<>();
+
+    HgtCache(File demFolder, boolean interpolationOverlap, GraphicFactory graphicsFactory, ShadingAlgorithm algorithm, int mainCacheSize, int neighborCacheSize) {
+        this.demFolder = demFolder;
+        this.interpolatorOverlap = interpolationOverlap;
+        this.graphicsFactory = graphicsFactory;
+        this.algorithm = algorithm;
+        this.mainCacheSize = mainCacheSize;
+        this.neighborCacheSize = neighborCacheSize;
+
+        mainLru = new Lru(this.mainCacheSize);
+        secondaryLru = (interpolatorOverlap ? new Lru(neighborCacheSize) : null);
+
+        hgtFiles = new LazyFuture<Map<TileKey,HgtFileInfo>>() {
+            @Override protected Map<TileKey, HgtFileInfo> calculate() throws ExecutionException, InterruptedException {
+                Map<TileKey, HgtFileInfo> map = new HashMap<>();
+                Matcher matcher = Pattern.compile("([ns])(\\d{1,2})([ew])(\\d{1,3})\\.hgt", Pattern.CASE_INSENSITIVE).matcher("");
+                crawl(HgtCache.this.demFolder, matcher, map, problems);
+                return map;
+            }
+
+            void crawl(File file, Matcher matcher, Map<TileKey, HgtFileInfo> map, List<String> problems) {
+                if (file.exists()) {
+                    if (file.isFile()) {
+                        String name = file.getName();
+                        if (matcher.reset(name).matches()) {
+                            int northsouth = Integer.parseInt(matcher.group(2));
+                            int eastwest = Integer.parseInt(matcher.group(4));
+
+                            int north = "n".equals(matcher.group(1).toLowerCase()) ? northsouth : -northsouth;
+                            int east = "e".equals(matcher.group(3).toLowerCase()) ? eastwest : -eastwest;
+
+                            long length = file.length();
+                            long heights = length / 2;
+                            long sqrt = (long) Math.sqrt(heights);
+                            if (sqrt * sqrt != heights) {
+                                if (problems != null)
+                                    problems.add(file + " length in shorts (" + heights + ") is not a square number");
+                            } else {
+                                TileKey tileKey = new TileKey(north, east);
+                                HgtFileInfo existing = map.get(tileKey);
+                                if (existing == null || existing.size < length) {
+//                                hgtFiles.put(tileKey, new HgtFileInfo(file, east, north, east+1, north-1));
+                                    map.put(tileKey, new HgtFileInfo(file, north-1, east, north, east+1 ));
+                                }
+                            }
+                        }
+                    } else if (file.isDirectory()) {
+                        File[] files = file.listFiles();
+                        if(files!=null) {
+                            for (File sub : files) {
+                                crawl(sub, matcher, map, problems);
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+    }
+    void indexOnThread() {
+        hgtFiles.withRunningThread();
+    }
+
+
+    class LoadUnmergedFuture extends LazyFuture<HillshadingBitmap> {
+        private final HgtFileInfo hgtFileInfo;
+
+        LoadUnmergedFuture(HgtFileInfo hgtFileInfo) {
+            this.hgtFileInfo = hgtFileInfo;
+        }
+
+        public HillshadingBitmap calculate() {
+            ShadingAlgorithm.RawShadingResult raw = algorithm.transformToByteBuffer(hgtFileInfo, HgtCache.this.interpolatorOverlap?1:0);
+
+            // is this really necessary? Maybe, if some downscaling is filtered and rounding is not as expected
+            raw.fillPadding();
+
+            return graphicsFactory.createMonoBitmap(raw.width, raw.height, raw.bytes, raw.padding, hgtFileInfo);
+        }
+    }
+
+    /* */
+    class MergeOverlapFuture extends LazyFuture<HillshadingBitmap> {
+        final LoadUnmergedFuture loadFuture;
+        private HgtFileInfo hgtFileInfo;
+
+        MergeOverlapFuture(HgtFileInfo hgtFileInfo, LoadUnmergedFuture loadFuture){
+
+            this.hgtFileInfo = hgtFileInfo;
+            this.loadFuture = loadFuture;
+        }
+
+        MergeOverlapFuture(HgtFileInfo hgtFileInfo) {
+            this(hgtFileInfo, new LoadUnmergedFuture(hgtFileInfo));
+        }
+
+        public HillshadingBitmap calculate() throws ExecutionException, InterruptedException {
+            HillshadingBitmap monoBitmap = loadFuture.get();
+
+            for(HillshadingBitmap.Border border : HillshadingBitmap.Border.values()) {
+                HgtFileInfo neighbor = hgtFileInfo.getNeighbor(border);
+                mergePaddingOnBitmap(monoBitmap, neighbor, border);
+            }
+
+            return monoBitmap;
+        }
+
+        private void mergePaddingOnBitmap(HillshadingBitmap fresh, HgtFileInfo neighbor, HillshadingBitmap.Border border) {
+            int padding = fresh.getPadding();
+
+            if(padding <1) return;
+            if(neighbor!=null){
+                Future<HillshadingBitmap> neighborUnmergedFuture = neighbor.getUnmergedAsMergePartner();
+                if(neighborUnmergedFuture!=null){
+                    try {
+                        HillshadingBitmap other = neighborUnmergedFuture.get();
+                        Canvas copyCanvas=graphicsFactory.createCanvas();
+
+                        mergeSameSized(fresh, other, border, padding, copyCanvas);
+
+                    } catch (InterruptedException | ExecutionException e) {
+                        e.printStackTrace();
+                    }
+                }
+            }
+        }
+    }
+
+
+    class HgtFileInfo extends BoundingBox implements ShadingAlgorithm.RawHillTileSource {
+        final File file;
+        WeakReference<Future<HillshadingBitmap>> weakRef = null;
+
+        final long size;
+
+        HgtFileInfo(File file, double minLatitude, double minLongitude, double maxLatitude, double maxLongitude) {
+            super(minLatitude, minLongitude, maxLatitude, maxLongitude);
+            this.file = file;
+            size = file.length();
+        }
+
+        Future<HillshadingBitmap> getBitmapFuture(double pxPerLat, double pxPerLng){
+            if (HgtCache.this.interpolatorOverlap) {
+
+                int axisLen = algorithm.getAxisLenght(this);
+                if(pxPerLat>axisLen || pxPerLng > axisLen){
+                    return getForHires();
+                } else {
+                    return getForLores();
+                }
+            } else {
+                return getForLores();
+            }
+        }
+
+
+        /**
+         * for zoomed in view (if padding): merged or unmerged padding for padding merge of a neighbor
+         * @return MergeOverlapFuture or LoadUnmergedFuture as available
+         */
+        private MergeOverlapFuture getForHires() {
+            final WeakReference<Future<HillshadingBitmap>> weak = this.weakRef;
+            Future<HillshadingBitmap> candidate = weak ==null?null: weak.get();
+
+            final MergeOverlapFuture ret;
+            if(candidate instanceof MergeOverlapFuture) {
+                ret = ((MergeOverlapFuture) candidate);
+            }else if(candidate instanceof LoadUnmergedFuture) {
+                LoadUnmergedFuture loadFuture = (LoadUnmergedFuture) candidate;
+                ret = new MergeOverlapFuture(this, loadFuture);
+                this.weakRef = new WeakReference<Future<HillshadingBitmap>>(ret);
+                secondaryLru.evict(loadFuture);  // candidate will henceforth be referenced via created (until created is gone)
+            }else{
+                ret = new MergeOverlapFuture(this);
+//logLru("new merged", mainLru, ret);
+                weakRef = new WeakReference<Future<HillshadingBitmap>>(ret);
+            }
+            mainLru.markUsed(ret);
+
+//logLru("merged", mainLru, ret);
+            return ret;
+        }
+
+        /**
+         * for zoomed in view (if padding): merged or unmerged padding for padding merge of a neighbor
+         * @return MergeOverlapFuture or LoadUnmergedFuture as available
+         */
+        private LoadUnmergedFuture getUnmergedAsMergePartner() {
+            final WeakReference<Future<HillshadingBitmap>> weak = this.weakRef;
+            Future<HillshadingBitmap> candidate = weak ==null?null: weak.get();
+
+
+            final LoadUnmergedFuture ret;
+            if (candidate instanceof LoadUnmergedFuture) {
+                secondaryLru.markUsed(candidate);
+                ret = (LoadUnmergedFuture) candidate;
+            } else if (candidate instanceof MergeOverlapFuture) {
+                mainLru.markUsed(candidate);
+                ret = ((MergeOverlapFuture) candidate).loadFuture;
+            } else {
+                final LoadUnmergedFuture created = new LoadUnmergedFuture(this);
+                this.weakRef = new WeakReference<Future<HillshadingBitmap>>(created);
+                secondaryLru.markUsed(created);
+                ret = created;
+            }
+            return ret;
+        }
+
+        /**
+         * for zoomed out view (or all resolutions, if no padding): merged or unmerged padding, primary LRU spilling over to secondary (if available)
+         * @return MergeOverlapFuture or LoadUnmergedFuture as available
+         */
+        private Future<HillshadingBitmap> getForLores() {
+            final WeakReference<Future<HillshadingBitmap>> weak = this.weakRef;
+            Future<HillshadingBitmap> candidate = weak ==null?null: weak.get();
+
+            if(candidate==null){
+                candidate = new LoadUnmergedFuture(this);
+                this.weakRef = new WeakReference<>(candidate);
+            }
+            Future<HillshadingBitmap> evicted = mainLru.markUsed(candidate);
+            if(secondaryLru!=null) secondaryLru.markUsed(evicted);
+            return candidate;
+        }
+
+        @Override
+        public HillshadingBitmap getFinishedConverted() {
+            WeakReference<Future<HillshadingBitmap>> weak = this.weakRef;
+            if(weak!=null){
+                Future<HillshadingBitmap> hillshadingBitmapFuture = weak.get();
+                if(hillshadingBitmapFuture!=null && hillshadingBitmapFuture.isDone()){
+                    try {
+                        return hillshadingBitmapFuture.get();
+                    } catch (InterruptedException | ExecutionException e) {
+                        e.printStackTrace();
+                    }
+                }
+            }
+            return null;
+        }
+        @Override
+        public long getSize() {
+            return size;
+        }
+
+        @Override
+        public BufferedInputStream openInputStream() throws IOException {
+            return new BufferedInputStream(new FileInputStream(file));
+        }
+
+
+        @Override
+        public double northLat() {
+            return maxLatitude;
+        }
+
+        @Override
+        public double southLat() {
+            return minLatitude;
+        }
+
+        @Override
+        public double westLng() {
+            return minLongitude;
+        }
+
+        @Override
+        public double eastLng() {
+            return maxLongitude;
+        }
+
+        private HgtFileInfo getNeighbor(HillshadingBitmap.Border border) throws ExecutionException, InterruptedException {
+
+            Map<TileKey, HgtFileInfo> map = hgtFiles.get();
+            switch (border) {
+                case NORTH:
+                    return map.get(new TileKey((int) maxLatitude + 1, (int) minLongitude));
+                case SOUTH:
+                    return map.get(new TileKey((int)maxLatitude - 1, (int)minLongitude));
+                case EAST:
+                    return map.get(new TileKey((int)maxLatitude, (int)minLongitude + 1));
+                case WEST:
+                    return map.get(new TileKey((int)maxLatitude, (int)minLongitude - 1));
+            }
+            return null;
+        }
+
+        @Override
+        public String toString() {
+            Future<HillshadingBitmap> future = weakRef==null?null:weakRef.get();
+            return "[lt:"+minLatitude+"-"+maxLatitude+" ln:"+minLongitude+"-"+maxLongitude+(future ==null?"": future.isDone()?"done":"wip")+"]";
+        }
+    }
+
+
+    HillshadingBitmap getHillshadingBitmap(int northInt, int eastInt, double pxPerLat, double pxPerLng) throws InterruptedException, ExecutionException {
+        HgtFileInfo hgtFileInfo = hgtFiles.get().get(new TileKey(northInt, eastInt));
+        if (hgtFileInfo == null)
+            return null;
+
+        Future<HillshadingBitmap> future = hgtFileInfo.getBitmapFuture(pxPerLat, pxPerLng);
+        return future.get();
+    }
+
+    static void mergeSameSized(HillshadingBitmap center, HillshadingBitmap neighbor, HillshadingBitmap.Border border, int padding, Canvas copyCanvas) {
+        HillshadingBitmap sink;
+        HillshadingBitmap source;
+
+        if (border == HillshadingBitmap.Border.EAST) {
+            sink = center; source = neighbor;
+            copyCanvas.setBitmap(sink);
+            copyCanvas.setClip(sink.getWidth()-padding, padding, padding, sink.getHeight() - 2 * padding);
+            copyCanvas.drawBitmap(source, (source.getWidth() - 2 * padding), 0);
+        } else if (border == HillshadingBitmap.Border.WEST) {
+            sink = center; source = neighbor;
+            copyCanvas.setBitmap(sink);
+            copyCanvas.setClip(0, padding, padding, sink.getHeight() - 2 * padding);
+            copyCanvas.drawBitmap(source, 2 * padding -(source.getWidth()), 0);
+        } else if (border == HillshadingBitmap.Border.NORTH) {
+            sink = center; source = neighbor;
+            copyCanvas.setBitmap(sink);
+            copyCanvas.setClip(padding, 0, sink.getWidth() - 2 * padding, padding);
+            copyCanvas.drawBitmap(source, 0, 2 * padding -(source.getHeight()));
+        } else if (border == HillshadingBitmap.Border.SOUTH) {
+            sink = center; source = neighbor;
+            copyCanvas.setBitmap(sink);
+            copyCanvas.setClip(padding, sink.getHeight()-padding, sink.getWidth() - 2 * padding, padding);
+            copyCanvas.drawBitmap(source, 0, (source.getHeight() - 2 * padding));
+        }
+    }
+
+//    private void logLru(String merged, Lru lru, Future<HillshadingBitmap> ret) {
+//        try {
+//            StringBuilder sb = new StringBuilder();
+//            sb.append(merged).append("\n  LRU: ");
+//            synchronized (lru.lru) {
+//                for (Future<HillshadingBitmap> f : lru.lru){
+//                    sb.append("   E#"+System.identityHashCode(f));
+//                }
+//                sb.append("\n  ");
+//                for(HgtFileInfo hgt : hgtFiles.get().values()){
+//                    WeakReference<Future<HillshadingBitmap>> weakRef = hgt.weakRef;
+//                    if(weakRef!=null){
+//                        Future<HillshadingBitmap> f = weakRef.get();
+//                        if(f!=null){
+//                            sb.append("  ").append(f.getClass().getSimpleName().substring(0,3));
+//                            sb.append("#").append(System.identityHashCode(f));
+//                        }
+//                    }
+//                }
+//            }
+//            System.out.println("\n"+sb+"\n");
+//        }  catch(RuntimeException e){
+//            e.printStackTrace();
+//        } catch (InterruptedException e) {
+//            e.printStackTrace();
+//        } catch (ExecutionException e) {
+//            e.printStackTrace();
+//        }
+//    }
+
+
+//    private static void logbytes(HillshadingBitmap fresh, String msg) {
+//        try {
+//            Class<?> superclass = fresh.getClass().getSuperclass();
+//            Field bufferedImage = superclass.getDeclaredField("bufferedImage");
+//            bufferedImage.setAccessible(true);
+//            BufferedImage bi = (BufferedImage) bufferedImage.get(fresh);
+//            Raster data = bi.getData();
+//            StringBuilder sb = new StringBuilder();
+//            for(int y=0;y<data.getHeight();y+=(y==4?data.getHeight()-8:1)) {
+//                if(y==4) {
+//                    sb.append("\n");
+//                    continue;
+//                }
+//                sb.append("\n").append(String.format(" %5d", y)).append(":     ");
+//                for(int x=0;x<data.getWidth();x+=(x==4?data.getWidth()-8:1)) {
+//                    if(x==4) {
+//                        sb.append("   ");
+//                        continue;
+//                    }
+//                    int sample = data.getSample(x, y, 0);
+//                    sb.append(String.format(" %3d", sample));
+//                }
+//
+//            }
+//            System.out.println(msg+" sample: "+fresh.getAreaRect()+sb);
+//
+//        } catch (NoSuchFieldException e) {
+//            e.printStackTrace();
+//        } catch (IllegalAccessException e) {
+//            e.printStackTrace();
+//        }
+//
+//    }
+}

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/LazyFuture.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/LazyFuture.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2017 usrusr
+ *
+ * This program is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.mapsforge.map.layer.hills;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * a simple calculation future for cross-thread result sharing and optional eager parallelism via {@link #withRunningThread()}
+ * @param <X> result type
+ */
+public abstract class LazyFuture<X> implements Future<X> {
+    private static class DummyExecutionException extends ExecutionException {
+        DummyExecutionException(String name){
+            super(name, null);
+        }
+        /** static instances don't need a stacktrace */
+        @Override public synchronized Throwable fillInStackTrace() {
+            return null;
+        }
+        @Override public String toString() {
+            return "[state marker "+getMessage()+"]";
+        }
+    }
+    private static final ExecutionException STARTED = new DummyExecutionException("started");
+    private static final ExecutionException CANCELLED = new DummyExecutionException("cancelled");
+    private static final ExecutionException DONE = new DummyExecutionException("done");
+
+    /** can hold null (not even started), STARTED, CANCELLED, DONE or an actual exception */
+    private final AtomicReference<ExecutionException> state=new AtomicReference<>(null);
+
+    private final CountDownLatch latch = new CountDownLatch(1);
+    private volatile X result;
+    private volatile Thread thread;
+
+    @Override
+    public boolean cancel(boolean mayInterruptIfRunning) {
+        if(state.get()==CANCELLED) return true;
+        if(state.get()==DONE) return false;
+        if(mayInterruptIfRunning) {
+            Thread t = this.thread;
+            if(t !=null && state.compareAndSet(STARTED, CANCELLED)){
+                t.interrupt();
+                return true;
+            }
+        }
+        return state.compareAndSet(null, CANCELLED);
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return state.get()==CANCELLED;
+    }
+
+    @Override
+    public boolean isDone() {
+        ExecutionException state = this.state.get();
+        return state!=null && state!=STARTED;
+    }
+
+    @Override
+    public X get() throws InterruptedException, ExecutionException {
+        if (state.compareAndSet(null, STARTED)) {
+            internalCalc();
+        } else {
+            latch.await();
+        }
+        throwIfException();
+        return result;
+    }
+    private void throwIfException() throws ExecutionException{
+        ExecutionException executionException = state.get();
+        if(executionException!=null && ! (executionException instanceof DummyExecutionException)) throw executionException;
+    }
+    @Override
+    public X get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        if (state.compareAndSet(null, STARTED)) {
+            internalCalc();
+        } else {
+            latch.await(timeout, unit);
+        }
+        throwIfException();
+        return result;
+    }
+    private void internalCalc() throws ExecutionException, InterruptedException {
+        thread = Thread.currentThread();
+        try {
+            result = calculate();
+            state.compareAndSet(STARTED, DONE);
+        }catch (RuntimeException e){
+            state.compareAndSet(STARTED, new ExecutionException(e));
+        }catch (ExecutionException e){
+            state.compareAndSet(STARTED, e);
+        } finally {
+            thread =null;
+            latch.countDown();
+        }
+    }
+
+    protected abstract X calculate() throws ExecutionException, InterruptedException;
+
+    /**
+     * spawns a new thread if not already started or done (otherwise, calculation happens in the first get call)
+     * @return this for chaining */
+    public LazyFuture<X> withRunningThread(){
+        if( state.get()==DONE) return this;
+        if (state.compareAndSet(null, STARTED)) {
+            Thread thread = new Thread(LazyFuture.this.getClass().getName() + ".withRunningThread") {
+                @Override
+                public void run() {
+                    try {
+                        LazyFuture.this.internalCalc();
+                    } catch (ExecutionException | InterruptedException e) {
+                        e.printStackTrace();
+                    }
+                }
+            };
+            thread.start();
+
+            return this;
+        } else {
+            return this;
+        }
+    }
+}

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/ShadingAlgorithm.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/ShadingAlgorithm.java
@@ -14,16 +14,120 @@
  */
 package org.mapsforge.map.layer.hills;
 
-import org.mapsforge.core.graphics.Bitmap;
-import org.mapsforge.core.graphics.GraphicFactory;
+import org.mapsforge.core.graphics.HillshadingBitmap;
 
 import java.io.BufferedInputStream;
 import java.io.IOException;
 
 public interface ShadingAlgorithm {
 
-    Bitmap convertTile(RawHillTileSource source, GraphicFactory graphicFactory);
+//    HillshadingBitmap convertTile(RawHillTileSource source, GraphicFactory graphicFactory);
 
+    int getAxisLenght(HgtCache.HgtFileInfo source);
+
+    RawShadingResult transformToByteBuffer(HgtCache.HgtFileInfo hgtFileInfo, int padding);
+
+    class RawShadingResult {
+        public final byte[] bytes;
+        public final int width;
+        public final int height;
+        public final int padding;
+
+        public RawShadingResult(byte[] bytes, int width, int height, int padding) {
+            this.bytes = bytes;
+            this.width = width;
+            this.height = height;
+            this.padding = padding;
+        }
+
+        /** two-way merge, if padding */
+        public void mergePaddingWith(HillshadingBitmap hillshadingBitmap, HillshadingBitmap.Border side) {
+            if(padding==0) return;
+
+
+        }
+        /** fill padding like clamp */
+        void fillPadding(HillshadingBitmap.Border side) {
+            int innersteps;
+            int skip;
+            int outersteps;
+            int start;
+            int sourceOffset;
+            int sourceOuterStep;
+            int sourceInnerStep;
+            int lineLen = padding * 2 + width;
+            if(side.vertical){
+                innersteps = padding;
+                skip = width+padding;
+                outersteps = height;
+                if(side== HillshadingBitmap.Border.WEST){
+                    start = padding* lineLen; // first col, after padding ignored lines
+                    sourceOffset = start+padding;
+                }else{
+                    start = padding* lineLen + padding+width; // first padding col after padding ignored lines + nearly one line
+                    sourceOffset = start-1;
+                }
+                sourceInnerStep = 0;
+                sourceOuterStep = lineLen;
+            }else{ // horizontal
+                innersteps = width;
+                skip = 2*padding;
+                outersteps = padding;
+                if(side== HillshadingBitmap.Border.NORTH){
+                    start = padding;
+                    sourceOffset = start+padding*lineLen;
+                }else{
+                    start = (height+padding)* lineLen +padding;
+                    sourceOffset = start-lineLen;
+                }
+                sourceInnerStep = 1;
+                sourceOuterStep = - width; // "carriage return"
+            }
+
+            int dest = start;
+            int src = sourceOffset;
+            for(int o=0;o<outersteps;o++){
+
+                for(int i=0;i<innersteps;i++){
+                    bytes[dest] = bytes[src];
+                    dest++;
+                    src+=sourceInnerStep;
+                }
+
+                dest+=skip;
+                src+=sourceOuterStep;
+            }
+        }
+
+        public void fillPadding() {
+            if(padding<1) return;
+            fillPadding(HillshadingBitmap.Border.EAST);
+            fillPadding(HillshadingBitmap.Border.WEST);
+            fillPadding(HillshadingBitmap.Border.NORTH);
+            fillPadding(HillshadingBitmap.Border.SOUTH);
+
+            // fill diagonal padding (this won't be blended with neighbors but the artifacts of that are truely minimal)
+            int lineLen = padding * 2 + width;
+            int widthOncePadded = width + padding;
+            int heightOncePadded = height + padding;
+            byte nw = bytes[lineLen*padding+padding];
+            byte ne = bytes[lineLen*padding+widthOncePadded-1];
+            byte se = bytes[lineLen*(heightOncePadded -1)+padding];
+            byte sw = bytes[lineLen*(heightOncePadded -1)+(widthOncePadded-1)];
+
+            int seOffset = lineLen * heightOncePadded;
+            int swOffset = seOffset + widthOncePadded;
+            for(int y=0;y<padding;y++){
+                int yoff = lineLen * y;
+                for(int x=0;x<padding;x++){
+                    bytes[x+yoff] = nw;
+                    bytes[x+yoff + widthOncePadded ] = ne;
+                    bytes[x+yoff + seOffset ] = se;
+                    bytes[x+yoff + swOffset] = sw;
+                }
+            }
+        }
+    }
     /**
      * Abstracts the file handling and access so that ShadingAlgorithm implementations
      * could run on any height model source (e.g. on an android content provider for
@@ -34,15 +138,19 @@ public interface ShadingAlgorithm {
 
         BufferedInputStream openInputStream() throws IOException;
 
+        /* for overlap */
+        HillshadingBitmap getFinishedConverted();
+
         /**
-         * Just in case someone wants to sacrifice speed for fidelity
+         * A ShadingAlgorithm might want to determine the projected dimensions of the tile
          */
-        RawHillTileSource getNeighborNorth();
+        double northLat();
 
-        RawHillTileSource getNeighborSouth();
+        double southLat();
 
-        RawHillTileSource getNeighborEast();
+        double westLng();
 
-        RawHillTileSource getNeighborWest();
+        double eastLng();
     }
+
 }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/TrigShadingAlgortithm.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/TrigShadingAlgortithm.java
@@ -1,0 +1,128 @@
+//package org.mapsforge.map.layer.hills;
+//
+//import org.mapsforge.core.graphics.Bitmap;
+//import org.mapsforge.core.graphics.GraphicFactory;
+//import org.mapsforge.core.model.LatLong;
+//import org.mapsforge.core.util.IOUtils;
+//import org.mapsforge.core.util.LatLongUtils;
+//
+//import java.io.BufferedInputStream;
+//import java.io.DataInputStream;
+//import java.io.IOException;
+//import java.io.InputStream;
+//import java.util.logging.Level;
+//import java.util.logging.Logger;
+//
+///**
+// * currently just a really stupid slope-to-lightness
+// *
+// * Created by usrusr on 22.01.2017.
+// */
+//public class TrigShadingAlgortithm implements ShadingAlgorithm {
+//    private static final Logger LOGGER = Logger.getLogger(TrigShadingAlgortithm.class.getName());
+//    @Override public Bitmap convertTile(RawHillTileSource source, GraphicFactory graphicFactory){
+//        long size = source.getSize();
+//        long elements = size / 2;
+//        int rowLen = (int) Math.ceil(Math.sqrt(elements));
+//        if(rowLen*rowLen*2!=size) {
+//            return null;
+//        }
+//        BufferedInputStream in=null;
+//        try{
+//
+//            return convert(source, size, graphicFactory);
+//        } catch (IOException e) {
+//            LOGGER.log(Level.FINE, e.getMessage(), e);
+//            return null;
+//        }finally{
+//            IOUtils.closeQuietly(in);
+//        }
+//    }
+//
+//
+//    private static Bitmap convert(RawHillTileSource source, long streamLen, GraphicFactory graphicFactory) throws IOException {
+//        InputStream in = source.openInputStream();
+//        byte[] bytes;
+//        int axisLength;
+//        int rowLen = (int) Math.ceil(Math.sqrt(streamLen/2));
+//
+//
+//        axisLength = rowLen - 1;
+//        short[] ringbuffer = new short[rowLen];
+//        bytes = new byte[axisLength * axisLength];
+//
+//        DataInputStream din = new DataInputStream(in);
+//
+//        double widthLongitude = source.eastLng() - source.westLng();
+//        while(widthLongitude<0) widthLongitude = Math.abs(widthLongitude-360d);
+//        double heightLatitude = source.northLat() - source.southLat();
+//
+//        double pixelWidthNorth = LatLongUtils.sphericalDistance(
+//                new LatLong(source.northLat(), 0)
+//                , new LatLong(source.northLat(), widthLongitude)
+//        );
+//        double pixelWidthSouth = LatLongUtils.sphericalDistance(
+//                new LatLong(source.southLat(), 0)
+//                , new LatLong(source.southLat(), widthLongitude)
+//        );
+//        double pixelHeightNorth = LatLongUtils.sphericalDistance(
+//                new LatLong(source.southLat(), 0)
+//                , new LatLong(source.southLat(), widthLongitude)
+//        );
+//        double pixelHeightSouth = LatLongUtils.sphericalDistance(
+//                new LatLong(source.southLat(), 0)
+//                , new LatLong(source.southLat(), widthLongitude)
+//        );
+//
+//        int outidx = 0;
+//        int rbcur = 0;
+//        {
+//            short last = 0;
+//            for (int col = 0; col < rowLen * 1; col++) {
+//                last = readNext(din, last);
+//                ringbuffer[rbcur++] = last;
+//
+//            }
+//        }
+//        for (int line = 1; line <= axisLength; line++) {
+//            if (rbcur >= rowLen) {
+//                rbcur = 0;
+//            }
+//
+//            short nw = ringbuffer[rbcur];
+//            short sw = readNext(din, nw);
+//            ringbuffer[rbcur++] = sw;
+//
+//
+//            for (int col = 1; col <= axisLength; col++) {
+//
+//                short ne = ringbuffer[rbcur];
+//                short se = readNext(din, ne);
+//                ringbuffer[rbcur++] = se;
+//
+//                int noso = -((se - ne) + (sw - nw));
+//
+//                int eawe = -((ne - nw) + (se - sw));
+//
+//                float avg = ((float)ne+(float)se+(float)nw+(float)sw)/4f;
+//// todo geometry
+//
+//                int intVal = Math.min(255, Math.max(0, noso+eawe+128));
+//
+//                int shade = intVal & 0xFF;
+//
+//                bytes[outidx++] = (byte) shade;
+//
+//                nw = ne;
+//                sw = se;
+//            }
+//        }
+//        return graphicFactory.createMonoBitmap(axisLength, axisLength, bytes, , , , );
+//    }
+//
+//    private static short readNext(DataInputStream din, short fallback) throws IOException {
+//        short read = din.readShort();
+//        if (read == Short.MIN_VALUE) return fallback;
+//        return read;
+//    }
+//}

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/HillshadingContainer.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/HillshadingContainer.java
@@ -15,6 +15,7 @@
 package org.mapsforge.map.layer.renderer;
 
 import org.mapsforge.core.graphics.Bitmap;
+import org.mapsforge.core.graphics.HillshadingBitmap;
 import org.mapsforge.core.model.Rectangle;
 
 public class HillshadingContainer implements ShapeContainer {
@@ -24,7 +25,7 @@ public class HillshadingContainer implements ShapeContainer {
     public final Rectangle hillsRect;
     public final Rectangle tileRect;
 
-    public HillshadingContainer(Bitmap bitmap, float magnitude, Rectangle hillsRect, Rectangle tileRect) {
+    public HillshadingContainer(HillshadingBitmap bitmap, float magnitude, Rectangle hillsRect, Rectangle tileRect) {
         this.magnitude = magnitude;
         this.bitmap = bitmap;
         this.hillsRect = hillsRect;
@@ -38,6 +39,6 @@ public class HillshadingContainer implements ShapeContainer {
 
     @Override
     public String toString() {
-        return "[Hillshading:" + magnitude + " @ " + hillsRect + " -> " + tileRect + "]";
+        return "[Hillshading:" + magnitude + "#"+System.identityHashCode(bitmap)+"\n @# " + hillsRect + "\n -> " + tileRect + "\n]";
     }
 }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/Hillshading.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/Hillshading.java
@@ -15,8 +15,8 @@
  */
 package org.mapsforge.map.rendertheme.renderinstruction;
 
-import org.mapsforge.core.graphics.Bitmap;
 import org.mapsforge.core.graphics.GraphicFactory;
+import org.mapsforge.core.graphics.HillshadingBitmap;
 import org.mapsforge.core.model.Point;
 import org.mapsforge.core.model.Rectangle;
 import org.mapsforge.core.model.Tile;
@@ -38,6 +38,7 @@ public class Hillshading {
 
     private static final Logger LOGGER = Logger.getLogger(Hillshading.class.getName());
 
+    private boolean always;
     private final GraphicFactory graphicFactory;
     private final int level;
     private final byte layer;
@@ -45,7 +46,8 @@ public class Hillshading {
     private final byte maxZoom;
     private final float magnitude;
 
-    public Hillshading(byte minZoom, byte maxZoom, short magnitude, byte layer, int level, GraphicFactory graphicFactory) {
+    public Hillshading(byte minZoom, byte maxZoom, short magnitude, byte layer, boolean always, int level, GraphicFactory graphicFactory) {
+        this.always = always;
         this.graphicFactory = graphicFactory;
         this.level = level;
         this.layer = layer;
@@ -56,6 +58,11 @@ public class Hillshading {
 
     public void render(final RenderContext renderContext, HillsRenderConfig hillsRenderConfig) {
         if (hillsRenderConfig == null) {
+            if(always){
+                renderContext.setDrawingLayers(layer);
+                ShapeContainer hillShape = new HillshadingContainer(null, magnitude, null, null);
+                renderContext.addToCurrentDrawingLayer(level, new ShapePaintContainer(hillShape, null));
+            }
             return;
         }
         Tile tile = renderContext.rendererJob.tile;
@@ -69,8 +76,15 @@ public class Hillshading {
 
         double maptileBottomLat = MercatorProjection.pixelYToLatitude((long) origin.y + tile.tileSize, tile.mapSize);
         double maptileRightLng = MercatorProjection.pixelXToLongitude((long) origin.x + tile.tileSize, tile.mapSize);
+
+        double mapTileLatDegrees = maptileTopLat - maptileBottomLat;
+        double mapTileLngDegrees = maptileRightLng - maptileLeftLng;
+        double pxPerLat = (tile.tileSize / mapTileLatDegrees);
+        double pxPerLng = (tile.tileSize / mapTileLngDegrees);
+
         if (maptileRightLng < maptileLeftLng)
             maptileRightLng += tile.mapSize;
+
 
         int shadingLngStep = 1;
         int shadingLatStep = 1;
@@ -79,22 +93,40 @@ public class Hillshading {
                 int shadingRightLng = shadingLeftLng + 1;
                 int shadingTopLat = shadingBottomLat + 1;
 
-                Bitmap shadingTile = null;
+                HillshadingBitmap shadingTile = null;
                 try {
-                    shadingTile = hillsRenderConfig.getShadingTile(shadingBottomLat, shadingLeftLng);
+                    shadingTile = hillsRenderConfig.getShadingTile(shadingBottomLat, shadingLeftLng, pxPerLat, pxPerLng);
                 } catch (Exception e) {
                     LOGGER.log(Level.SEVERE, e.getMessage(), e);
                 }
-                if (shadingTile == null)
-                    continue;
-
+                if (shadingTile == null) {
+                    if( ! always) {
+                        continue;
+                    }
+                }
                 double shadingPixelOffset = 0d;
 
+
+                final int padding;
+                final int shadingInnerWidth;
+                final int shadingInnerHeight;
+                if( shadingTile!=null) {
+                    padding = shadingTile.getPadding();
+                    shadingInnerWidth = shadingTile.getWidth() - 2 * padding;
+                    shadingInnerHeight = shadingTile.getHeight() - 2 * padding;
+                }else{
+                    // dummy values to not confuse the maptile calculations
+                    padding = 0;
+                    shadingInnerWidth = 1;
+                    shadingInnerHeight = 1;
+                }
+
                 // shading tile subset if it fully fits inside map tile
-                double shadingSubrectTop = 0;
-                double shadingSubrectLeft = 0;
-                double shadingSubrectRight = shadingTile.getWidth();
-                double shadingSubrectBottom = shadingTile.getHeight();
+                double shadingSubrectTop = padding;
+                double shadingSubrectLeft = padding;
+
+                double shadingSubrectRight = shadingSubrectLeft + shadingInnerWidth;
+                double shadingSubrectBottom = shadingSubrectTop + shadingInnerHeight;
 
                 // map tile subset if it fully fits inside shading tile
                 double maptileSubrectLeft = 0;
@@ -104,27 +136,27 @@ public class Hillshading {
 
                 // find the intersection between map tile and shading tile in earth coordinates and determine the pixel 
                 if (shadingTopLat > maptileTopLat) { // map tile ends in shading tile
-                    shadingSubrectTop = shadingTile.getHeight() * ((shadingTopLat - maptileTopLat) / shadingLatStep);
+                    shadingSubrectTop = padding + shadingInnerHeight * ((shadingTopLat - maptileTopLat) / shadingLatStep);
                 } else if (maptileTopLat > shadingTopLat) {
-                    maptileSubrectTop = MercatorProjection.latitudeToPixelY(shadingTopLat + (shadingPixelOffset / shadingTile.getHeight()), tile.mapSize) - origin.y;
+                    maptileSubrectTop = MercatorProjection.latitudeToPixelY(shadingTopLat + (shadingPixelOffset / shadingInnerHeight), tile.mapSize) - origin.y;
                 }
                 if (shadingBottomLat < maptileBottomLat) { // map tile ends in shading tile
-                    shadingSubrectBottom = shadingTile.getHeight() - shadingTile.getHeight() * ((maptileBottomLat - shadingBottomLat) / shadingLatStep);
+                    shadingSubrectBottom = padding + shadingInnerHeight - shadingInnerHeight * ((maptileBottomLat - shadingBottomLat) / shadingLatStep);
                 } else if (maptileBottomLat < shadingBottomLat) {
-                    maptileSubrectBottom = MercatorProjection.latitudeToPixelY(shadingBottomLat + (shadingPixelOffset / shadingTile.getHeight()), tile.mapSize) - origin.y;
+                    maptileSubrectBottom = MercatorProjection.latitudeToPixelY(shadingBottomLat + (shadingPixelOffset / shadingInnerHeight), tile.mapSize) - origin.y;
                 }
                 if (shadingLeftLng < maptileLeftLng) { // map tile ends in shading tile
-                    shadingSubrectLeft = shadingTile.getWidth() * ((maptileLeftLng - shadingLeftLng) / shadingLngStep);
+                    shadingSubrectLeft = padding + shadingInnerWidth * ((maptileLeftLng - shadingLeftLng) / shadingLngStep);
                 } else if (maptileLeftLng < shadingLeftLng) {
-                    maptileSubrectLeft = MercatorProjection.longitudeToPixelX(shadingLeftLng + (shadingPixelOffset / shadingTile.getWidth()), tile.mapSize) - origin.x;
+                    maptileSubrectLeft = MercatorProjection.longitudeToPixelX(shadingLeftLng + (shadingPixelOffset / shadingInnerWidth), tile.mapSize) - origin.x;
                 }
                 if (shadingRightLng > maptileRightLng) { // map tile ends in shading tile
-                    shadingSubrectRight = shadingTile.getWidth() - shadingTile.getWidth() * ((shadingRightLng - maptileRightLng) / shadingLngStep);
+                    shadingSubrectRight = padding + shadingInnerWidth - shadingInnerWidth * ((shadingRightLng - maptileRightLng) / shadingLngStep);
                 } else if (maptileRightLng > shadingRightLng) {
-                    maptileSubrectRight = MercatorProjection.longitudeToPixelX(shadingRightLng + (shadingPixelOffset / shadingTile.getHeight()), tile.mapSize) - origin.x;
+                    maptileSubrectRight = MercatorProjection.longitudeToPixelX(shadingRightLng + (shadingPixelOffset / shadingInnerHeight), tile.mapSize) - origin.x;
                 }
 
-                Rectangle hillsRect = new Rectangle(shadingSubrectLeft, shadingSubrectTop, shadingSubrectRight, shadingSubrectBottom);
+                Rectangle hillsRect = (shadingTile==null) ? null : new Rectangle(shadingSubrectLeft, shadingSubrectTop, shadingSubrectRight, shadingSubrectBottom);
                 Rectangle maptileRect = new Rectangle(maptileSubrectLeft, maptileSubrectTop, maptileSubrectRight, maptileSubrectBottom);
                 ShapeContainer hillShape = new HillshadingContainer(shadingTile, magnitude, hillsRect, maptileRect);
 

--- a/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/rule/RenderThemeHandler.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/rule/RenderThemeHandler.java
@@ -18,6 +18,10 @@
  */
 package org.mapsforge.map.rendertheme.rule;
 
+import org.xmlpull.v1.XmlPullParser;
+import org.xmlpull.v1.XmlPullParserException;
+import org.xmlpull.v1.XmlPullParserFactory;
+
 import org.mapsforge.core.graphics.GraphicFactory;
 import org.mapsforge.core.util.IOUtils;
 import org.mapsforge.map.model.DisplayModel;
@@ -34,9 +38,6 @@ import org.mapsforge.map.rendertheme.renderinstruction.LineSymbol;
 import org.mapsforge.map.rendertheme.renderinstruction.PathText;
 import org.mapsforge.map.rendertheme.renderinstruction.RenderInstruction;
 import org.mapsforge.map.rendertheme.renderinstruction.Symbol;
-import org.xmlpull.v1.XmlPullParser;
-import org.xmlpull.v1.XmlPullParserException;
-import org.xmlpull.v1.XmlPullParserFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -51,7 +52,7 @@ import java.util.logging.Logger;
  */
 public final class RenderThemeHandler {
 
-    private static enum Element {
+    private enum Element {
         RENDER_THEME, RENDERING_INSTRUCTION, RULE, RENDERING_STYLE;
     }
 
@@ -288,6 +289,7 @@ public final class RenderThemeHandler {
                 byte maxZoom = 17;
                 byte layer = 5;
                 short magnitude = 64;
+                boolean always = false;
 
                 for (int i = 0; i < pullParser.getAttributeCount(); ++i) {
                     String name = pullParser.getAttributeName(i);
@@ -301,13 +303,15 @@ public final class RenderThemeHandler {
                         magnitude = (short) XmlUtils.parseNonNegativeInteger("magnitude", value);
                         if (magnitude > 255)
                             throw new XmlPullParserException("Attribute 'magnitude' must not be > 255");
+                    } else if ("always".equals(name)) {
+                        always = Boolean.valueOf(value);
                     } else if ("layer".equals(name)) {
                         layer = XmlUtils.parseNonNegativeByte("layer", value);
                     }
                 }
 
                 int hillShadingLevel = this.level++;
-                Hillshading hillshading = new Hillshading(minZoom, maxZoom, magnitude, layer, hillShadingLevel, this.graphicFactory);
+                Hillshading hillshading = new Hillshading(minZoom, maxZoom, magnitude, layer, always, hillShadingLevel, this.graphicFactory);
 
                 renderTheme.addHillShadings(hillshading);
             } else {

--- a/mapsforge-map/src/test/java/org/mapsforge/map/layer/hills/RawShadingResultTest.java
+++ b/mapsforge-map/src/test/java/org/mapsforge/map/layer/hills/RawShadingResultTest.java
@@ -1,0 +1,149 @@
+package org.mapsforge.map.layer.hills;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.mapsforge.core.graphics.HillshadingBitmap;
+
+import java.util.Arrays;
+
+/**
+ * Created by usrusr on 05.03.2017.
+ */
+public class RawShadingResultTest {
+    @Test
+    public void fillOnePaddingTest(){
+        byte[] array = new byte[]{
+                0,0,0,0,0,
+                0,1,2,3,0,
+                0,4,5,6,0,
+                0,0,0,0,0
+        };
+
+        ShadingAlgorithm.RawShadingResult result = new ShadingAlgorithm.RawShadingResult(array, 3, 2, 1);
+
+
+        result.fillPadding(HillshadingBitmap.Border.EAST);
+        check(new byte[]{
+                0, 0, 0, 0, 0,
+                0, 1, 2, 3, 3,
+                0, 4, 5, 6, 6,
+                0, 0, 0, 0, 0
+        }, array,5);
+
+
+        result.fillPadding(HillshadingBitmap.Border.SOUTH);
+        check(new byte[]{
+                0, 0, 0, 0, 0,
+                0, 1, 2, 3, 3,
+                0, 4, 5, 6, 6,
+                0, 4, 5, 6, 0
+        }, array,5);
+
+        result.fillPadding(HillshadingBitmap.Border.NORTH);
+        check(new byte[]{
+                0, 1, 2, 3, 0,
+                0, 1, 2, 3, 3,
+                0, 4, 5, 6, 6,
+                0, 4, 5, 6, 0
+        }, array,5);
+
+        result.fillPadding(HillshadingBitmap.Border.WEST);
+        check(new byte[]{
+                0, 1, 2, 3, 0,
+                1, 1, 2, 3, 3,
+                4, 4, 5, 6, 6,
+                0, 4, 5, 6, 0
+        }, array,5);
+
+
+        result.fillPadding();
+        check(new byte[]{
+                1, 1, 2, 3, 3,
+                1, 1, 2, 3, 3,
+                4, 4, 5, 6, 6,
+                4, 4, 5, 6, 6
+        }, array,5);
+    }
+    @Test
+    public void fillTwoPaddingTest(){
+        byte[] array = new byte[]{
+                0,0,0,0,0,0,0,
+                0,0,0,0,0,0,0,
+                0,0,1,2,3,0,0,
+                0,0,4,5,6,0,0,
+                0,0,0,0,0,0,0,
+                0,0,0,0,0,0,0
+        };
+
+        ShadingAlgorithm.RawShadingResult result = new ShadingAlgorithm.RawShadingResult(array, 3, 2, 2);
+
+
+        result.fillPadding(HillshadingBitmap.Border.EAST);
+        check(new byte[]{
+                0,0,0,0,0,0,0,
+                0,0,0,0,0,0,0,
+                0,0,1,2,3,3,3,
+                0,0,4,5,6,6,6,
+                0,0,0,0,0,0,0,
+                0,0,0,0,0,0,0
+        }, array,7);
+        result.fillPadding(HillshadingBitmap.Border.WEST);
+        check(new byte[]{
+                0,0,0,0,0,0,0,
+                0,0,0,0,0,0,0,
+                1,1,1,2,3,3,3,
+                4,4,4,5,6,6,6,
+                0,0,0,0,0,0,0,
+                0,0,0,0,0,0,0
+        }, array,7);
+
+        result.fillPadding(HillshadingBitmap.Border.NORTH);
+        check(new byte[]{
+                0,0,1,2,3,0,0,
+                0,0,1,2,3,0,0,
+                1,1,1,2,3,3,3,
+                4,4,4,5,6,6,6,
+                0,0,0,0,0,0,0,
+                0,0,0,0,0,0,0
+        }, array,7);
+
+        result.fillPadding(HillshadingBitmap.Border.SOUTH);
+        check(new byte[]{
+                0,0,1,2,3,0,0,
+                0,0,1,2,3,0,0,
+                1,1,1,2,3,3,3,
+                4,4,4,5,6,6,6,
+                0,0,4,5,6,0,0,
+                0,0,4,5,6,0,0
+        }, array,7);
+
+
+        result.fillPadding();
+        check(new byte[]{
+                1,1,1,2,3,3,3,
+                1,1,1,2,3,3,3,
+                1,1,1,2,3,3,3,
+                4,4,4,5,6,6,6,
+                4,4,4,5,6,6,6,
+                4,4,4,5,6,6,6
+        }, array,7);
+    }
+
+    private void check(byte[] expected, byte[] actual, int width){
+        Assert.assertEquals("should be same length "+Arrays.toString(expected)+" "+Arrays.toString(actual), expected.length, actual.length);
+        StringBuilder sb = new StringBuilder();
+        for(int i=0;i<actual.length; i++){
+            if(i%width==0) sb.append("\n");
+            byte x = expected[i];
+            byte a = actual[i];
+            if(x !=actual[i]){
+                sb.append(" "+x+"!"+a+" ");
+            }else{
+                sb.append(" ("+a+") ");
+            }
+
+        }
+        Assert.assertArrayEquals(sb.toString(), expected,actual);
+    }
+}

--- a/mapsforge-samples-android/AndroidManifest.xml
+++ b/mapsforge-samples-android/AndroidManifest.xml
@@ -22,6 +22,20 @@
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
+
+            </intent-filter>
+            <intent-filter >
+                <!--
+                support URIs like mapsforgesamples://?activity=DefaultTheme&mapdir=/path/to/my/maps&mapfile=my.map
+                provide custom defaults for SamplesBaseActivity and/or directly jump into an activity
+                serves as a supbstitute for command line arguments for easy launches during development
+
+                if it does not work, check if your IDE (or other tooling) requires you escape the & characters as \&
+                -->
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <data android:scheme="mapsforgesamples"/>
             </intent-filter>
         </activity>
         <activity
@@ -68,6 +82,9 @@
             android:configChanges="keyboardHidden|orientation|screenSize" />
         <activity
             android:name=".HillshadingMapViewer"
+            android:configChanges="keyboardHidden|orientation|screenSize" />
+        <activity
+            android:name=".HillshadingMapViewerFaster"
             android:configChanges="keyboardHidden|orientation|screenSize" />
         <activity
             android:name=".ItemDetailActivity"

--- a/mapsforge-samples-android/res/layout/activity_item_detail.xml
+++ b/mapsforge-samples-android/res/layout/activity_item_detail.xml
@@ -1,7 +1,7 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/item_detail_container"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context="org.mapsforge.samples.android.ItemDetailActivity"
-    tools:ignore="MergeRootFrame" />
+             xmlns:tools="http://schemas.android.com/tools"
+             android:id="@+id/item_detail_container"
+             android:layout_width="match_parent"
+             android:layout_height="match_parent"
+             tools:context="org.mapsforge.samples.android.ItemDetailActivity"
+             tools:ignore="MergeRootFrame"/>

--- a/mapsforge-samples-android/src/main/java/org/mapsforge/samples/android/HillshadingMapViewerFaster.java
+++ b/mapsforge-samples-android/src/main/java/org/mapsforge/samples/android/HillshadingMapViewerFaster.java
@@ -24,23 +24,23 @@ import org.mapsforge.map.layer.hills.HillsRenderConfig;
 import java.io.File;
 
 /**
- * Standard map view with hill shading.
+ * Standard map view with hill shading, configured for speed over prettiness.
  */
-public class HillshadingMapViewer extends DefaultTheme {
+public class HillshadingMapViewerFaster extends DefaultTheme {
     final private HillsRenderConfig hillsConfig;
     private final File demFolder;
 
-    public HillshadingMapViewer() {
+    public HillshadingMapViewerFaster() {
         demFolder = new File(getMapFileDirectory(), "dem");
 
         if( ! (demFolder.exists() && demFolder.isDirectory() && demFolder.canRead() && demFolder.listFiles().length>0)) {
             hillsConfig=null;
         }else {
-            // minumum setup for hillshading
+            // minumum setup for hillshading:
             hillsConfig = new HillsRenderConfig(demFolder, AndroidGraphicFactory.INSTANCE);
 
-            // slower version smooth along the one degree latitude/longitude grid:
-            hillsConfig.setEnableInterpolationOverlap(true);
+            // faster configuration with visible seams along the one degree latitude/longitude grid where the terrain is rough
+            hillsConfig.setEnableInterpolationOverlap(false);
 
             // call after setting/changing parameters, walks filesystem for DEM metadata
             hillsConfig.indexOnThread();

--- a/mapsforge-samples-android/src/main/java/org/mapsforge/samples/android/Samples.java
+++ b/mapsforge-samples-android/src/main/java/org/mapsforge/samples/android/Samples.java
@@ -40,7 +40,8 @@ import org.mapsforge.map.android.graphics.AndroidGraphicFactory;
  * Start screen for the sample activities.
  */
 public class Samples extends Activity {
-
+    /** serves as a supbstitute for command line arguments for easy launches during development */
+    public static Uri launchUrl;
     private Button createButton(Class<?> clazz) {
         return this.createButton(clazz, null, null);
     }
@@ -83,7 +84,7 @@ public class Samples extends Activity {
         super.onCreate(savedInstanceState);
 
         setContentView(R.layout.activity_samples);
-        LinearLayout linearLayout = findViewById(R.id.samples);
+        LinearLayout linearLayout = (LinearLayout) findViewById(R.id.samples);
         linearLayout.addView(createButton(DefaultTheme.class));
         linearLayout.addView(createButton(DiagnosticsMapViewer.class));
         linearLayout.addView(createButton(SimplestMapViewer.class));
@@ -172,12 +173,9 @@ public class Samples extends Activity {
         linearLayout.addView(createButton(SimpleDataStoreMapViewer.class));
 
         linearLayout.addView(createLabel("Experiments"));
-        linearLayout.addView(createButton(HillshadingMapViewer.class, null, new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                startupDialog("hillshading", R.string.startup_message_hillshading, HillshadingMapViewer.class);
-            }
-        }));
+        linearLayout.addView(createButton(HillshadingMapViewer.class));
+        linearLayout.addView(createButton(HillshadingMapViewerFaster.class));
+
         linearLayout.addView(createButton(ReverseGeocodeViewer.class));
         linearLayout.addView(createButton(NightModeViewer.class));
         linearLayout.addView(createButton(RenderThemeChanger.class));
@@ -237,6 +235,22 @@ public class Samples extends Activity {
                     });
             builder.setMessage(R.string.startup_message);
             builder.show();
+        }
+
+        launchUrl = getIntent().getData();
+
+
+        String activity =  (launchUrl==null) ? null : launchUrl.getQueryParameter("activity");
+        if(activity!=null){
+            String fqn = Samples.class.getPackage().getName() + "." + activity;
+            try {
+                Class<?> clazz = getClass().getClassLoader().loadClass(fqn);
+                if(Activity.class.isAssignableFrom(clazz)){
+                    startActivity(new Intent(Samples.this, clazz));
+                }
+            } catch (ClassNotFoundException e) {
+                e.printStackTrace();
+            }
         }
     }
 

--- a/mapsforge-samples-android/src/main/java/org/mapsforge/samples/android/SamplesBaseActivity.java
+++ b/mapsforge-samples-android/src/main/java/org/mapsforge/samples/android/SamplesBaseActivity.java
@@ -50,6 +50,8 @@ import org.mapsforge.map.scalebar.ImperialUnitAdapter;
 import org.mapsforge.map.scalebar.MetricUnitAdapter;
 import org.mapsforge.map.scalebar.NauticalUnitAdapter;
 
+import java.io.File;
+
 /**
  * Code common to most activities in the Samples app.
  */
@@ -122,12 +124,26 @@ public abstract class SamplesBaseActivity extends MapViewerTemplateRuntimePermis
                 this.mapView.getModel().frameBufferModel.getOverdrawFactor(), persistent));
     }
 
-    /**
-     * @return the map file name to be used
-     */
     @Override
     protected String getMapFileName() {
+        String map =  (Samples.launchUrl==null) ? null : Samples.launchUrl.getQueryParameter("map");
+        if(map!=null) {
+            return map;
+        }
         return "germany.map";
+    }
+
+    @Override
+    protected File getMapFileDirectory() {
+        String mapdir = (Samples.launchUrl==null) ? null : Samples.launchUrl.getQueryParameter("mapdir");
+        if(mapdir!=null) {
+            File file = new File(mapdir);
+            if(file.exists() && file.isDirectory()) {
+                return file;
+            }
+            throw new RuntimeException(file+" does not exist or is not a directory (configured in launch URI "+Samples.launchUrl+" )");
+        }
+        return super.getMapFileDirectory();
     }
 
     @Override

--- a/resources/renderTheme.xsd
+++ b/resources/renderTheme.xsd
@@ -275,6 +275,12 @@
         <xs:attribute name="zoom-min" default="5" type="xs:unsignedByte" use="optional" />
         <xs:attribute name="zoom-max" default="17" type="xs:unsignedByte" use="optional" />
         <xs:attribute name="magnitude" default="64" type="xs:unsignedByte" use="optional" />
+        <xs:attribute name="always" default="false" type="xs:boolean" use="optional">
+            <xs:annotation>
+                <xs:documentation>Apply neutral shading when tiles are missing or shading is disabled to keep colors consisten
+                (for themes that compensate color intensity for hillshading desaturation)</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
         <!-- customization unlikely to make any sense -->
         <xs:attribute name="layer" default="5" type="xs:unsignedByte" use="optional" />
     </xs:complexType>


### PR DESCRIPTION
Updates to #923 hillshading, the seams reported by  @demiantres should be addressed by this, amongst others.
The biggest changes:
1. Filtered upscaling on android (using a questionably arcane way, but more straight-forward approaches failed to give filtered upscaling on my test Z1c)
2. Perfect (as far as i can tell?) alignment at tile borders 
3. Optional interpolation padding at hillshading tile borders to get rid of interpolation artifacts. Unfortunately it is very slow on android (first map tile rendered after five hgt tiles are loaded instead of after one hgt), it might be faster to just merge the border pixels on the go into a four pixels wide temporary bitmap that is painted separately (as a two-hillpixels wide piece)
4. An "always" attribute in the hillshading theme element that causes flat shading to be applied whenever hgt files are missing or hillshading is not enabled, so that themes can compensate for desaturation
