### PR TITLE
Mapsforge maps v5: allow arbitrary tag keys

### DIFF
--- a/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/TextKey.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/TextKey.java
@@ -16,30 +16,19 @@ package org.mapsforge.map.rendertheme.renderinstruction;
 
 import org.mapsforge.core.model.Tag;
 
+import java.util.HashMap;
 import java.util.List;
 
 final class TextKey {
-    private static final String KEY_ELEVATION = "ele";
-    private static final String KEY_HOUSENUMBER = "addr:housenumber";
-    private static final String KEY_NAME = "name";
-    private static final String KEY_REF = "ref";
-    private static final TextKey TEXT_KEY_ELEVATION = new TextKey(KEY_ELEVATION);
-    private static final TextKey TEXT_KEY_HOUSENUMBER = new TextKey(KEY_HOUSENUMBER);
-    private static final TextKey TEXT_KEY_NAME = new TextKey(KEY_NAME);
-    private static final TextKey TEXT_KEY_REF = new TextKey(KEY_REF);
+    private static final HashMap<String, TextKey> textKeys = new HashMap<>();
 
     static TextKey getInstance(String key) {
-        if (KEY_ELEVATION.equals(key)) {
-            return TEXT_KEY_ELEVATION;
-        } else if (KEY_HOUSENUMBER.equals(key)) {
-            return TEXT_KEY_HOUSENUMBER;
-        } else if (KEY_NAME.equals(key)) {
-            return TEXT_KEY_NAME;
-        } else if (KEY_REF.equals(key)) {
-            return TEXT_KEY_REF;
-        } else {
-            throw new IllegalArgumentException("invalid key: " + key);
+        TextKey textKey = textKeys.get(key);
+        if (textKey == null) {
+            textKey = new TextKey(key);
+            textKeys.put(key, textKey);
         }
+        return textKey;
     }
 
     private final String key;


### PR DESCRIPTION
Implements #1041.
Seems to work fine, I now got my nice zoom-level dependent captions without needing to abue the name/housenumber/... fields.