### PR TITLE
mapsforge-map-writer: reference all part elements

### DIFF
--- a/mapsforge-map-writer/src/main/config/tag-mapping.xml
+++ b/mapsforge-map-writer/src/main/config/tag-mapping.xml
@@ -421,14 +421,15 @@
         <osm-tag key="roof:angle" renderable="false" value="%f" />
         <osm-tag key="roof:levels" renderable="false" value="%f" />
         <osm-tag key="roof:direction" renderable="false" value="%f" />
-        <!--<osm-tag equivalent-values="N,n,north" key="roof:direction" renderable="false" value="0" />-->
-        <!--<osm-tag equivalent-values="NE,ne" key="roof:direction" renderable="false" value="45" />-->
-        <!--<osm-tag equivalent-values="NW,nw" key="roof:direction" renderable="false" value="315" />-->
-        <!--<osm-tag equivalent-values="S,s,south" key="roof:direction" renderable="false" value="180" />-->
-        <!--<osm-tag equivalent-values="SE,se" key="roof:direction" renderable="false" value="135" />-->
-        <!--<osm-tag equivalent-values="SW,sw" key="roof:direction" renderable="false" value="225" />-->
-        <!--<osm-tag equivalent-values="E,e,east" key="roof:direction" renderable="false" value="90" />-->
-        <!--<osm-tag equivalent-values="W,w,west" key="roof:direction" renderable="false" value="270" />-->
+        <osm-tag equivalent-values="N,n,north" key="roof:direction" renderable="false" value="0" />
+        <osm-tag equivalent-values="NE,ne" key="roof:direction" renderable="false" value="45" />
+        <osm-tag equivalent-values="NW,nw" key="roof:direction" renderable="false" value="315" />
+        <osm-tag equivalent-values="S,s,south" key="roof:direction" renderable="false"
+            value="180" />
+        <osm-tag equivalent-values="SE,se" key="roof:direction" renderable="false" value="135" />
+        <osm-tag equivalent-values="SW,sw" key="roof:direction" renderable="false" value="225" />
+        <osm-tag equivalent-values="E,e,east" key="roof:direction" renderable="false" value="90" />
+        <osm-tag equivalent-values="W,w,west" key="roof:direction" renderable="false" value="270" />
 
 
         <osm-tag key="building:colour" renderable="false" value="%f" />

--- a/mapsforge-map-writer/src/main/java/org/mapsforge/map/writer/BaseTileBasedDataProcessor.java
+++ b/mapsforge-map-writer/src/main/java/org/mapsforge/map/writer/BaseTileBasedDataProcessor.java
@@ -513,8 +513,8 @@ abstract class BaseTileBasedDataProcessor implements TileBasedDataProcessor, Nod
             return;
         }
 
-        int progressImplicitRelations = 0;
-        float limitImplicitRelations = this.tilesToPartElements.entrySet().size();
+        /*int progressImplicitRelations = 0;
+        float limitImplicitRelations = this.tilesToPartElements.entrySet().size();*/
 
         // Iterate through tiles which contain parts
         for (Map.Entry<TileCoordinate, TLongHashSet> tilePartElementEntry : this.tilesToPartElements.entrySet()) {
@@ -527,12 +527,12 @@ abstract class BaseTileBasedDataProcessor implements TileBasedDataProcessor, Nod
             }
 
             // Log
-            String wayRelLog = "Progress: Implicit relations "
+            /*String wayRelLog = "Progress: Implicit relations "
                     + ((int) ((progressImplicitRelations / limitImplicitRelations) * 100))
                     + "%% - Tile (" + tilePartElementEntry.getKey().getX()
                     + ", " + tilePartElementEntry.getKey().getY() + ")";
             progressImplicitRelations++;
-            int nRootElements = 0;
+            int nRootElements = 0;*/
 
             // Load parts only once in cache
             List<TDWay> pElems = new ArrayList<>();
@@ -593,7 +593,6 @@ abstract class BaseTileBasedDataProcessor implements TileBasedDataProcessor, Nod
                         // Remove part which is already referenced
                         pElems.remove(pElem);
                         tilePartElementEntry.getValue().remove(pElem.getId());
-                        break;
                     }
                 }
             }


### PR DESCRIPTION
- reference all part elements (not only the first one; necessary to pass tags on to parts in reader)
- tag-mapping: enable roof directions

Minimal increased size and processing time
