### PR TITLE
Manual zoom/move listener

### DIFF
--- a/mapsforge-map-android/src/main/java/org/mapsforge/map/android/input/MapZoomControls.java
+++ b/mapsforge-map-android/src/main/java/org/mapsforge/map/android/input/MapZoomControls.java
@@ -117,7 +117,7 @@ public class MapZoomControls extends LinearLayout implements Observer {
     private final Handler zoomControlsHideHandler;
     private byte zoomLevelMax, zoomLevelMin;
 
-    public MapZoomControls(Context context, MapView mapView) {
+    public MapZoomControls(Context context, final MapView mapView) {
         super(context);
         this.mapView = mapView;
         this.autoHide = true;
@@ -148,12 +148,14 @@ public class MapZoomControls extends LinearLayout implements Observer {
         buttonZoomIn.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View view) {
+                mapView.manualZoomStarted();
                 MapZoomControls.this.mapView.getModel().mapViewPosition.zoomIn();
             }
         });
         buttonZoomOut.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View view) {
+                mapView.manualZoomStarted();
                 MapZoomControls.this.mapView.getModel().mapViewPosition.zoomOut();
             }
         });

--- a/mapsforge-map-android/src/main/java/org/mapsforge/map/android/input/TouchGestureHandler.java
+++ b/mapsforge-map-android/src/main/java/org/mapsforge/map/android/input/TouchGestureHandler.java
@@ -92,6 +92,8 @@ public class TouchGestureHandler extends GestureDetector.SimpleOnGestureListener
                         double moveVertical = (center.y - e.getY()) / Math.pow(2, zoomLevelDiff);
                         LatLong pivot = this.mapView.getMapViewProjection().fromPixels(e.getX(), e.getY());
                         if (pivot != null) {
+                            mapView.manualZoomStarted();
+
                             mapViewPosition.setPivot(pivot);
                             mapViewPosition.moveCenterAndZoom(moveHorizontal, moveVertical, zoomLevelDiff);
                         }
@@ -166,6 +168,7 @@ public class TouchGestureHandler extends GestureDetector.SimpleOnGestureListener
             this.focusX = detector.getFocusX();
             this.focusY = detector.getFocusY();
             this.pivot = this.mapView.getMapViewProjection().fromPixels(focusX, focusY);
+            mapView.manualZoomStarted();
         }
         return true;
     }
@@ -218,6 +221,7 @@ public class TouchGestureHandler extends GestureDetector.SimpleOnGestureListener
     @Override
     public boolean onScroll(MotionEvent e1, MotionEvent e2, float distanceX, float distanceY) {
         if (!this.isInScale && e1.getPointerCount() == 1 && e2.getPointerCount() == 1) {
+            mapView.manualMoveStarted();
             this.mapView.getModel().mapViewPosition.moveCenter(-distanceX, -distanceY, false);
             return true;
         }

--- a/mapsforge-map-android/src/main/java/org/mapsforge/map/android/view/MapView.java
+++ b/mapsforge-map-android/src/main/java/org/mapsforge/map/android/view/MapView.java
@@ -119,6 +119,8 @@ public class MapView extends ViewGroup implements org.mapsforge.map.view.MapView
     private final ScaleGestureDetector scaleGestureDetector;
     private final TouchGestureHandler touchGestureHandler;
 
+    private final List<IManualInputListener> manualInputListeners = new LinkedList<>();
+
     public MapView(Context context) {
         this(context, null);
     }
@@ -473,4 +475,29 @@ public class MapView extends ViewGroup implements org.mapsforge.map.view.MapView
         this.model.mapViewPosition.setZoomLevelMin(zoomLevelMin);
         this.mapZoomControls.setZoomLevelMin(zoomLevelMin);
     }
+
+    @Override
+    public void registerManualInputListener(IManualInputListener manualInputListener) {
+        manualInputListeners.add(manualInputListener);
+    }
+
+    @Override
+    public void unregisterManualInputListener(IManualInputListener manualInputListener) {
+        manualInputListeners.remove(manualInputListener);
+    }
+
+    @Override
+    public void manualMoveStarted() {
+        for (IManualInputListener manualInputListener : manualInputListeners) {
+            manualInputListener.manualMoveStarted();
+        }
+    }
+
+    @Override
+    public void manualZoomStarted() {
+        for (IManualInputListener manualInputListener : manualInputListeners) {
+            manualInputListener.manualZoomStarted();
+        }
+    }
+
 }

