### PR TITLE
fix #1069 NPE in ClusterManager.getCurBounds()

### DIFF
--- a/mapsforge-samples-android/src/main/java/org/mapsforge/samples/android/cluster/ClusterManager.java
+++ b/mapsforge-samples-android/src/main/java/org/mapsforge/samples/android/cluster/ClusterManager.java
@@ -264,7 +264,8 @@ public class ClusterManager<T extends GeoItem> implements Observer, SelectionHan
      * @return true if item is within viewport.
      */
     protected boolean isItemInViewport(final GeoItem item) {
-        return getCurBounds().contains(item.getLatLong());
+        final BoundingBox curBounds = getCurBounds();
+        return curBounds != null && curBounds.contains(item.getLatLong());
     }
 
     /**
@@ -289,12 +290,14 @@ public class ClusterManager<T extends GeoItem> implements Observer, SelectionHan
             LatLong se_ = mapView.getMapViewProjection().fromPixels(mapView.getWidth(),
                     mapView.getHeight());
 //            Log.e(TAG, " se_.latitude => " + se_.latitude + " se_.longitude => " + se_.longitude );
-            if (se_.latitude > nw_.latitude) {
-                currBoundingBox = new BoundingBox(nw_.latitude, se_.longitude, se_.latitude,
-                        nw_.longitude);
-            } else {
-                currBoundingBox = new BoundingBox(se_.latitude, nw_.longitude, nw_.latitude,
-                        se_.longitude);
+            if (se_ != null && nw_ != null) {
+                if (se_.latitude > nw_.latitude) {
+                    currBoundingBox = new BoundingBox(nw_.latitude, se_.longitude, se_.latitude,
+                            nw_.longitude);
+                } else {
+                    currBoundingBox = new BoundingBox(se_.latitude, nw_.longitude, nw_.latitude,
+                            se_.longitude);
+                }
             }
         }
         return currBoundingBox;


### PR DESCRIPTION
The local variables nw_ and se_ might be null, if the BoundingBox is not in the current viewport.
This patch adds a null check.