### PR TITLE
Optional fast parent tiles

### DIFF
--- a/mapsforge-core/src/main/java/org/mapsforge/core/graphics/GraphicContext.java
+++ b/mapsforge-core/src/main/java/org/mapsforge/core/graphics/GraphicContext.java
@@ -28,6 +28,8 @@ public interface GraphicContext {
 
     void drawBitmap(Bitmap bitmap, Matrix matrix, Filter filter);
 
+    void drawBitmap(Bitmap bitmap, Rectangle src, Rectangle dst, Filter filter);
+
     void drawCircle(int x, int y, int radius, Paint paint);
 
     void drawLine(int x1, int y1, int x2, int y2, Paint paint);
@@ -47,6 +49,12 @@ public interface GraphicContext {
     void setClip(int left, int top, int width, int height);
 
     void setClipDifference(int left, int top, int width, int height);
+
+    InterpolationMode getInterpolationMode();
+    void setInterpolationMode(InterpolationMode mode);
+
+    boolean getAntiAliasEnabled();
+    void setAntiAliasEnabled(boolean enabled);
 
     /**
      * Shade whole map tile when tileRect is null (and bitmap, shadeRect are null).

--- a/mapsforge-core/src/main/java/org/mapsforge/core/graphics/InterpolationMode.java
+++ b/mapsforge-core/src/main/java/org/mapsforge/core/graphics/InterpolationMode.java
@@ -1,0 +1,5 @@
+package org.mapsforge.core.graphics;
+
+public enum InterpolationMode {
+    UNKNOWN, NEAREST_NEIGHBOR, BILINEAR, BICUBIC;
+};

--- a/mapsforge-core/src/main/java/org/mapsforge/core/util/Parameters.java
+++ b/mapsforge-core/src/main/java/org/mapsforge/core/util/Parameters.java
@@ -40,6 +40,13 @@ public final class Parameters {
     public static boolean PARENT_TILES_RENDERING = true;
 
     /**
+     * If true, use fast, less memory-consuming rendering for parent tiles.
+     * Note that fast parent tiles rendering will give poorer image quality
+     * for parent tiles as compared to default parent tile rendering.
+     */
+    public static boolean FAST_PARENT_TILES_RENDERING = false;
+
+    /**
      * If square frame buffer is enabled, the frame buffer allocated for drawing will be
      * large enough for drawing in either orientation, so no change is needed when the device
      * orientation changes. To avoid overly large frame buffers, the aspect ratio for this policy

--- a/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidCanvas.java
+++ b/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidCanvas.java
@@ -29,6 +29,7 @@ import org.mapsforge.core.graphics.Bitmap;
 import org.mapsforge.core.graphics.Canvas;
 import org.mapsforge.core.graphics.Color;
 import org.mapsforge.core.graphics.Filter;
+import org.mapsforge.core.graphics.InterpolationMode;
 import org.mapsforge.core.graphics.Matrix;
 import org.mapsforge.core.graphics.Paint;
 import org.mapsforge.core.graphics.Path;
@@ -130,6 +131,29 @@ class AndroidCanvas implements Canvas {
     public void drawBitmap(Bitmap bitmap, Matrix matrix, Filter filter) {
         applyFilter(filter);
         this.canvas.drawBitmap(AndroidGraphicFactory.getBitmap(bitmap), AndroidGraphicFactory.getMatrix(matrix), bitmapPaint);
+        if (filter != Filter.NONE) {
+            bitmapPaint.setColorFilter(null);
+        }
+    }
+
+    @Override
+    public void drawBitmap(Bitmap bitmap, Rectangle src, Rectangle dst, Filter filter) {
+
+        applyFilter(filter);
+
+        final android.graphics.Rect andSrc = (src != null) ?
+            new android.graphics.Rect( (int)src.left, (int)src.top,
+                                       (int)src.right, (int)src.bottom ) :
+            null;
+
+        final android.graphics.Rect andDst = (dst != null ) ?
+            new android.graphics.Rect( (int)dst.left, (int)dst.top,
+                                       (int)dst.right, (int)dst.bottom ) :
+            null;
+
+        this.canvas.drawBitmap( AndroidGraphicFactory.getBitmap(bitmap),
+                                andSrc, andDst, bitmapPaint );
+
         if (filter != Filter.NONE) {
             bitmapPaint.setColorFilter(null);
         }
@@ -372,6 +396,37 @@ class AndroidCanvas implements Canvas {
         this.canvas.restore();
     }
 
+    @Override
+    public InterpolationMode getInterpolationMode() {
+        final boolean filterBitmapFlag =
+            ( bitmapPaint.getFlags() &
+              android.graphics.Paint.FILTER_BITMAP_FLAG ) > 0;
+
+        return filterBitmapFlag ?
+            InterpolationMode.BILINEAR :
+            InterpolationMode.NEAREST_NEIGHBOR;
+    }
+
+    @Override
+    public void setInterpolationMode(InterpolationMode mode) {
+        if ( mode == InterpolationMode.NEAREST_NEIGHBOR ) {
+            bitmapPaint.setFilterBitmap(false);
+        } else {
+            bitmapPaint.setFilterBitmap(true);
+        }
+    }
+
+    @Override
+    public boolean getAntiAliasEnabled() {
+        return ( bitmapPaint.getFlags() &
+                 android.graphics.Paint.ANTI_ALIAS_FLAG ) > 0;
+    }
+
+    @Override
+    public void setAntiAliasEnabled(boolean enabled) {
+        bitmapPaint.setAntiAlias(enabled);
+    }
+
     private static class HilshadingTemps {
         private final Rect asr = new Rect(0, 0, 0, 0);
         private final Rect adr = new Rect(0, 0, 0, 0);
@@ -466,4 +521,3 @@ class AndroidCanvas implements Canvas {
         }
     }
 }
-

--- a/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/graphics/AwtCanvas.java
+++ b/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/graphics/AwtCanvas.java
@@ -20,6 +20,7 @@ import org.mapsforge.core.graphics.Bitmap;
 import org.mapsforge.core.graphics.Canvas;
 import org.mapsforge.core.graphics.Color;
 import org.mapsforge.core.graphics.Filter;
+import org.mapsforge.core.graphics.InterpolationMode;
 import org.mapsforge.core.graphics.Matrix;
 import org.mapsforge.core.graphics.Paint;
 import org.mapsforge.core.graphics.Path;
@@ -177,8 +178,18 @@ class AwtCanvas implements Canvas {
     }
 
     @Override
-    public void drawBitmap(Bitmap bitmap, Matrix matrix, Filter filter) {
+    public void drawBitmap(Bitmap bitmap, Matrix matrix,
+                           Filter filter) {
         this.graphics2D.drawRenderedImage(applyFilter(AwtGraphicFactory.getBitmap(bitmap), filter), AwtGraphicFactory.getAffineTransform(matrix));
+    }
+
+    @Override
+    public void drawBitmap(Bitmap bitmap, Rectangle src, Rectangle dst, Filter filter) {
+        this.graphics2D.drawImage
+            ( applyFilter(AwtGraphicFactory.getBitmap(bitmap), filter),
+              (int)dst.left, (int)dst.top, (int)dst.right, (int)dst.bottom,
+              (int)src.left, (int)src.top, (int)src.right, (int)src.bottom,
+              null );
     }
 
     @Override
@@ -411,4 +422,56 @@ class AwtCanvas implements Canvas {
         }
     }
 
+    @Override
+    public InterpolationMode getInterpolationMode() {
+        final Object hint = this.graphics2D.getRenderingHint
+            ( RenderingHints.KEY_INTERPOLATION );
+
+        if ( hint == RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR ) {
+            return InterpolationMode.NEAREST_NEIGHBOR;
+        } else if ( hint == RenderingHints.VALUE_INTERPOLATION_BILINEAR ) {
+            return InterpolationMode.BILINEAR;
+        } else if ( hint == RenderingHints.VALUE_INTERPOLATION_BICUBIC ) {
+            return InterpolationMode.BICUBIC;
+        } else {
+            return InterpolationMode.UNKNOWN;
+        }
+    }
+
+    @Override
+    public void setInterpolationMode(InterpolationMode mode) {
+        switch (mode) {
+        case NEAREST_NEIGHBOR:
+            this.graphics2D.setRenderingHint
+                ( RenderingHints.KEY_INTERPOLATION,
+                  RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR );
+            break;
+        case BILINEAR:
+            this.graphics2D.setRenderingHint
+                ( RenderingHints.KEY_INTERPOLATION,
+                  RenderingHints.VALUE_INTERPOLATION_BILINEAR );
+            break;
+        case BICUBIC:
+            this.graphics2D.setRenderingHint
+                ( RenderingHints.KEY_INTERPOLATION,
+                  RenderingHints.VALUE_INTERPOLATION_BICUBIC );
+            break;
+        }
+    }
+
+    @Override
+    public boolean getAntiAliasEnabled() {
+        return this.graphics2D.getRenderingHint
+            (RenderingHints.KEY_ANTIALIASING) ==
+            RenderingHints.VALUE_ANTIALIAS_ON;
+    }
+
+    @Override
+    public void setAntiAliasEnabled(boolean enabled) {
+        this.graphics2D.setRenderingHint
+            ( RenderingHints.KEY_ANTIALIASING,
+              enabled ?
+              RenderingHints.VALUE_ANTIALIAS_ON :
+              RenderingHints.VALUE_ANTIALIAS_OFF );
+    }
 }


### PR DESCRIPTION
Maybe you could reconsider my pull request: I added another parameter FAST_PARENT_TILES_RENDERING to enable the fast rendering algorithm optionally. Modifications to TileLayer itself are minimal with just a small additional if-block for fast rendering.