### PR TITLE
Render themes: PNG scaling

### DIFF
--- a/mapsforge-core/src/main/java/org/mapsforge/core/graphics/GraphicFactory.java
+++ b/mapsforge-core/src/main/java/org/mapsforge/core/graphics/GraphicFactory.java
@@ -51,7 +51,7 @@ public interface GraphicFactory {
     PointTextContainer createPointTextContainer(Point xy, Display display, int priority, String text, Paint paintFront, Paint paintBack,
                                                 SymbolContainer symbolContainer, Position position, int maxTextWidth);
 
-    ResourceBitmap createResourceBitmap(InputStream inputStream, int hash) throws IOException;
+    ResourceBitmap createResourceBitmap(InputStream inputStream, float scaleFactor, int width, int height, int percent, int hash) throws IOException;
 
     TileBitmap createTileBitmap(InputStream inputStream, int tileSize, boolean isTransparent) throws IOException;
 

--- a/mapsforge-core/src/main/java/org/mapsforge/core/graphics/GraphicUtils.java
+++ b/mapsforge-core/src/main/java/org/mapsforge/core/graphics/GraphicUtils.java
@@ -51,6 +51,44 @@ public final class GraphicUtils {
     }
 
     /**
+     *  Given the original image size, as well as symbol-width/height/percent parameters from the render theme,
+     *  this computes the final image size as it will appear on screen
+     * @param picWidth original image width
+     * @param picHeight original image height
+     * @param scaleFactor scale factor to scale to screen DPI
+     * @param width width from rendertheme
+     * @param height height from rendertheme
+     * @param percent scale percent from rendertheme
+     * @return
+     */
+    public static float[] computeFinalImageSize(float picWidth, float picHeight, float scaleFactor, int width, int height, int percent) {
+        float bitmapWidth = picWidth * scaleFactor;
+        float bitmapHeight = picHeight * scaleFactor;
+
+        float aspectRatio = picWidth / picHeight;
+
+        if (width != 0 && height != 0) {
+            // both width and height set, override any other setting
+            bitmapWidth = width;
+            bitmapHeight = height;
+        } else if (width == 0 && height != 0) {
+            // only width set, calculate from aspect ratio
+            bitmapWidth = height * aspectRatio;
+            bitmapHeight = height;
+        } else if (width != 0 && height == 0) {
+            // only height set, calculate from aspect ratio
+            bitmapHeight = width / aspectRatio;
+            bitmapWidth = width;
+        }
+
+        if (percent != 100) {
+            bitmapWidth *= percent / 100f;
+            bitmapHeight *= percent / 100f;
+        }
+        return new float[] { bitmapWidth, bitmapHeight };
+    }
+
+    /**
      * @param color color value in layout 0xAARRGGBB.
      * @return the alpha value for the color.
      */

--- a/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidGraphicFactory.java
+++ b/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidGraphicFactory.java
@@ -258,8 +258,8 @@ public final class AndroidGraphicFactory implements GraphicFactory {
     }
 
     @Override
-    public ResourceBitmap createResourceBitmap(InputStream inputStream, int hash) throws IOException {
-        return new AndroidResourceBitmap(inputStream, hash);
+    public ResourceBitmap createResourceBitmap(InputStream inputStream, float scaleFactor, int width, int height, int percent, int hash) throws IOException {
+        return new AndroidResourceBitmap(inputStream, scaleFactor, width, height, percent, hash);
     }
 
     @Override

--- a/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidResourceBitmap.java
+++ b/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidResourceBitmap.java
@@ -84,7 +84,7 @@ public class AndroidResourceBitmap extends AndroidBitmap implements ResourceBitm
                     throw new IOException("BitmapFactory failed to decodeStream");
                 }
                 float[] finalSize = GraphicUtils.computeFinalImageSize(bitmap.getWidth(), bitmap.getHeight(), scaleFactor, width, height, percent);
-                if ((int) finalSize[0] != width || (int) finalSize[1] != height)
+                if ((int) finalSize[0] != bitmap.getWidth() || (int) finalSize[1] != bitmap.getHeight())
                     bitmap = Bitmap.createScaledBitmap(bitmap, (int) finalSize[0], (int) finalSize[1], true);
                 Pair<android.graphics.Bitmap, Integer> updated = new Pair<android.graphics.Bitmap, Integer>(bitmap,
                         Integer.valueOf(1));

--- a/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidResourceBitmap.java
+++ b/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidResourceBitmap.java
@@ -20,6 +20,7 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.util.Pair;
 
+import org.mapsforge.core.graphics.GraphicUtils;
 import org.mapsforge.core.graphics.ResourceBitmap;
 
 import java.io.IOException;
@@ -68,7 +69,7 @@ public class AndroidResourceBitmap extends AndroidBitmap implements ResourceBitm
         }
     }
 
