### PR TITLE
mapsforge-map-writer: add places of worship as areas

### DIFF
--- a/mapsforge-map-writer/src/main/config/tag-mapping.xml
+++ b/mapsforge-map-writer/src/main/config/tag-mapping.xml
@@ -280,11 +280,16 @@
         <osm-tag key="amenity" value="grave_yard" zoom-appear="14" />
         <osm-tag key="amenity" value="hospital" zoom-appear="13" />
         <osm-tag key="amenity" value="parking" zoom-appear="14" />
+        <osm-tag key="amenity" value="place_of_worship" zoom-appear="14" />
         <osm-tag key="amenity" value="school" zoom-appear="14" />
         <osm-tag key="amenity" value="swimming_pool" zoom-appear="14" />
         <osm-tag key="amenity" value="theatre" zoom-appear="14" />
         <osm-tag key="amenity" value="toilets" zoom-appear="17" />
         <osm-tag key="amenity" value="university" zoom-appear="13" />
+
+        <osm-tag key="religion" renderable="false" value="christian" />
+        <osm-tag key="religion" renderable="false" value="jewish" />
+        <osm-tag key="religion" renderable="false" value="muslim" />
 
         <osm-tag key="tourism" value="attraction" zoom-appear="14" />
         <osm-tag key="tourism" value="hostel" zoom-appear="15" />


### PR DESCRIPTION
Until now only nodes are stored as place of worship. So churches and similar not were discernible.
Now areas are displayed too. Also plan to support more ways/areas incl. symbols in VTM.