--- a/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/input/MouseEventListener.java
+++ b/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/input/MouseEventListener.java
@@ -57,6 +57,8 @@ public class MouseEventListener extends MouseAdapter {
         if (SwingUtilities.isLeftMouseButton(e)) {
             Point point = e.getPoint();
             if (this.lastDragPoint != null) {
+                mapView.manualMoveStarted();
+
                 int moveHorizontal = point.x - this.lastDragPoint.x;
                 int moveVertical = point.y - this.lastDragPoint.y;
                 this.mapView.getModel().mapViewPosition.moveCenter(moveHorizontal, moveVertical);
@@ -80,6 +82,7 @@ public class MouseEventListener extends MouseAdapter {
     @Override
     public void mouseWheelMoved(MouseWheelEvent e) {
         byte zoomLevelDiff = (byte) -e.getWheelRotation();
+            mapView.manualZoomStarted();
         this.mapView.getModel().mapViewPosition.zoom(zoomLevelDiff);
     }
 }

--- a/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/view/MapView.java
+++ b/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/view/MapView.java
@@ -40,9 +40,12 @@ import org.mapsforge.map.util.MapViewProjection;
 import org.mapsforge.map.view.FpsCounter;
 import org.mapsforge.map.view.FrameBuffer;
 import org.mapsforge.map.view.FrameBufferHA2;
+import org.mapsforge.map.view.IManualInputListener;
 
 import java.awt.Container;
 import java.awt.Graphics;
+import java.util.LinkedList;
+import java.util.List;
 
 public class MapView extends Container implements org.mapsforge.map.view.MapView {
 
@@ -56,6 +59,8 @@ public class MapView extends Container implements org.mapsforge.map.view.MapView
     private MapScaleBar mapScaleBar;
     private final MapViewProjection mapViewProjection;
     private final Model model;
+
+    private final List<IManualInputListener> manualInputListeners = new LinkedList<>();
 
     public MapView() {
         super();
@@ -210,5 +215,29 @@ public class MapView extends Container implements org.mapsforge.map.view.MapView
     @Override
     public void setZoomLevelMin(byte zoomLevelMin) {
         this.model.mapViewPosition.setZoomLevelMin(zoomLevelMin);
+    }
+
+    @Override
+    public void registerManualInputListener(IManualInputListener manualInputListener) {
+        manualInputListeners.add(manualInputListener);
+    }
+
+    @Override
+    public void unregisterManualInputListener(IManualInputListener manualInputListener) {
+        manualInputListeners.remove(manualInputListener);
+    }
+
+    @Override
+    public void manualMoveStarted() {
+        for (IManualInputListener manualInputListener : manualInputListeners) {
+            manualInputListener.manualMoveStarted();
+        }
+    }
+
+    @Override
+    public void manualZoomStarted() {
+        for (IManualInputListener manualInputListener : manualInputListeners) {
+            manualInputListener.manualZoomStarted();
+        }
     }
 }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/view/IManualInputListener.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/view/IManualInputListener.java
@@ -1,0 +1,23 @@
+package org.mapsforge.map.view;
+
+/**
+ * This listener can be used to get informed about _manual_ changes of position or zoom. It will not inform about automatic (software-driven) changes.
+ * The intentional purpose for this class is to switch off automatic positioning or automatic zooming as soon as the user takes manual positioning or zooming.
+ * <p>
+ * Created by Mike on 11/11/2017.
+ */
+
+public interface IManualInputListener {
+
+    /**
+     * a manual movement has been started. The user drags the map over the screen. This method is called before any movement takes place. There is no
+     * guarantee that this method is called just once per user intervention.
+     */
+    void manualMoveStarted();
+
+    /**
+     * a manual zoom has been started. The user uses pinch-to-zoom, uses its mousewheel or the ZoomControls. This method is called before any zoom takes place.
+     * There is no guarantee that this method is called just once per user intervention.
+     */
+    void manualZoomStarted();
+}

--- a/mapsforge-map/src/main/java/org/mapsforge/map/view/MapView.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/view/MapView.java
@@ -76,4 +76,22 @@ public interface MapView {
     void setZoomLevelMax(byte zoomLevelMax);
 
     void setZoomLevelMin(byte zoomLevelMin);
+
+    void registerManualInputListener(IManualInputListener manualInputListener);
+
+    void unregisterManualInputListener(IManualInputListener manualInputListener);
+
+    /**
+     * This method is called by internal programs only. The underlying mapView implementation will notify registered
+     * {@link IManualInputListener} about the start of a manual zoom. Notify that this method may be called multiple
+     * times while the zoom has been started. Also note that only manual zooms gets notified.
+     */
+    void manualZoomStarted();
+
+    /**
+     * This method is called by internal programs only. The underlying mapView implementation will notify registered
+     * {@link IManualInputListener} about the start of a manual move. Notify that this method may be called multiple
+     * times while the move has been started. Also note that only manual moves gets notified.
+     */
+    void manualMoveStarted();
 }


### PR DESCRIPTION
Introduces a Listener for manual zooming/manual move. Will be called when the user drags or pinches the map. Also be called when dragging with the mouse or using the scrollwheel. 

Note that the listening methods may be called multiple times. 

This listener can be used to get notified when the user moves or zooms the map and eventually switch off automatic zooming/moving. 