### PR TITLE
map-writer maps v5: reference building-parts to buildings (implicit relations)

### DIFF
--- a/mapsforge-map-writer/src/main/config/tag-mapping.xml
+++ b/mapsforge-map-writer/src/main/config/tag-mapping.xml
@@ -143,6 +143,9 @@
 
 
     <!-- ************* WAYS *************** -->
+    <ways>
+        <osm-tag key="id" renderable="false" value="%f" />
+    </ways>
 
     <!-- HIGHWAY TAGS -->
     <ways>

--- a/mapsforge-map-writer/src/main/java/org/mapsforge/map/writer/HDTileData.java
+++ b/mapsforge-map-writer/src/main/java/org/mapsforge/map/writer/HDTileData.java
@@ -40,6 +40,7 @@ public class HDTileData extends TileData {
 
     @Override
     public final void addWay(TDWay way) {
+        // TODO #HDstoreData: store whole object data, not only the id
         this.ways.add(way.getId());
     }
 

--- a/mapsforge-map-writer/src/main/java/org/mapsforge/map/writer/RAMTileBasedDataProcessor.java
+++ b/mapsforge-map-writer/src/main/java/org/mapsforge/map/writer/RAMTileBasedDataProcessor.java
@@ -25,7 +25,6 @@ import org.mapsforge.map.writer.model.TileCoordinate;
 import org.mapsforge.map.writer.model.TileData;
 import org.mapsforge.map.writer.model.TileInfo;
 import org.mapsforge.map.writer.model.ZoomIntervalConfiguration;
-import org.mapsforge.map.writer.util.GeoUtils;
 import org.openstreetmap.osmosis.core.domain.v0_6.Node;
 import org.openstreetmap.osmosis.core.domain.v0_6.Relation;
 import org.openstreetmap.osmosis.core.domain.v0_6.Way;
@@ -100,18 +99,7 @@ public final class RAMTileBasedDataProcessor extends BaseTileBasedDataProcessor 
         this.ways.put(tdWay.getId(), tdWay);
         this.maxWayID = Math.max(this.maxWayID, way.getId());
 
-        if (tdWay.isCoastline()) {
-            // find matching tiles on zoom level 12
-            Set<TileCoordinate> coastLineTiles = GeoUtils.mapWayToTiles(tdWay, TileInfo.TILE_INFO_ZOOMLEVEL, 0);
-            for (TileCoordinate tileCoordinate : coastLineTiles) {
-                TLongHashSet coastlines = this.tilesToCoastlines.get(tileCoordinate);
-                if (coastlines == null) {
-                    coastlines = new TLongHashSet();
-                    this.tilesToCoastlines.put(tileCoordinate, coastlines);
-                }
-                coastlines.add(tdWay.getId());
-            }
-        }
+        this.prepareImplicitWayRelations(tdWay);
     }
 
     @Override
