### PR TITLE
fix deadlock

### DIFF
--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/LayerManager.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/LayerManager.java
@@ -42,7 +42,8 @@ public class LayerManager extends PausableThread implements Redrawer {
 
     public LayerManager(MapView mapView, IMapViewPosition mapViewPosition, GraphicFactory graphicFactory) {
         super();
-
+        
+        this.waitForDoWork = true;
         this.mapView = mapView;
         this.mapViewPosition = mapViewPosition;
 

--- a/mapsforge-map/src/main/java/org/mapsforge/map/util/PausableThread.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/util/PausableThread.java
@@ -123,8 +123,8 @@ public abstract class PausableThread extends Thread {
     public final void run() {
         setName(getClass().getSimpleName());
         setPriority(getThreadPriority().priority);
-		
-        while ((!this.shouldStop && !isInterrupted()) || hasWork()) {
+
+        while (!this.shouldStop && !isInterrupted()) {
             synchronized (this) {
                 while (!this.shouldStop && !isInterrupted() && (this.shouldPause || !hasWork())) {
                     try {
@@ -139,7 +139,7 @@ public abstract class PausableThread extends Thread {
                 }
             }
 
-            if ((this.shouldStop || isInterrupted()) && !hasWork()) {
+            if (this.shouldStop || isInterrupted()) {
                 break;
             }
 

--- a/mapsforge-map/src/main/java/org/mapsforge/map/util/PausableThread.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/util/PausableThread.java
@@ -61,6 +61,7 @@ public abstract class PausableThread extends Thread {
     private boolean pausing;
     private boolean shouldPause;
     private boolean shouldStop;
+    protected boolean waitForDoWork;
 
     /**
      * Causes the current thread to wait until this thread is pausing.
@@ -124,7 +125,7 @@ public abstract class PausableThread extends Thread {
         setName(getClass().getSimpleName());
         setPriority(getThreadPriority().priority);
 
-        while (!this.shouldStop && !isInterrupted()) {
+        while ((!this.shouldStop && !isInterrupted()) || (waitForDoWork && hasWork())) {
             synchronized (this) {
                 while (!this.shouldStop && !isInterrupted() && (this.shouldPause || !hasWork())) {
                     try {
@@ -139,7 +140,7 @@ public abstract class PausableThread extends Thread {
                 }
             }
 
-            if (this.shouldStop || isInterrupted()) {
+            if ((this.shouldStop || isInterrupted()) && (!waitForDoWork || !hasWork())) {
                 break;
             }
 

--- a/mapsforge-map/src/main/java/org/mapsforge/map/util/PausableThread.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/util/PausableThread.java
@@ -123,8 +123,8 @@ public abstract class PausableThread extends Thread {
     public final void run() {
         setName(getClass().getSimpleName());
         setPriority(getThreadPriority().priority);
-
-        while (!this.shouldStop && !isInterrupted()) {
+		
+        while ((!this.shouldStop && !isInterrupted()) || hasWork()) {
             synchronized (this) {
                 while (!this.shouldStop && !isInterrupted() && (this.shouldPause || !hasWork())) {
                     try {
@@ -139,7 +139,7 @@ public abstract class PausableThread extends Thread {
                 }
             }
 
-            if (this.shouldStop || isInterrupted()) {
+            if ((this.shouldStop || isInterrupted()) && !hasWork()) {
                 break;
             }
 


### PR DESCRIPTION
If a mapView is created and destroyed very quickly can happen that LayerManager locks a Bitmap using getDrawingBitmap and the lock is not realeased until there is an animation in progress, so PausableThread need to execute all the pending work before exit to avoid deadlocks