-    private static android.graphics.Bitmap getResourceBitmap(InputStream inputStream, int hash) throws IOException {
+    private static android.graphics.Bitmap getResourceBitmap(InputStream inputStream, float scaleFactor, int width, int height, int percent, int hash) throws IOException {
         synchronized (RESOURCE_BITMAPS) {
             Pair<android.graphics.Bitmap, Integer> data = RESOURCE_BITMAPS.get(hash);
             if (data != null) {
@@ -82,6 +83,9 @@ public class AndroidResourceBitmap extends AndroidBitmap implements ResourceBitm
                 if (bitmap == null) {
                     throw new IOException("BitmapFactory failed to decodeStream");
                 }
+                float[] finalSize = GraphicUtils.computeFinalImageSize(bitmap.getWidth(), bitmap.getHeight(), scaleFactor, width, height, percent);
+                if ((int) finalSize[0] != width || (int) finalSize[1] != height)
+                    bitmap = Bitmap.createScaledBitmap(bitmap, (int) finalSize[0], (int) finalSize[1], true);
                 Pair<android.graphics.Bitmap, Integer> updated = new Pair<android.graphics.Bitmap, Integer>(bitmap,
                         Integer.valueOf(1));
                 RESOURCE_BITMAPS.put(hash, updated);
@@ -139,9 +143,9 @@ public class AndroidResourceBitmap extends AndroidBitmap implements ResourceBitm
         this.hash = hash;
     }
 
-    AndroidResourceBitmap(InputStream inputStream, int hash) throws IOException {
+    AndroidResourceBitmap(InputStream inputStream, float scaleFactor, int width, int height, int percent, int hash) throws IOException {
         this(hash);
-        this.bitmap = getResourceBitmap(inputStream, hash);
+        this.bitmap = getResourceBitmap(inputStream, scaleFactor, width, height, percent, hash);
     }
 
     // destroy is the super method here, which will take care of bitmap accounting

--- a/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidSvgBitmap.java
+++ b/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidSvgBitmap.java
@@ -24,6 +24,8 @@ import android.util.Pair;
 
 import com.caverock.androidsvg.SVG;
 
+import org.mapsforge.core.graphics.GraphicUtils;
+
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -41,34 +43,12 @@ public class AndroidSvgBitmap extends AndroidResourceBitmap {
 
             double scale = scaleFactor / Math.sqrt((picture.getHeight() * picture.getWidth()) / defaultSize);
 
-            float bitmapWidth = (float) (picture.getWidth() * scale);
-            float bitmapHeight = (float) (picture.getHeight() * scale);
+            float[] bmpSize = GraphicUtils.computeFinalImageSize(picture.getWidth(), picture.getHeight(), (float) scale, width, height, percent);
 
-            float aspectRatio = (1f * picture.getWidth()) / picture.getHeight();
-
-            if (width != 0 && height != 0) {
-                // both width and height set, override any other setting
-                bitmapWidth = width;
-                bitmapHeight = height;
-            } else if (width == 0 && height != 0) {
-                // only width set, calculate from aspect ratio
-                bitmapWidth = height * aspectRatio;
-                bitmapHeight = height;
-            } else if (width != 0 && height == 0) {
-                // only height set, calculate from aspect ratio
-                bitmapHeight = width / aspectRatio;
-                bitmapWidth = width;
-            }
-
-            if (percent != 100) {
-                bitmapWidth *= percent / 100f;
-                bitmapHeight *= percent / 100f;
-            }
-
-            android.graphics.Bitmap bitmap = android.graphics.Bitmap.createBitmap((int) Math.ceil(bitmapWidth),
-                    (int) Math.ceil(bitmapHeight), AndroidGraphicFactory.TRANSPARENT_BITMAP);
+            android.graphics.Bitmap bitmap = android.graphics.Bitmap.createBitmap((int) Math.ceil(bmpSize[0]),
+                    (int) Math.ceil(bmpSize[1]), AndroidGraphicFactory.TRANSPARENT_BITMAP);
             Canvas canvas = new Canvas(bitmap);
-            canvas.drawPicture(picture, new RectF(0, 0, bitmapWidth, bitmapHeight));
+            canvas.drawPicture(picture, new RectF(0, 0, bmpSize[0], bmpSize[1]));
 
             return bitmap;
         } catch (Exception e) {

--- a/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/graphics/AwtGraphicFactory.java
+++ b/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/graphics/AwtGraphicFactory.java
@@ -194,8 +194,8 @@ public class AwtGraphicFactory implements GraphicFactory {
     }
 
     @Override
-    public ResourceBitmap createResourceBitmap(InputStream inputStream, int hash) throws IOException {
-        return new AwtResourceBitmap(inputStream);
+    public ResourceBitmap createResourceBitmap(InputStream inputStream, float scaleFactor, int width, int height, int percent, int hash) throws IOException {
+        return new AwtResourceBitmap(inputStream, scaleFactor, width, height, percent);
     }
 
     @Override

--- a/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/graphics/AwtResourceBitmap.java
+++ b/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/graphics/AwtResourceBitmap.java
@@ -15,6 +15,7 @@
  */
 package org.mapsforge.map.awt.graphics;
 
+import org.mapsforge.core.graphics.GraphicUtils;
 import org.mapsforge.core.graphics.ResourceBitmap;
 
 import java.awt.image.BufferedImage;
@@ -23,8 +24,10 @@ import java.io.InputStream;
 
 public class AwtResourceBitmap extends AwtBitmap implements ResourceBitmap {
 
-    AwtResourceBitmap(InputStream inputStream) throws IOException {
+    AwtResourceBitmap(InputStream inputStream, float scaleFactor, int width, int height, int percent) throws IOException {
         super(inputStream);
+        float[] finalSize = GraphicUtils.computeFinalImageSize(getWidth(), getHeight(), scaleFactor, width, height, percent);
+        scaleTo((int) finalSize[0], (int) finalSize[1]);
     }
 
     AwtResourceBitmap(BufferedImage bufferedImage) {

--- a/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/graphics/AwtSvgBitmap.java
+++ b/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/graphics/AwtSvgBitmap.java
@@ -18,6 +18,8 @@ import com.kitfox.svg.SVGCache;
 import com.kitfox.svg.SVGDiagram;
 import com.kitfox.svg.app.beans.SVGIcon;
 
+import org.mapsforge.core.graphics.GraphicUtils;
+
 import java.awt.Dimension;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
@@ -37,34 +39,12 @@ public class AwtSvgBitmap extends AwtResourceBitmap {
 
             double scale = scaleFactor / Math.sqrt((diagram.getHeight() * diagram.getWidth()) / defaultSize);
 
-            float bitmapWidth = (float) (diagram.getWidth() * scale);
-            float bitmapHeight = (float) (diagram.getHeight() * scale);
-
-            float aspectRatio = diagram.getWidth() / diagram.getHeight();
-
-            if (width != 0 && height != 0) {
-                // both width and height set, override any other setting
-                bitmapWidth = width;
-                bitmapHeight = height;
-            } else if (width == 0 && height != 0) {
-                // only width set, calculate from aspect ratio
-                bitmapWidth = height * aspectRatio;
-                bitmapHeight = height;
-            } else if (width != 0 && height == 0) {
-                // only height set, calculate from aspect ratio
-                bitmapHeight = width / aspectRatio;
-                bitmapWidth = width;
-            }
-
-            if (percent != 100) {
-                bitmapWidth *= percent / 100f;
-                bitmapHeight *= percent / 100f;
-            }
+            float[] bmpSize = GraphicUtils.computeFinalImageSize(diagram.getWidth(), diagram.getHeight(), (float) scale, width, height, percent);
 
             SVGIcon icon = new SVGIcon();
             icon.setAntiAlias(true);
             icon.setAutosize(SVGIcon.AUTOSIZE_STRETCH);
-            icon.setPreferredSize(new Dimension((int) bitmapWidth, (int) bitmapHeight));
+            icon.setPreferredSize(new Dimension((int) bmpSize[0], (int) bmpSize[1]));
             icon.setSvgURI(uri);
             BufferedImage bufferedImage = new BufferedImage(icon.getIconWidth(), icon.getIconHeight(), BufferedImage.TYPE_INT_ARGB);
             icon.paintIcon(null, bufferedImage.createGraphics(), 0, 0);

--- a/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/XmlUtils.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/XmlUtils.java
@@ -68,7 +68,7 @@ public final class XmlUtils {
                 }
             }
             try {
-                return graphicFactory.createResourceBitmap(inputStream, absoluteName.hashCode());
+                return graphicFactory.createResourceBitmap(inputStream, displayModel.getScaleFactor(), width, height, percent, hash);
             } catch (IOException e) {
                 throw new IOException("Reading bitmap file failed " + src, e);
             }


### PR DESCRIPTION
As reported yesterday, here is my proposed implementation for DPI scaling and respecting symbol-width/height/percent.
It also contains a small refactoring that puts the code that determines the final image size from the given parameters in a separate function. Previousely, the exact same code existed twice for Android and AWT. Now it exists only once in mapsforge-core/GraphicUtils.