@@ -121,10 +109,14 @@ public final class RAMTileBasedDataProcessor extends BaseTileBasedDataProcessor 
 
     @Override
     public void complete() {
+        handleImplicitWayRelations();
+
         // Polygonize multipolygon
+        LOGGER.info("handle relations...");
         RelationHandler relationHandler = new RelationHandler();
         this.multipolygons.forEachValue(relationHandler);
 
+        LOGGER.info("handle ways...");
         WayHandler wayHandler = new WayHandler();
         this.ways.forEachValue(wayHandler);
 

--- a/mapsforge-map-writer/src/main/java/org/mapsforge/map/writer/model/OSMTag.java
+++ b/mapsforge-map-writer/src/main/java/org/mapsforge/map/writer/model/OSMTag.java
@@ -122,6 +122,20 @@ public class OSMTag {
     }
 
     /**
+     * @return whether the tag represents a building
+     */
+    public final boolean isBuilding() {
+        return this.key.equals("building");
+    }
+
+    /**
+     * @return whether the tag represents a building
+     */
+    public final boolean isBuildingPart() {
+        return this.key.equals("building:part");
+    }
+
+    /**
      * @return whether the tag represents a coastline
      */
     public final boolean isCoastline() {

--- a/mapsforge-map-writer/src/main/java/org/mapsforge/map/writer/model/TDWay.java
+++ b/mapsforge-map-writer/src/main/java/org/mapsforge/map/writer/model/TDWay.java
@@ -254,6 +254,36 @@ public class TDWay {
     }
 
     /**
+     * @return true, if the way represents a root element
+     */
+    public boolean isRootElement() {
+        List<OSMTag> osmTags = OSMTagMapping.getInstance().getWayTags(this.tags.keySet());
+        for (OSMTag tag : osmTags) {
+            // May add more tags
+            if (tag.isBuilding()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return true, if the way represents a part element
+     */
+    public boolean isPartElement() {
+        List<OSMTag> osmTags = OSMTagMapping.getInstance().getWayTags(this.tags.keySet());
+        for (OSMTag tag : osmTags) {
+            // May add more tags
+            if (tag.isBuildingPart()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * @return true, if the way represents a coastline
      */
     public boolean isCoastline() {

--- a/mapsforge-map-writer/src/main/java/org/mapsforge/map/writer/util/OSMUtils.java
+++ b/mapsforge-map-writer/src/main/java/org/mapsforge/map/writer/util/OSMUtils.java
@@ -63,23 +63,8 @@ public final class OSMUtils {
             for (Tag tag : entity.getTags()) {
                 OSMTag poiTag = mapping.getPoiTag(tag.getKey(), tag.getValue());
                 if (poiTag != null) {
-                    Object value = null;
                     String wildcard = poiTag.getValue();
-                    if (wildcard.charAt(0) == '%' && wildcard.length() == 2) {
-                        Character format = wildcard.charAt(1);
-                        if (format == 'b') {
-                            value = getByteValue(tag.getValue());
-                        } else if (format == 'i') {
-                            value = getIntegerValue(tag.getValue());
-                        } else if (format == 'f') {
-                            value = getFloatValue(tag.getValue());
-                        } else if (format == 'h') {
-                            value = getShortValue(tag.getValue());
-                        } else if (format == 's') {
-                            value = getStringValue(tag.getValue());
-                        }
-                    }
-                    tagMap.put(poiTag.getId(), value);
+                    tagMap.put(poiTag.getId(), getObjectFromWildcardAndValue(wildcard, tag.getValue()));
                 }
             }
         }
@@ -99,23 +84,8 @@ public final class OSMUtils {
             for (Tag tag : entity.getTags()) {
                 OSMTag wayTag = mapping.getWayTag(tag.getKey(), tag.getValue());
                 if (wayTag != null) {
-                    Object value = null;
                     String wildcard = wayTag.getValue();
-                    if (wildcard.charAt(0) == '%' && wildcard.length() == 2) {
-                        Character format = wildcard.charAt(1);
-                        if (format == 'b') {
-                            value = getByteValue(tag.getValue());
-                        } else if (format == 'i') {
-                            value = getIntegerValue(tag.getValue());
-                        } else if (format == 'f') {
-                            value = getFloatValue(tag.getValue());
-                        } else if (format == 'h') {
-                            value = getShortValue(tag.getValue());
-                        } else if (format == 's') {
-                            value = getStringValue(tag.getValue());
-                        }
-                    }
-                    tagMap.put(wayTag.getId(), value);
+                    tagMap.put(wayTag.getId(), getObjectFromWildcardAndValue(wildcard, tag.getValue()));
                 }
             }
         }
@@ -300,6 +270,29 @@ public final class OSMUtils {
             integer = OSMUtils.parseDoubleUnit(value).intValue();
         }
         return integer;
+    }
+
+    /**
+     * @param wildcard the type of value as wildcard
+     * @param value    the value as string
+     * @return an object that represents value
+     */
+    public static Object getObjectFromWildcardAndValue(String wildcard, String value) {
+        if (wildcard.charAt(0) == '%' && wildcard.length() == 2) {
+            Character format = wildcard.charAt(1);
+            if (format == 'b') {
+                return getByteValue(value);
+            } else if (format == 'i') {
+                return getIntegerValue(value);
+            } else if (format == 'f') {
+                return getFloatValue(value);
+            } else if (format == 'h') {
+                return getShortValue(value);
+            } else if (format == 's') {
+                return getStringValue(value);
+            }
+        }
+        return null;
     }
 
     /**


### PR DESCRIPTION
Hi,
I added the relation between building parts and its buildings like described in #1012. I called them implicit relations in code. I only added an `id` to the elements which contain parts. Parts have a `ref`-tag.
See [root_id](https://mapzen.com/documentation/vector-tiles/layers/) in Mapzen.
Here an example, how i solved it in VTM; ~~I will start a PR there, if this is a good approach~~:
![artifacts](https://user-images.githubusercontent.com/18537755/32916858-a09e62e6-cb1d-11e7-9f1b-95c3d327887b.jpg)

The increasement of file space is not noticeable (only possible with v5). It needs a little bit longer to calculate in HD'processor. 
Under `#HDstoreData` I added a `TODO`, which may can improve the process of whole HD'processing...

While implementing, I noticed that the `tilesToCoastlines` in `BaseTileBasedDataProcessor` wasn't updated by HD'processor, but nothing had influence on the result. What is the reason for that?

BTW: I added some logging code, which is not necessarily bonded on the pull request. You're always welcome to change my code yourself or request changes.