### PR TITLE
Mapsforge-map: support alterable osm tag values

### DIFF
--- a/docs/Specification-Binary-Map-File.md
+++ b/docs/Specification-Binary-Map-File.md
@@ -112,7 +112,7 @@ To read the data of a specific tile in the sub-file, the position of the fixed-s
 |32|yes|POI signature|If the debug bit in the file header is set:<br />`***POIStartX***` where X defines the OSM-ID of the POI; the text is always padded to 32 bytes by adding whitespaces|
 |variable||position|geo coordinate difference to the top-left corner of the current tile as *`VBE-S` INT*, in the order lat-diff, lon-diff|
 |1||special byte|<ul><li>1.-4. bit: layer (OSM-Tag: layer=...) + 5 (to avoid negative values)</li><li>5.-8. bit: amount of tags for the POI</li></ul>|
-|variable||tag id|for each tag of the POI:<ul><li>tag id as *`VBE-U` INT*</li></ul>|
+|variable||tag id|for each tag of the POI:<ul><li>tag id as *`VBE-U` INT*</li><li>optional values as different datatypes, whose amount can be calculated from previous tag's wildcard</li></ul>|
 |1||flags|<ul><li>1. bit: flag for existence of a POI name</li><li>2. bit: flag for existence of a house number</li><li>3. bit: flag for existence of an elevation</li><li>4.-8. bit: reserved for future use</li></ul>|
 |variable|yes|name|name of the POI as a string|
 |variable|yes|house number|house number of the POI as a string|
@@ -129,7 +129,7 @@ To read the data of a specific tile in the sub-file, the position of the fixed-s
 |variable||way data size|number of bytes that are needed to encode the current way as *`VBE-U` INT*, starting from the sub tile bitmap (i.e. way signature and way size are not counted)|
 |2||sub tile bitmap|A tile on zoom level z is made up of exactly 16 sub tiles on zoom level z+2<br />for each sub tile (row-wise, left to right):<ul><li>1 bit that represents a flag whether the way is relevant for the sub tile</li></ul>Special case: coastline ways must always have all 16 bits set.|
 |1||special byte|<ul><li>1.-4. bit: layer (OSM-Tag: layer=...) + 5 (to avoid negative values)</li><li>5.-8. bit: amount of tags for the way</li></ul>|
-|variable||tag id|for each tag of the way:<ul><li>tag id as *`VBE-U` INT*</li></ul>|
+|variable||tag id|for each tag of the way:<ul><li>tag id as *`VBE-U` INT*</li><li>optional value ids as different datatypes, whose amount can be calculated from previous tag's wildcard</li></ul>|
 |1||flags|<ul><li>1. bit: flag for existence of a way name</li><li>2. bit: flag for existence of a house number</li><li>3. bit: flag for existence of a reference</li><li>4. bit: flag for existence of a label position</li><li>5. bit: flag for existence of *number of way data blocks* field<ul><li>case 0: field does not exist, number of blocks is one</li><li>case 1: field exists, more than one block</li></ul></li><li>6. bit: flag indicating encoding of way coordinate blocks<ul><li>case 0: single delta encoding</li><li>case 1: double delta encoding</li></ul></li><li>7.-8. bit: reserved for future use</li></ul>|
 |variable|yes|name|name of the way as a string|
 |variable|yes|house number|house number of the way as a string|

--- a/mapsforge-map-reader/src/main/java/org/mapsforge/map/reader/ReadBuffer.java
+++ b/mapsforge-map-reader/src/main/java/org/mapsforge/map/reader/ReadBuffer.java
@@ -111,6 +111,18 @@ public class ReadBuffer {
     }
 
     /**
+     * Converts four bytes from the read buffer to a float.
+     *
+     * @return the float value.
+     */
+    public float readFloat() {
+        byte[] bytes = new byte[4];
+        System.arraycopy(bufferData, bufferPosition, bytes, 0, 4);
+        this.bufferPosition += 4;
+        return ByteBuffer.wrap(bytes).getFloat();
+    }
+
+    /**
      * Converts four bytes from the read buffer to a signed int.
      * <p/>
      * The byte order is big-endian.

--- a/mapsforge-map-reader/src/main/java/org/mapsforge/map/reader/header/OptionalFields.java
+++ b/mapsforge-map-reader/src/main/java/org/mapsforge/map/reader/header/OptionalFields.java
@@ -52,6 +52,11 @@ final class OptionalFields {
     private static final int HEADER_BITMASK_START_ZOOM_LEVEL = 0x20;
 
     /**
+     * Bitmask for the variable tag value fields.
+     */
+    private static final int HEADER_BITMASK_TAG_VALUES = 0x02;
+
+    /**
      * Maximum valid start zoom level.
      */
     private static final int START_ZOOM_LEVEL_MAX = 22;
