### PR TITLE
map-writer: ensure that implicit relations can be written (with id tag) for v5 maps

### DIFF
--- a/mapsforge-map-writer/src/main/java/org/mapsforge/map/writer/OSMTagMapping.java
+++ b/mapsforge-map-writer/src/main/java/org/mapsforge/map/writer/OSMTagMapping.java
@@ -680,5 +680,16 @@ public final class OSMTagMapping {
      */
     public void setTagValues(boolean tagValues) {
         this.tagValues = tagValues;
+
+        /* Ensure that implicit relations can be written (with id tag) */
+        if (this.tagValues) {
+            OSMTag tag = this.stringToWayTag.get(OSMTag.tagKey("id", "%f"));
+            if (tag == null) {
+                tag = new OSMTag(this.wayID, "id", "%f", Byte.MAX_VALUE, false, false, false);
+                if (addWayTag(tag, null)) {
+                    this.wayID++;
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Ensure that implicit relations can be processed, even if "id" tag is not present in "tag-mapping" file. See [forum](https://groups.google.com/forum/#!topic/mapsforge-dev/Z2Bl4exwWWU).