### PR TITLE
POI: allow tag keys as category

### DIFF
--- a/mapsforge-poi-writer/src/main/config/poi-mapping.xml
+++ b/mapsforge-poi-writer/src/main/config/poi-mapping.xml
@@ -1546,4 +1546,10 @@
         </category>
     </category>
 
+    <!-- Address search -->
+    <!--<category title="Address">
+        <mapping tag="addr:street" />
+        <mapping tag="addr:housenumber" />
+    </category>-->
+
 </category>

--- a/mapsforge-poi-writer/src/main/java/org/mapsforge/poi/writer/PoiWriter.java
+++ b/mapsforge-poi-writer/src/main/java/org/mapsforge/poi/writer/PoiWriter.java
@@ -472,6 +472,10 @@ public final class PoiWriter {
                 try {
                     // Get categories from tag
                     List<PoiCategory> pcs = this.tagMappingResolver.getCategoriesFromTag(tagStr);
+                    // Get categories from key, if tag wasn't matching
+                    // This means that key categories should be parents of their tag values.
+                    if (pcs == null)
+                        pcs = this.tagMappingResolver.getCategoriesFromTag(key);
 
                     if (pcs != null) {
                         for (PoiCategory pc : pcs) {

--- a/mapsforge-poi-writer/src/main/java/org/mapsforge/poi/writer/TagMappingResolver.java
+++ b/mapsforge-poi-writer/src/main/java/org/mapsforge/poi/writer/TagMappingResolver.java
@@ -100,7 +100,10 @@ class TagMappingResolver {
 
         // For each mapping's tag: split and save key (uniquely)
         for (String tag : this.tagMap.keySet()) {
-            this.mappingTags.add(tag.split("=")[0]);
+            if (tag.contains("="))
+                this.mappingTags.add(tag.split("=")[0]);
+            else
+                this.mappingTags.add(tag);
         }
     }
 


### PR DESCRIPTION
I added functionality.
Important is if using key categories, they should be parents of their value categories (if there're any). The key category isn't respected, if any value categories appear. Otherwise an element would be added to the value category and the key category, although it's already a parent...