@@ -70,6 +75,7 @@ final class OptionalFields {
     final boolean hasLanguagesPreference;
     final boolean hasStartPosition;
     final boolean hasStartZoomLevel;
+    final boolean hasTagValues;
     final boolean isDebugFile;
     String languagesPreference;
     LatLong startPosition;
@@ -82,6 +88,7 @@ final class OptionalFields {
         this.hasLanguagesPreference = (flags & HEADER_BITMASK_LANGUAGES_PREFERENCE) != 0;
         this.hasComment = (flags & HEADER_BITMASK_COMMENT) != 0;
         this.hasCreatedBy = (flags & HEADER_BITMASK_CREATED_BY) != 0;
+        this.hasTagValues = (flags & HEADER_BITMASK_TAG_VALUES) != 0;
     }
 
     private void readLanguagesPreference(ReadBuffer readBuffer) {

--- a/mapsforge-map-reader/src/main/java/org/mapsforge/map/reader/header/RequiredFields.java
+++ b/mapsforge-map-reader/src/main/java/org/mapsforge/map/reader/header/RequiredFields.java
@@ -51,7 +51,7 @@ final class RequiredFields {
     /**
      * Highest version of the map file format supported by this implementation.
      */
-    private static final int SUPPORTED_FILE_VERSION_MAX = 4;
+    private static final int SUPPORTED_FILE_VERSION_MAX = 5;
 
     static void readBoundingBox(ReadBuffer readBuffer, MapFileInfoBuilder mapFileInfoBuilder) {
         double minLatitude = LatLongUtils.microdegreesToDegrees(readBuffer.readInt());

--- a/mapsforge-map-writer/src/main/config/mapsforge-map.properties
+++ b/mapsforge-map-writer/src/main/config/mapsforge-map.properties
@@ -1,3 +1,3 @@
 mapfile.specification.version.min=3
-mapfile.specification.version.max=4
+mapfile.specification.version.max=5
 mapfile.writer.version=${mapfile.writer.version}

--- a/mapsforge-map-writer/src/main/config/tag-mapping.xml
+++ b/mapsforge-map-writer/src/main/config/tag-mapping.xml
@@ -368,6 +368,102 @@
         <osm-tag key="building" value="yes" zoom-appear="15" />
     </ways>
 
+    <!-- Building Extrusions -->
+    <ways>
+        <osm-tag key="building:part" value="arch" zoom-appear="17" />
+        <osm-tag key="building:part" value="balcony" zoom-appear="17" />
+        <osm-tag key="building:part" value="base" zoom-appear="17" />
+        <osm-tag key="building:part" value="column" zoom-appear="17" />
+        <osm-tag key="building:part" value="elevator" zoom-appear="17" />
+        <osm-tag key="building:part" value="entrance" zoom-appear="17" />
+        <osm-tag key="building:part" value="floor" zoom-appear="17" />
+        <osm-tag key="building:part" value="hall" zoom-appear="17" />
+        <osm-tag key="building:part" value="main" zoom-appear="17" />
+        <osm-tag key="building:part" value="passageway" zoom-appear="17" />
+        <osm-tag key="building:part" value="pillar" zoom-appear="17" />
+        <osm-tag key="building:part" value="porch" zoom-appear="17" />
+        <osm-tag key="building:part" value="ramp" zoom-appear="17" />
+        <osm-tag key="building:part" value="roof" zoom-appear="17" />
+        <osm-tag key="building:part" value="room" zoom-appear="17" />
+        <osm-tag key="building:part" value="steps" zoom-appear="17" />
+        <osm-tag key="building:part" value="stilobate" zoom-appear="17" />
+        <osm-tag key="building:part" value="tier" zoom-appear="17" />
+        <osm-tag key="building:part" value="tower" zoom-appear="17" />
+        <osm-tag key="building:part" value="verticalpassage" zoom-appear="17" />
+        <osm-tag key="building:part" value="wall" zoom-appear="17" />
+        <osm-tag key="building:part" value="window" zoom-appear="17" />
+        <osm-tag key="building:part" value="yes" zoom-appear="17" />
+
+        <osm-tag key="height" renderable="false" value="%f" />
+        <osm-tag key="min-height" renderable="false" value="%f" />
+        <osm-tag key="building:levels" renderable="false" value="%f" />
+        <osm-tag key="building:min-levels" renderable="false" value="%f" />
+    </ways>
+
+    <!-- S3DB Tags -->
+    <ways>
+        <osm-tag key="roof:shape" renderable="false" value="flat" />
+        <osm-tag key="roof:shape" renderable="false" value="skillion" />
+        <osm-tag key="roof:shape" renderable="false" value="gabled" />
+        <osm-tag key="roof:shape" renderable="false" value="half-hipped" />
+        <osm-tag key="roof:shape" renderable="false" value="hipped" />
+        <osm-tag key="roof:shape" renderable="false" value="pyramidal" />
+        <osm-tag key="roof:shape" renderable="false" value="gambrel" />
+        <osm-tag key="roof:shape" renderable="false" value="mansard" />
+        <osm-tag key="roof:shape" renderable="false" value="dome" />
+        <osm-tag key="roof:shape" renderable="false" value="onion" />
+        <osm-tag key="roof:shape" renderable="false" value="round" />
+        <osm-tag key="roof:shape" renderable="false" value="saltbox" />
+
+        <osm-tag key="roof:orientation" renderable="false" value="along" />
+        <osm-tag key="roof:orientation" renderable="false" value="across" />
+        <osm-tag key="roof:height" renderable="false" value="%f" />
+        <osm-tag key="roof:angle" renderable="false" value="%f" />
+        <osm-tag key="roof:levels" renderable="false" value="%f" />
+        <osm-tag key="roof:direction" renderable="false" value="%f" />
+
+        <osm-tag key="building:colour" renderable="false" value="%f" />
+        <!--<osm-tag key="building:colour" renderable="false" value="%s" /> Detect uncatched tags -->
+        <osm-tag key="roof:colour" renderable="false" value="%f" />
+        <!--<osm-tag key="roof:colour" renderable="false" value="%s" /> Detect uncatched tags -->
+        <osm-tag key="building:material" renderable="false" value="plaster" />
+        <osm-tag key="building:material" renderable="false" value="brick" />
+        <osm-tag key="building:material" renderable="false" value="wood" />
+        <osm-tag key="building:material" renderable="false" value="concrete" />
+        <osm-tag key="building:material" renderable="false" value="glass" />
+        <osm-tag key="building:material" renderable="false" value="mirror" />
+        <osm-tag key="building:material" renderable="false" value="stone" />
+        <osm-tag key="building:material" renderable="false" value="sandstone" />
+        <osm-tag key="building:material" renderable="false" value="steel" />
+        <osm-tag key="building:material" renderable="false" value="metal" />
+        <!--<osm-tag key="building:material" renderable="false" value="limestone" />-->
+        <!--<osm-tag key="building:material" renderable="false" value="sand_cement_blocks" />-->
+        <!--<osm-tag key="building:material" renderable="false" value="metal_plates" />-->
+        <!--<osm-tag key="building:material" renderable="false" value="mdf" />-->
+        <!--<osm-tag key="building:material" renderable="false" value="timber_framing" />-->
+        <!--<osm-tag key="building:material" renderable="false" value="plastic" />-->
+        <!--<osm-tag key="building:material" renderable="false" value="vinyl" />-->
+        <!--<osm-tag key="building:material" renderable="false" value="tiles" />-->
+        <!--<osm-tag key="building:material" renderable="false" value="%s" /> Detect uncatched tags -->
+        <osm-tag key="roof:material" renderable="false" value="acrylic_glass" />
+        <osm-tag key="roof:material" renderable="false" value="concrete" />
+        <osm-tag key="roof:material" renderable="false" value="copper" />
+        <osm-tag key="roof:material" renderable="false" value="eternit" />
+        <osm-tag key="roof:material" renderable="false" value="plastic" />
+        <osm-tag key="roof:material" renderable="false" value="asphalt " />
+        <osm-tag key="roof:material" renderable="false" value="glass" />
+        <osm-tag key="roof:material" renderable="false" value="grass" />
+        <osm-tag key="roof:material" renderable="false" value="gravel" />
+        <osm-tag key="roof:material" renderable="false" value="metal" />
+        <osm-tag key="roof:material" renderable="false" value="plants" />
+        <osm-tag key="roof:material" renderable="false" value="roof_tiles" />
+        <osm-tag key="roof:material" renderable="false" value="slate" />
+        <osm-tag key="roof:material" renderable="false" value="stone" />
+        <osm-tag key="roof:material" renderable="false" value="tar_paper" />
+        <osm-tag key="roof:material" renderable="false" value="thatch" />
+        <osm-tag key="roof:material" renderable="false" value="wood" />
+    </ways>
+
     <!-- ADMINISTRATIVE BOUNDARIES -->
     <ways>
 

--- a/mapsforge-map-writer/src/main/java/org/mapsforge/map/writer/BaseTileBasedDataProcessor.java
+++ b/mapsforge-map-writer/src/main/java/org/mapsforge/map/writer/BaseTileBasedDataProcessor.java
@@ -142,7 +142,7 @@ abstract class BaseTileBasedDataProcessor implements TileBasedDataProcessor, Nod
                     addWayToTiles(outerWay, BaseTileBasedDataProcessor.this.bboxEnlargement);
                     handleVirtualOuterWay(outerWay);
                     // adjust tag statistics, cannot be omitted!!!
-                    countWayTags(relation.getTags());
+                    countWayTags(relation.getTags().keySet());
                 }
 
                 // the outer way consists of only one segment
@@ -167,7 +167,7 @@ abstract class BaseTileBasedDataProcessor implements TileBasedDataProcessor, Nod
                         // handle relation tags
                         handleAdditionalRelationTags(outerWay, relation);
                         addWayToTiles(outerWay, BaseTileBasedDataProcessor.this.bboxEnlargement);
-                        countWayTags(outerWay.getTags());
+                        countWayTags(outerWay.getTags().keySet());
                     }
                 }
 
@@ -192,17 +192,30 @@ abstract class BaseTileBasedDataProcessor implements TileBasedDataProcessor, Nod
                     if (innerSegments.size() == 1) {
                         innerWay = innerSegments.getFirst();
                         if (innerWay.hasTags() && outer.hasTags()) {
-                            short[] iTags = innerWay.getTags();
-                            short[] oTags = outer.getTags();
                             int contained = 0;
-                            for (short iTagID : iTags) {
-                                for (short oTagID : oTags) {
-                                    if (iTagID == oTagID) {
-                                        contained++;
+                            for (Entry<Short, Object> innerTag : innerWay.getTags().entrySet()) {
+                                for (Entry<Short, Object> outerTag : outer.getTags().entrySet()) {
+                                    if (innerTag.getKey().equals(outerTag.getKey())) {
+                                        Object innerValue = innerTag.getValue();
+                                        Object outerValue = outerTag.getValue();
+                                        if (innerValue != null) {
+                                            if (outerValue != null) {
+                                                if ((innerValue instanceof Byte && outerValue instanceof Byte && innerValue.equals(outerValue))
+                                                        || (innerValue instanceof Integer && outerValue instanceof Integer && innerValue.equals(outerValue))
+                                                        || (innerValue instanceof Float && outerValue instanceof Float && innerValue.equals(outerValue))
+                                                        || (innerValue instanceof Short && outerValue instanceof Short && innerValue.equals(outerValue))
+                                                        || (innerValue instanceof String && outerValue instanceof String && innerValue.equals(outerValue))) {
+                                                    contained++;
+                                                }
+                                            }
+                                        } else if (outerValue == null) {
+                                            contained++;
+                                        }
                                     }
                                 }
                             }
-                            if (contained == iTags.length) {
+
+                            if (contained == innerWay.getTags().size()) {
                                 BaseTileBasedDataProcessor.this.innerWaysWithoutAdditionalTags.add(innerWay.getId());
                             }
                         }
@@ -384,12 +397,12 @@ abstract class BaseTileBasedDataProcessor implements TileBasedDataProcessor, Nod
         if (poi == null || poi.getTags() == null) {
             return;
         }
-        for (short tag : poi.getTags()) {
+        for (short tag : poi.getTags().keySet()) {
             this.histogramPoiTags.adjustOrPutValue(tag, 1, 1);
         }
     }
 
-    protected void countWayTags(short[] tags) {
+    protected void countWayTags(Set<Short> tags) {
         if (tags != null) {
             for (short tag : tags) {
                 this.histogramWayTags.adjustOrPutValue(tag, 1, 1);
@@ -399,7 +412,7 @@ abstract class BaseTileBasedDataProcessor implements TileBasedDataProcessor, Nod
 
     protected void countWayTags(TDWay way) {
         if (way != null) {
-            countWayTags(way.getTags());
+            countWayTags(way.getTags().keySet());
         }
     }
 

--- a/mapsforge-map-writer/src/main/java/org/mapsforge/map/writer/model/MapWriterConfiguration.java
+++ b/mapsforge-map-writer/src/main/java/org/mapsforge/map/writer/model/MapWriterConfiguration.java
@@ -53,6 +53,8 @@ public class MapWriterConfiguration {
 
     private boolean skipInvalidRelations;
 
+    private boolean hasTagValues;
+
     private OSMTagMapping tagMapping;
     private boolean wayClipping;
 
@@ -272,6 +274,13 @@ public class MapWriterConfiguration {
     }
 
     /**
+     * @return true if tag values are stored
+     */
+    public boolean hasTagValues() {
+        return hasTagValues;
+    }
+
+    /**
      * Convenience method.
      *
      * @return true if map start zoom level is set
@@ -341,6 +350,7 @@ public class MapWriterConfiguration {
         } else {
             this.tagMapping = OSMTagMapping.getInstance();
         }
+        this.tagMapping.storeTagValues(this.hasTagValues);
     }
 
     /**
@@ -463,6 +473,13 @@ public class MapWriterConfiguration {
      */
     public void setSkipInvalidRelations(boolean skipInvalidRelations) {
         this.skipInvalidRelations = skipInvalidRelations;
+    }
+
+    /**
+     * @param hasTagValues the storeTagValues to set
+     */
+    public void setStoreTagValues(boolean hasTagValues) {
+        this.hasTagValues = hasTagValues;
     }
 
     /**

--- a/mapsforge-map-writer/src/main/java/org/mapsforge/map/writer/model/TDNode.java
+++ b/mapsforge-map-writer/src/main/java/org/mapsforge/map/writer/model/TDNode.java
@@ -23,6 +23,7 @@ import org.openstreetmap.osmosis.core.domain.v0_6.Node;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 public class TDNode {
 
@@ -39,7 +40,7 @@ public class TDNode {
      */
     public static TDNode fromNode(Node node, List<String> preferredLanguages) {
         SpecialTagExtractionResult ster = OSMUtils.extractSpecialFields(node, preferredLanguages);
-        short[] knownWayTags = OSMUtils.extractKnownPOITags(node);
+        Map<Short, Object> knownWayTags = OSMUtils.extractKnownPOITags(node);
 
         return new TDNode(node.getId(), LatLongUtils.degreesToMicrodegrees(node.getLatitude()),
                 LatLongUtils.degreesToMicrodegrees(node.getLongitude()), ster.getElevation(), ster.getLayer(),
@@ -55,7 +56,7 @@ public class TDNode {
     private final int longitude;
     private final String name;
 
-    private short[] tags;
+    private Map<Short, Object> tags;
 
     /**
      * @param id          the OSM id
@@ -84,10 +85,10 @@ public class TDNode {
      * @param layer       the layer if existent
      * @param houseNumber the house number if existent
      * @param name        the name if existent
-     * @param tags        the
+     * @param tags        the tags (tag map contains optional values)
      */
     public TDNode(long id, int latitude, int longitude, short elevation, byte layer, String houseNumber, String name,
-                  short[] tags) {
+                  Map<Short, Object> tags) {
         this.id = id;
         this.latitude = latitude;
         this.longitude = longitude;
@@ -168,7 +169,7 @@ public class TDNode {
     /**
      * @return the tags
      */
-    public short[] getTags() {
+    public Map<Short, Object> getTags() {
         return this.tags;
     }
 
@@ -176,13 +177,13 @@ public class TDNode {
      * @return the zoom level on which the node appears first
      */
     public byte getZoomAppear() {
-        if (this.tags == null || this.tags.length == 0) {
+        if (this.tags == null || this.tags.size() == 0) {
             if (this.houseNumber != null) {
                 return ZOOM_HOUSENUMBER;
             }
             return Byte.MAX_VALUE;
         }
-        return OSMTagMapping.getInstance().getZoomAppearPOI(this.tags);
+        return OSMTagMapping.getInstance().getZoomAppearPOI(this.tags.keySet());
     }
 
     @Override
@@ -197,19 +198,19 @@ public class TDNode {
      * @return true if the node represents a POI
      */
     public boolean isPOI() {
-        return this.houseNumber != null || this.elevation != 0 || this.tags.length > 0;
+        return this.houseNumber != null || this.elevation != 0 || this.tags.size() > 0;
     }
 
     /**
      * @param tags the tags to set
      */
-    public void setTags(short[] tags) {
+    public void setTags(Map<Short, Object> tags) {
         this.tags = tags;
     }
 
     @Override
     public final String toString() {
         return "TDNode [id=" + this.id + ", latitude=" + this.latitude + ", longitude=" + this.longitude + ", name="
-                + this.name + ", tags=" + Arrays.toString(this.tags) + "]";
+                + this.name + ", tags=" + Arrays.toString(this.tags.keySet().toArray()) + "]";
     }
 }

--- a/mapsforge-map-writer/src/main/java/org/mapsforge/map/writer/model/TDRelation.java
+++ b/mapsforge-map-writer/src/main/java/org/mapsforge/map/writer/model/TDRelation.java
@@ -24,6 +24,7 @@ import org.openstreetmap.osmosis.core.domain.v0_6.RelationMember;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Logger;
 
 /**
@@ -50,7 +51,7 @@ public class TDRelation {
         }
 
         SpecialTagExtractionResult ster = OSMUtils.extractSpecialFields(relation, preferredLanguages);
-        short[] knownWayTags = OSMUtils.extractKnownWayTags(relation);
+        Map<Short, Object> knownWayTags = OSMUtils.extractKnownWayTags(relation);
 
         // special tags
         // TODO what about the layer of relations?
@@ -102,7 +103,7 @@ public class TDRelation {
 
     private final String ref;
 
-    private final short[] tags;
+    private final Map<Short, Object> tags;
 
     /**
      * Constructor.
@@ -112,10 +113,10 @@ public class TDRelation {
      * @param name        the name
      * @param houseNumber the house number if existent
      * @param ref         the ref attribute
-     * @param tags        the tags
+     * @param tags        the tags (tag map contains optional values)
      * @param memberWays  the member ways
      */
-    TDRelation(long id, byte layer, String name, String houseNumber, String ref, short[] tags, TDWay[] memberWays) {
+    TDRelation(long id, byte layer, String name, String houseNumber, String ref, Map<Short, Object> tags, TDWay[] memberWays) {
         this.id = id;
         this.layer = layer;
         this.name = name;
@@ -188,8 +189,8 @@ public class TDRelation {
     /**
      * @return the tags
      */
-    public short[] getTags() {
-        return this.tags;
+    public Map<Short, Object> getTags() {
+        return tags;
     }
 
     @Override
@@ -204,19 +205,15 @@ public class TDRelation {
      * @return true if the relation has associated tags
      */
     public boolean hasTags() {
-        return this.tags != null && this.tags.length > 0;
+        return this.tags != null && this.tags.size() > 0;
     }
 
     /**
      * @return true if the relation represents a coastline
      */
     public boolean isCoastline() {
-        if (this.tags == null) {
-            return false;
-        }
-        OSMTag tag;
-        for (short tagID : this.tags) {
-            tag = OSMTagMapping.getInstance().getWayTag(tagID);
+        List<OSMTag> osmTags = OSMTagMapping.getInstance().getWayTags(this.tags.keySet());
+        for (OSMTag tag : osmTags) {
             if (tag.isCoastline()) {
                 return true;
             }
@@ -235,6 +232,6 @@ public class TDRelation {
     @Override
     public String toString() {
         return "TDRelation [id=" + this.id + ", layer=" + this.layer + ", name=" + this.name + ", ref=" + this.ref
-                + ", tags=" + Arrays.toString(this.tags) + "]";
+                + ", tags=" + Arrays.toString(this.tags.keySet().toArray()) + "]";
     }
 }

--- a/mapsforge-map-writer/src/main/java/org/mapsforge/map/writer/osmosis/MapFileWriterFactory.java
+++ b/mapsforge-map-writer/src/main/java/org/mapsforge/map/writer/osmosis/MapFileWriterFactory.java
@@ -43,6 +43,7 @@ class MapFileWriterFactory extends TaskManagerFactory {
     private static final String PARAM_SIMPLIFICATION_MAX_ZOOM = "simplification-max-zoom";
     private static final String PARAM_SKIP_INVALID_RELATIONS = "skip-invalid-relations";
     private static final String PARAM_TAG_MAPPING_FILE = "tag-conf-file";
+    private static final String PARAM_TAG_VALUES = "tag-values";
     private static final String PARAM_THREADS = "threads";
     private static final String PARAM_TYPE = "type";
     private static final String PARAM_WAY_CLIPPING = "way-clipping";
@@ -52,6 +53,7 @@ class MapFileWriterFactory extends TaskManagerFactory {
     protected TaskManager createTaskManagerImpl(TaskConfiguration taskConfig) {
         MapWriterConfiguration configuration = new MapWriterConfiguration();
         configuration.addOutputFile(getStringArgument(taskConfig, PARAM_OUTFILE, Constants.DEFAULT_PARAM_OUTFILE));
+        configuration.setStoreTagValues(getBooleanArgument(taskConfig, PARAM_TAG_VALUES, true)); // must be set before loading tag mapping file
         configuration.loadTagMappingFile(getStringArgument(taskConfig, PARAM_TAG_MAPPING_FILE, null));
 
         configuration.addMapStartPosition(getStringArgument(taskConfig, PARAM_MAP_START_POSITION, null));

--- a/mapsforge-map-writer/src/main/java/org/mapsforge/map/writer/osmosis/MapFileWriterTask.java
+++ b/mapsforge-map-writer/src/main/java/org/mapsforge/map/writer/osmosis/MapFileWriterTask.java
@@ -61,11 +61,21 @@ public class MapFileWriterTask implements Sink {
                     + properties.getProperty(Constants.PROPERTY_NAME_WRITER_VERSION));
             // If multilingual map then set newer map file version
             boolean multilingual = configuration.getPreferredLanguages() != null && configuration.getPreferredLanguages().size() > 1;
-            configuration.setFileSpecificationVersion(Integer.parseInt(properties.getProperty(
-                    multilingual ? Constants.PROPERTY_NAME_FILE_SPECIFICATION_VERSION_MAX : Constants.PROPERTY_NAME_FILE_SPECIFICATION_VERSION_MIN)));
+            boolean hasTagValues = configuration.hasTagValues();
+            Integer specificationVersion = Integer.parseInt(
+                    properties.getProperty(Constants.PROPERTY_NAME_FILE_SPECIFICATION_VERSION_MIN));
+            if (hasTagValues)
+                specificationVersion = (specificationVersion > 5) ? specificationVersion : 5;
+            if (multilingual)
+                specificationVersion = (specificationVersion > 4) ? specificationVersion : 4;
+            if (specificationVersion > Integer.parseInt(
+                    properties.getProperty(Constants.PROPERTY_NAME_FILE_SPECIFICATION_VERSION_MAX))) {
+                throw new RuntimeException("map file specification version is not supported");
+            }
+            configuration.setFileSpecificationVersion(specificationVersion);
 
             LOGGER.info("mapfile-writer version: " + configuration.getWriterVersion());
-            LOGGER.info("mapfile format specification version: " + configuration.getFileSpecificationVersion());
+            LOGGER.info("mapfile format specification version: " + specificationVersion);
         } catch (IOException e) {
             throw new RuntimeException("could not find default properties", e);
         } catch (NumberFormatException e) {

--- a/mapsforge-map-writer/src/main/java/org/mapsforge/map/writer/util/ColorsCSS.java
+++ b/mapsforge-map-writer/src/main/java/org/mapsforge/map/writer/util/ColorsCSS.java
@@ -1,0 +1,170 @@
+package org.mapsforge.map.writer.util;
+
+import java.util.HashMap;
+
+/**
+ * Colors from http://www.w3.org/TR/css3-color
+ */
+public class ColorsCSS {
+
+    static HashMap<String, Integer> sColors;
+
+    public static Integer get(String name) {
+        if (sColors == null)
+            init();
+
+        return sColors.get(name);
+    }
+
+    static void init() {
+        sColors = new HashMap<>();
+
+        sColors.put("aliceblue", Integer.valueOf(0xFFF0F8FF));
+        sColors.put("antiquewhite", Integer.valueOf(0xFFFAEBD7));
+        sColors.put("aqua", Integer.valueOf(0xFF00FFFF));
+        sColors.put("aquamarine", Integer.valueOf(0xFF7FFFD4));
+        sColors.put("azure", Integer.valueOf(0xFFF0FFFF));
+        sColors.put("beige", Integer.valueOf(0xFFF5F5DC));
+        sColors.put("bisque", Integer.valueOf(0xFFFFE4C4));
+        sColors.put("black", Integer.valueOf(0xFF000000));
+        sColors.put("blanchedalmond", Integer.valueOf(0xFFFFEBCD));
+        sColors.put("blue", Integer.valueOf(0xFF0000FF));
+        sColors.put("blueviolet", Integer.valueOf(0xFF8A2BE2));
+        sColors.put("brown", Integer.valueOf(0xFFA52A2A));
+        sColors.put("burlywood", Integer.valueOf(0xFFDEB887));
+        sColors.put("cadetblue", Integer.valueOf(0xFF5F9EA0));
+        sColors.put("chartreuse", Integer.valueOf(0xFF7FFF00));
+        sColors.put("chocolate", Integer.valueOf(0xFFD2691E));
+        sColors.put("coral", Integer.valueOf(0xFFFF7F50));
+        sColors.put("cornflowerblue", Integer.valueOf(0xFF6495ED));
+        sColors.put("cornsilk", Integer.valueOf(0xFFFFF8DC));
+        sColors.put("crimson", Integer.valueOf(0xFFDC143C));
+        sColors.put("cyan", Integer.valueOf(0xFF00FFFF));
+        sColors.put("darkblue", Integer.valueOf(0xFF00008B));
+        sColors.put("darkcyan", Integer.valueOf(0xFF008B8B));
+        sColors.put("darkgoldenrod", Integer.valueOf(0xFFB8860B));
+        sColors.put("darkgray", Integer.valueOf(0xFFA9A9A9));
+        sColors.put("darkgreen", Integer.valueOf(0xFF006400));
+        sColors.put("darkgrey", Integer.valueOf(0xFFA9A9A9));
+        sColors.put("darkkhaki", Integer.valueOf(0xFFBDB76B));
+        sColors.put("darkmagenta", Integer.valueOf(0xFF8B008B));
+        sColors.put("darkolivegreen", Integer.valueOf(0xFF556B2F));
+        sColors.put("darkorange", Integer.valueOf(0xFFFF8C00));
+        sColors.put("darkorchid", Integer.valueOf(0xFF9932CC));
+        sColors.put("darkred", Integer.valueOf(0xFF8B0000));
+        sColors.put("darksalmon", Integer.valueOf(0xFFE9967A));
+        sColors.put("darkseagreen", Integer.valueOf(0xFF8FBC8F));
+        sColors.put("darkslateblue", Integer.valueOf(0xFF483D8B));
+        sColors.put("darkslategray", Integer.valueOf(0xFF2F4F4F));
+        sColors.put("darkslategrey", Integer.valueOf(0xFF2F4F4F));
+        sColors.put("darkturquoise", Integer.valueOf(0xFF00CED1));
+        sColors.put("darkviolet", Integer.valueOf(0xFF9400D3));
+        sColors.put("deeppink", Integer.valueOf(0xFFFF1493));
+        sColors.put("deepskyblue", Integer.valueOf(0xFF00BFFF));
+        sColors.put("dimgray", Integer.valueOf(0xFF696969));
+        sColors.put("dimgrey", Integer.valueOf(0xFF696969));
+        sColors.put("dodgerblue", Integer.valueOf(0xFF1E90FF));
+        sColors.put("firebrick", Integer.valueOf(0xFFB22222));
+        sColors.put("floralwhite", Integer.valueOf(0xFFFFFAF0));
+        sColors.put("forestgreen", Integer.valueOf(0xFF228B22));
+        sColors.put("fuchsia", Integer.valueOf(0xFFFF00FF));
+        sColors.put("gainsboro", Integer.valueOf(0xFFDCDCDC));
+        sColors.put("ghostwhite", Integer.valueOf(0xFFF8F8FF));
+        sColors.put("gold", Integer.valueOf(0xFFFFD700));
+        sColors.put("goldenrod", Integer.valueOf(0xFFDAA520));
+        sColors.put("gray", Integer.valueOf(0xFF808080));
+        sColors.put("green", Integer.valueOf(0xFF008000));
+        sColors.put("greenyellow", Integer.valueOf(0xFFADFF2F));
+        sColors.put("grey", Integer.valueOf(0xFF808080));
+        sColors.put("honeydew", Integer.valueOf(0xFFF0FFF0));
+        sColors.put("hotpink", Integer.valueOf(0xFFFF69B4));
+        sColors.put("indianred", Integer.valueOf(0xFFCD5C5C));
+        sColors.put("indigo", Integer.valueOf(0xFF4B0082));
+        sColors.put("ivory", Integer.valueOf(0xFFFFFFF0));
+        sColors.put("khaki", Integer.valueOf(0xFFF0E68C));
+        sColors.put("lavender", Integer.valueOf(0xFFE6E6FA));
+        sColors.put("lavenderblush", Integer.valueOf(0xFFFFF0F5));
+        sColors.put("lawngreen", Integer.valueOf(0xFF7CFC00));
+        sColors.put("lemonchiffon", Integer.valueOf(0xFFFFFACD));
+        sColors.put("lightblue", Integer.valueOf(0xFFADD8E6));
+        sColors.put("lightcoral", Integer.valueOf(0xFFF08080));
+        sColors.put("lightcyan", Integer.valueOf(0xFFE0FFFF));
+        sColors.put("lightgoldenrodyellow", Integer.valueOf(0xFFFAFAD2));
+        sColors.put("lightgray", Integer.valueOf(0xFFD3D3D3));
+        sColors.put("lightgreen", Integer.valueOf(0xFF90EE90));
+        sColors.put("lightgrey", Integer.valueOf(0xFFD3D3D3));
+        sColors.put("lightpink", Integer.valueOf(0xFFFFB6C1));
+        sColors.put("lightsalmon", Integer.valueOf(0xFFFFA07A));
+        sColors.put("lightseagreen", Integer.valueOf(0xFF20B2AA));
+        sColors.put("lightskyblue", Integer.valueOf(0xFF87CEFA));
+        sColors.put("lightslategray", Integer.valueOf(0xFF778899));
+        sColors.put("lightslategrey", Integer.valueOf(0xFF778899));
+        sColors.put("lightsteelblue", Integer.valueOf(0xFFB0C4DE));
+        sColors.put("lightyellow", Integer.valueOf(0xFFFFFFE0));
+        sColors.put("lime", Integer.valueOf(0xFF00FF00));
+        sColors.put("limegreen", Integer.valueOf(0xFF32CD32));
+        sColors.put("linen", Integer.valueOf(0xFFFAF0E6));
+        sColors.put("magenta", Integer.valueOf(0xFFFF00FF));
+        sColors.put("maroon", Integer.valueOf(0xFF800000));
+        sColors.put("mediumaquamarine", Integer.valueOf(0xFF66CDAA));
+        sColors.put("mediumblue", Integer.valueOf(0xFF0000CD));
+        sColors.put("mediumorchid", Integer.valueOf(0xFFBA55D3));
+        sColors.put("mediumpurple", Integer.valueOf(0xFF9370DB));
+        sColors.put("mediumseagreen", Integer.valueOf(0xFF3CB371));
+        sColors.put("mediumslateblue", Integer.valueOf(0xFF7B68EE));
+        sColors.put("mediumspringgreen", Integer.valueOf(0xFF00FA9A));
+        sColors.put("mediumturquoise", Integer.valueOf(0xFF48D1CC));
+        sColors.put("mediumvioletred", Integer.valueOf(0xFFC71585));
+        sColors.put("midnightblue", Integer.valueOf(0xFF191970));
+        sColors.put("mintcream", Integer.valueOf(0xFFF5FFFA));
+        sColors.put("mistyrose", Integer.valueOf(0xFFFFE4E1));
+        sColors.put("moccasin", Integer.valueOf(0xFFFFE4B5));
+        sColors.put("navajowhite", Integer.valueOf(0xFFFFDEAD));
+        sColors.put("navy", Integer.valueOf(0xFF000080));
+        sColors.put("oldlace", Integer.valueOf(0xFFFDF5E6));
+        sColors.put("olive", Integer.valueOf(0xFF808000));
+        sColors.put("olivedrab", Integer.valueOf(0xFF6B8E23));
+        sColors.put("orange", Integer.valueOf(0xFFFFA500));
+        sColors.put("orangered", Integer.valueOf(0xFFFF4500));
+        sColors.put("orchid", Integer.valueOf(0xFFDA70D6));
+        sColors.put("palegoldenrod", Integer.valueOf(0xFFEEE8AA));
+        sColors.put("palegreen", Integer.valueOf(0xFF98FB98));
+        sColors.put("paleturquoise", Integer.valueOf(0xFFAFEEEE));
+        sColors.put("palevioletred", Integer.valueOf(0xFFDB7093));
+        sColors.put("papayawhip", Integer.valueOf(0xFFFFEFD5));
+        sColors.put("peachpuff", Integer.valueOf(0xFFFFDAB9));
+        sColors.put("peru", Integer.valueOf(0xFFCD853F));
+        sColors.put("pink", Integer.valueOf(0xFFFFC0CB));
+        sColors.put("plum", Integer.valueOf(0xFFDDA0DD));
+        sColors.put("powderblue", Integer.valueOf(0xFFB0E0E6));
+        sColors.put("purple", Integer.valueOf(0xFF800080));
+        sColors.put("red", Integer.valueOf(0xFFFF0000));
+        sColors.put("rosybrown", Integer.valueOf(0xFFBC8F8F));
+        sColors.put("royalblue", Integer.valueOf(0xFF4169E1));
+        sColors.put("saddlebrown", Integer.valueOf(0xFF8B4513));
+        sColors.put("salmon", Integer.valueOf(0xFFFA8072));
+        sColors.put("sandybrown", Integer.valueOf(0xFFF4A460));
+        sColors.put("seagreen", Integer.valueOf(0xFF2E8B57));
+        sColors.put("seashell", Integer.valueOf(0xFFFFF5EE));
+        sColors.put("sienna", Integer.valueOf(0xFFA0522D));
+        sColors.put("silver", Integer.valueOf(0xFFC0C0C0));
+        sColors.put("skyblue", Integer.valueOf(0xFF87CEEB));
+        sColors.put("slateblue", Integer.valueOf(0xFF6A5ACD));
+        sColors.put("slategray", Integer.valueOf(0xFF708090));
+        sColors.put("slategrey", Integer.valueOf(0xFF708090));
+        sColors.put("snow", Integer.valueOf(0xFFFFFAFA));
+        sColors.put("springgreen", Integer.valueOf(0xFF00FF7F));
+        sColors.put("steelblue", Integer.valueOf(0xFF4682B4));
+        sColors.put("tan", Integer.valueOf(0xFFD2B48C));
+        sColors.put("teal", Integer.valueOf(0xFF008080));
+        sColors.put("thistle", Integer.valueOf(0xFFD8BFD8));
+        sColors.put("tomato", Integer.valueOf(0xFFFF6347));
+        sColors.put("turquoise", Integer.valueOf(0xFF40E0D0));
+        sColors.put("violet", Integer.valueOf(0xFFEE82EE));
+        sColors.put("wheat", Integer.valueOf(0xFFF5DEB3));
+        sColors.put("white", Integer.valueOf(0xFFFFFFFF));
+        sColors.put("whitesmoke", Integer.valueOf(0xFFF5F5F5));
+        sColors.put("yellow", Integer.valueOf(0xFFFFFF00));
+        sColors.put("yellowgreen", Integer.valueOf(0xFF9ACD32));
+    }
+}

--- a/resources/tag-mapping.xsd
+++ b/resources/tag-mapping.xsd
@@ -43,6 +43,10 @@
                 <documentation>
                     The value of the OpenStreetMap tag. E.g. 'primary'
                     in the tag 'highway=primary'.
+                    If tags have no fixed value, you can use "%f" for float and
+                    other numerical values and "%s" for string values. Avoid using the string
+                    wildcard, because it causes much overhead. Instead use osm specific
+                    strings. Color strings and hex code can be declared as numeric value, too.
                 </documentation>
             </annotation>
             <simpleType>


### PR DESCRIPTION
With this modification, all OSM-tag values (such as numerical and string values) can be saved in mapsforge .map format without specify a fixed value term in `tag-mapping.xml`. 
For that the wildcards `"%f"` (float) for numerical and `"%s"` for string values can be used. Internally the values are cast to the smallest possible type (like Byte: `%b`, Short: `%h`, Int: `%i`). Using `%s` wildcard is not recommended, better use ready `osm-tag`s. Colors can internally be converted to `int` values with `%f` wildcard.

The map-writer can be used for older versions too, if tag-values are disabled. If not, new specification doesn't allow older readers to read new one. New Readers won't have a problem to read them all. The tag-value bit in file header is not needed, but I set it, because I can't decide if assumes a role for later versions.

The writing performance keeps very similar. I inherited some S3DB-tags, (especially height tag) and the map file size only increases around 0,24% in my case.

_Why is it useful?_ 
Until now, no additional data could be stored (apart from concrete feature tags, like the house number).
Now heights, colors, angles and much more can be inherited, with marginal overhead.
This is not meant to include concrete style elements. E.g. colors and materials are only an assistance for later rendering.

Let me know what you think of ;D