### PR TITLE
Curved pathText rendering, increased number of road names (#885)

### DIFF
--- a/mapsforge-core/src/main/java/org/mapsforge/core/graphics/GraphicContext.java
+++ b/mapsforge-core/src/main/java/org/mapsforge/core/graphics/GraphicContext.java
@@ -45,6 +45,8 @@ public interface GraphicContext {
 
     void drawTextRotated(String text, int x1, int y1, int x2, int y2, Paint paint);
 
+    void drawPathText(String text, Path path, Paint paint);
+
     void fillColor(Color color);
 
     void fillColor(int color);

--- a/mapsforge-core/src/main/java/org/mapsforge/core/mapelements/WayTextContainer.java
+++ b/mapsforge-core/src/main/java/org/mapsforge/core/mapelements/WayTextContainer.java
@@ -17,6 +17,7 @@
 package org.mapsforge.core.mapelements;
 
 import org.mapsforge.core.graphics.Canvas;
+import org.mapsforge.core.graphics.Color;
 import org.mapsforge.core.graphics.Display;
 import org.mapsforge.core.graphics.Filter;
 import org.mapsforge.core.graphics.GraphicFactory;
@@ -27,6 +28,7 @@ import org.mapsforge.core.graphics.Path;
 import org.mapsforge.core.model.LineSegment;
 import org.mapsforge.core.model.LineString;
 import org.mapsforge.core.model.Point;
+import org.mapsforge.core.model.Rectangle;
 
 public class WayTextContainer extends MapElementContainer {
     private final Paint paintFront;
@@ -45,8 +47,7 @@ public class WayTextContainer extends MapElementContainer {
 
 
         this.boundary = null;
-        this.boundaryAbsolute = lineString.getBoundingRect();
-        this.boundaryAbsolute.enlarge(0, textHeight, 0, textHeight);
+        this.boundaryAbsolute = lineString.getBoundingRect().enlarge(textHeight / 2f, textHeight / 2f, textHeight / 2f, textHeight / 2f);
     }
 
     private Path generatePath(Point origin) {

--- a/mapsforge-core/src/main/java/org/mapsforge/core/model/LineSegment.java
+++ b/mapsforge-core/src/main/java/org/mapsforge/core/model/LineSegment.java
@@ -192,6 +192,19 @@ public final class LineSegment {
         }
     }
 
+    /** Computes the angle between this linesegment and another one.
+     * @param other the other segment
+     * @return angle in degrees
+     */
+    public double angleTo(LineSegment other) {
+        double angle1 = Math.atan2(start.y - end.y, start.x - end.x);
+        double angle2 = Math.atan2(other.start.y - other.end.y, other.start.x - other.end.x);
+        double angle = Math.toDegrees(angle1 - angle2);
+        if (angle <= -180) angle += 360;
+        if (angle >= 180) angle -= 360;
+        return angle;
+    }
+
     /**
      * New line segment with start and end reversed.
      *

--- a/mapsforge-core/src/main/java/org/mapsforge/core/model/LineString.java
+++ b/mapsforge-core/src/main/java/org/mapsforge/core/model/LineString.java
@@ -1,0 +1,109 @@
+package org.mapsforge.core.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class LineString {
+    private List<LineSegment> segments = new ArrayList<>();
+
+    public void LineString() {
+    }
+
+    public void addSegment(LineSegment segment) {
+        this.segments.add(segment);
+    }
+
+    public LineSegment getSegment(int index) {
+        return segments.get(index);
+    }
+
+    public double length() {
+        double res = 0;
+        for (LineSegment segment : segments)
+            res += segment.length();
+        return res;
+    }
+
+    public int segmentCount() {
+        return segments.size();
+    }
+
+    /**
+     * Interpolates on the segment and returns the coordinate of the interpolation result.
+     * Returns null if distance is < 0 or > length()
+     * @param distance
+     * @return
+     */
+    public Point interpolate(double distance) {
+        if (distance < 0)
+            return null;
+
+        for (LineSegment seg : segments) {
+            double segLen = seg.length();
+            if (distance < segLen)
+                return seg.pointAlongLineSegment(distance);
+            distance -= segLen;
+        }
+        return null;
+    }
+
+    /** Creates a new LineString that consists of only the part between startDist and endDist
+    */
+    public LineString extractPart(double startDist, double endDist) {
+        LineString res = new LineString();
+
+        for (int i = 0; i < segments.size(); startDist -= segments.get(i).length(), endDist -= segments.get(i).length(), i++) {
+            LineSegment seg = segments.get(i);
+
+            // Skip first segments that we don't need
+            double segLen = seg.length();
+            if (segLen < startDist)
+                continue;
+
+            Point startPoint = null, endPoint = null;
+            if (startDist >= 0) {
+                // This will be our starting point
+                startPoint = seg.pointAlongLineSegment(startDist);
+            }
+            if (endDist < segLen) {
+                // this will be our ending point
+                endPoint = seg.pointAlongLineSegment(endDist);
+            }
+
+            if (startPoint != null && endPoint == null) {
+                // This ist the starting segment, end will come in a later segment
+                res.addSegment(new LineSegment(startPoint, seg.end));
+            } else if (startPoint == null && endPoint == null) {
+                // Center segment between start and end segment. Add completely
+                res.addSegment(seg);
+            } else if (startPoint == null && endPoint != null) {
+                // End segment, start was in earlier segment
+                res.addSegment(new LineSegment(seg.start, endPoint));
+            } else if (startPoint != null && endPoint != null) {
+                // Start and end on same segment
+                res.addSegment(new LineSegment(startPoint, endPoint));
+            }
+
+
+            if (endPoint != null)
+                break;
+        }
+
+        return res;
+    }
+
+    public Rectangle getBoundingRect() {
+        double xmin = Double.MAX_VALUE;
+        double ymin = Double.MAX_VALUE;
+        double xmax = Double.MIN_VALUE;
+        double ymax = Double.MIN_VALUE;
+
+        for (LineSegment seg : segments) {
+            xmin = Math.min(xmin, Math.min(seg.start.x, seg.end.x));
+            ymin = Math.min(xmin, Math.min(seg.start.y, seg.end.y));
+            xmax = Math.max(xmax, Math.max(seg.start.x, seg.end.x));
+            ymax = Math.max(ymax, Math.max(seg.start.y, seg.end.y));
+        }
+        return new Rectangle(xmin, ymin, xmax, ymax);
+    }
+}

--- a/mapsforge-core/src/main/java/org/mapsforge/core/model/LineString.java
+++ b/mapsforge-core/src/main/java/org/mapsforge/core/model/LineString.java
@@ -40,7 +40,7 @@ public class LineString {
 
         for (LineSegment seg : segments) {
             double segLen = seg.length();
-            if (distance < segLen)
+            if (distance <= segLen)
                 return seg.pointAlongLineSegment(distance);
             distance -= segLen;
         }
@@ -100,10 +100,27 @@ public class LineString {
 
         for (LineSegment seg : segments) {
             xmin = Math.min(xmin, Math.min(seg.start.x, seg.end.x));
-            ymin = Math.min(xmin, Math.min(seg.start.y, seg.end.y));
+            ymin = Math.min(ymin, Math.min(seg.start.y, seg.end.y));
             xmax = Math.max(xmax, Math.max(seg.start.x, seg.end.x));
             ymax = Math.max(ymax, Math.max(seg.start.y, seg.end.y));
         }
         return new Rectangle(xmin, ymin, xmax, ymax);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (!(o instanceof LineString))
+            return false;
+
+        LineString other = (LineString) o;
+        if (other.segmentCount() != segmentCount())
+            return false;
+        for (int i = 0; i < segmentCount(); i++) {
+            if (!getSegment(i).equals(other.getSegment(i)))
+                return false;
+        }
+        return true;
     }
 }

--- a/mapsforge-core/src/test/java/org/mapsforge/core/model/LineStringTest.java
+++ b/mapsforge-core/src/test/java/org/mapsforge/core/model/LineStringTest.java
@@ -1,0 +1,77 @@
+package org.mapsforge.core.model;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LineStringTest {
+    @Test
+    public void lengthTest() {
+        Point point1 = new Point(0, 0);
+        Point point2 = new Point(1, 0);
+        Point point3 = new Point(1, 1);
+        Point point4 = new Point(3, 1);
+
+        LineString lineString = new LineString();
+        lineString.addSegment(new LineSegment(point1, point2));
+        lineString.addSegment(new LineSegment(point2, point3));
+        lineString.addSegment(new LineSegment(point3, point4));
+
+        Assert.assertEquals(4, lineString.length(), 0.0001);
+        Assert.assertEquals(3, lineString.segmentCount());
+    }
+
+    @Test
+    public void interpolateTest() {
+        Point point1 = new Point(0, 0);
+        Point point2 = new Point(1, 0);
+        Point point3 = new Point(1, 1);
+
+        LineString lineString = new LineString();
+        lineString.addSegment(new LineSegment(point1, point2));
+        lineString.addSegment(new LineSegment(point2, point3));
+
+        Assert.assertEquals(point1, lineString.interpolate(0));
+        Assert.assertEquals(new Point(0.5, 0), lineString.interpolate(0.5));
+        Assert.assertEquals(point2, lineString.interpolate(1));
+        Assert.assertEquals(new Point(1, 0.5), lineString.interpolate(1.5));
+        Assert.assertEquals(point3, lineString.interpolate(2));
+    }
+
+    @Test
+    public void extractPartTest() {
+        Point point1 = new Point(0, 0);
+        Point point2 = new Point(1, 0);
+        Point point3 = new Point(1, 1);
+
+        LineString lineString = new LineString();
+        lineString.addSegment(new LineSegment(point1, point2));
+        lineString.addSegment(new LineSegment(point2, point3));
+
+        LineString extract1 = new LineString();
+        extract1.addSegment(new LineSegment(new Point(0, 0), new Point(0.5, 0)));
+
+        LineString extract2 = new LineString();
+        extract2.addSegment(new LineSegment(new Point(0.5, 0), new Point(1, 0)));
+        extract2.addSegment(new LineSegment(new Point(1, 0), new Point(1, 0.5)));
+
+        LineString extract3 = new LineString();
+        extract3.addSegment(new LineSegment(new Point(1, 0.5), new Point(1, 1)));
+
+        Assert.assertEquals(extract1, lineString.extractPart(0, 0.5));
+        Assert.assertEquals(extract2, lineString.extractPart(0.5, 1.5));
+        Assert.assertEquals(extract3, lineString.extractPart(1.5, 2));
+    }
+
+    @Test
+    public void boundingRectTest() {
+        Point point1 = new Point(0, 0);
+        Point point2 = new Point(1, 0);
+        Point point3 = new Point(1, 1);
+
+        LineString lineString = new LineString();
+        lineString.addSegment(new LineSegment(point1, point2));
+        lineString.addSegment(new LineSegment(point2, point3));
+
+        Assert.assertEquals(new Rectangle(0, 0, 1,  1), lineString.getBoundingRect());
+    }
+}

--- a/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidCanvas.java
+++ b/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidCanvas.java
@@ -211,6 +211,15 @@ class AndroidCanvas implements Canvas {
         this.canvas.drawTextOnPath(text, path, 0, 3, AndroidGraphicFactory.getPaint(paint));
     }
 
+    public void drawPathText(String text, Path path, Paint paint) {
+        if (text == null || text.trim().isEmpty() || paint.isTransparent()) {
+            return;
+        }
+
+        android.graphics.Path p = AndroidGraphicFactory.getPath(path);
+        this.canvas.drawTextOnPath(text, p, 0, 3, AndroidGraphicFactory.getPaint(paint));
+    }
+
     @Override
     public void fillColor(Color color) {
         fillColor(AndroidGraphicFactory.getColor(color));

--- a/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidCanvas.java
+++ b/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidCanvas.java
@@ -216,8 +216,10 @@ class AndroidCanvas implements Canvas {
             return;
         }
 
-        android.graphics.Path p = AndroidGraphicFactory.getPath(path);
-        this.canvas.drawTextOnPath(text, p, 0, 3, AndroidGraphicFactory.getPaint(paint));
+        android.graphics.Path aPath = AndroidGraphicFactory.getPath(path);
+        android.graphics.Paint aPaint = AndroidGraphicFactory.getPaint(paint);
+        float textHeight = aPaint.getTextSize() / 2;
+        this.canvas.drawTextOnPath(text, aPath, 0, textHeight / 2, aPaint);
     }
 
     @Override

--- a/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/graphics/AwtCanvas.java
+++ b/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/graphics/AwtCanvas.java
@@ -26,16 +26,24 @@ import org.mapsforge.core.graphics.Paint;
 import org.mapsforge.core.graphics.Path;
 import org.mapsforge.core.graphics.Style;
 import org.mapsforge.core.model.Dimension;
+import org.mapsforge.core.model.LineSegment;
 import org.mapsforge.core.model.Rectangle;
 
 import java.awt.AlphaComposite;
 import java.awt.Composite;
 import java.awt.Graphics2D;
+import java.awt.Point;
 import java.awt.RenderingHints;
+import java.awt.Shape;
 import java.awt.color.ColorSpace;
+import java.awt.font.FontRenderContext;
+import java.awt.font.GlyphVector;
 import java.awt.font.TextLayout;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Area;
+import java.awt.geom.FlatteningPathIterator;
+import java.awt.geom.PathIterator;
+import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
 import java.awt.image.BufferedImageOp;
@@ -305,6 +313,24 @@ class AwtCanvas implements Canvas {
         drawText(text, x1 + dx, y1 + xy, paint);
 
         this.graphics2D.setTransform(affineTransform);
+    }
+
+    public void drawPathText(String text, Path path, Paint paint) {
+        if (text == null || text.trim().isEmpty() || paint.isTransparent()) {
+            return;
+        }
+
+        AwtPaint awtPaint = AwtGraphicFactory.getPaint(paint);
+        if (awtPaint.stroke == null) {
+            this.graphics2D.setColor(awtPaint.color);
+            this.graphics2D.setFont(awtPaint.font);
+        } else {
+            setColorAndStroke(awtPaint);
+        }
+        AwtPath awtPath = AwtGraphicFactory.getPath(path);
+        TextStroke textStroke = new TextStroke(text, awtPaint.font, false, false);
+        Shape shape = textStroke.createStrokedShape(awtPath.getRawPath(), graphics2D.getFontRenderContext());
+        this.graphics2D.fill(shape);
     }
 
     @Override

--- a/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/graphics/AwtCanvas.java
+++ b/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/graphics/AwtCanvas.java
@@ -35,6 +35,7 @@ import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.RenderingHints;
 import java.awt.Shape;
+import java.awt.Stroke;
 import java.awt.color.ColorSpace;
 import java.awt.font.FontRenderContext;
 import java.awt.font.GlyphVector;
@@ -327,10 +328,14 @@ class AwtCanvas implements Canvas {
         } else {
             setColorAndStroke(awtPaint);
         }
+
         AwtPath awtPath = AwtGraphicFactory.getPath(path);
         TextStroke textStroke = new TextStroke(text, awtPaint.font, graphics2D.getFontRenderContext(), false, false);
-        Shape shape = textStroke.createStrokedShape(awtPath.getRawPath());
-        this.graphics2D.fill(shape);
+        if (awtPaint.style == Style.STROKE) {
+            graphics2D.draw(textStroke.createStrokedShape(awtPath.getRawPath()));
+        } else {
+            graphics2D.fill(textStroke.createStrokedShape(awtPath.getRawPath()));
+        }
     }
 
     @Override

--- a/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/graphics/AwtCanvas.java
+++ b/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/graphics/AwtCanvas.java
@@ -328,8 +328,8 @@ class AwtCanvas implements Canvas {
             setColorAndStroke(awtPaint);
         }
         AwtPath awtPath = AwtGraphicFactory.getPath(path);
-        TextStroke textStroke = new TextStroke(text, awtPaint.font, false, false);
-        Shape shape = textStroke.createStrokedShape(awtPath.getRawPath(), graphics2D.getFontRenderContext());
+        TextStroke textStroke = new TextStroke(text, awtPaint.font, graphics2D.getFontRenderContext(), false, false);
+        Shape shape = textStroke.createStrokedShape(awtPath.getRawPath());
         this.graphics2D.fill(shape);
     }
 

--- a/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/graphics/AwtPath.java
+++ b/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/graphics/AwtPath.java
@@ -61,16 +61,13 @@ class AwtPath implements Path {
         this.path2D.moveTo(x, y);
     }
 
-    public PathIterator getPathIterator(AffineTransform transform) {
-        return this.path2D.getPathIterator(transform);
-    }
-
-    Path2D getRawPath() {
-        return this.path2D;
-    }
 
     @Override
     public void setFillRule(FillRule fillRule) {
         this.path2D.setWindingRule(getWindingRule(fillRule));
+    }
+
+    Path2D getRawPath() {
+        return this.path2D;
     }
 }

--- a/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/graphics/AwtPath.java
+++ b/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/graphics/AwtPath.java
@@ -18,7 +18,9 @@ package org.mapsforge.map.awt.graphics;
 import org.mapsforge.core.graphics.FillRule;
 import org.mapsforge.core.graphics.Path;
 
+import java.awt.geom.AffineTransform;
 import java.awt.geom.Path2D;
+import java.awt.geom.PathIterator;
 
 class AwtPath implements Path {
     private static int getWindingRule(FillRule fillRule) {
@@ -57,6 +59,14 @@ class AwtPath implements Path {
     @Override
     public void moveTo(float x, float y) {
         this.path2D.moveTo(x, y);
+    }
+
+    public PathIterator getPathIterator(AffineTransform transform) {
+        return this.path2D.getPathIterator(transform);
+    }
+
+    Path2D getRawPath() {
+        return this.path2D;
     }
 
     @Override

--- a/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/graphics/TextStroke.java
+++ b/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/graphics/TextStroke.java
@@ -21,141 +21,141 @@ import java.awt.*;
 import java.awt.font.*;
 import java.awt.geom.*;
 
-public class TextStroke {
-	private String text;
-	private Font font;
-	private boolean stretchToFit = false;
-	private boolean repeat = false;
-	private AffineTransform t = new AffineTransform();
+public class TextStroke implements Stroke {
+    private String text;
+    private Font font;
+    private boolean stretchToFit = false;
+    private boolean repeat = false;
+    private AffineTransform t = new AffineTransform();
+    private FontRenderContext fontRenderContext;
 
-	private static final float FLATNESS = 1;
+    private static final float FLATNESS = 1;
 
-	public TextStroke( String text, Font font ) {
-		this( text, font, true, false );
-	}
+    public TextStroke(String text, Font font, FontRenderContext frc) {
+        this(text, font, frc, true, false);
+    }
 
-	public TextStroke( String text, Font font, boolean stretchToFit, boolean repeat ) {
-		this.text = text;
-		this.font = font;
-		this.stretchToFit = stretchToFit;
-		this.repeat = repeat;
-	}
+    public TextStroke(String text, Font font, FontRenderContext frc, boolean stretchToFit, boolean repeat) {
+        this.text = text;
+        this.font = font;
+        this.stretchToFit = stretchToFit;
+        this.repeat = repeat;
+        this.fontRenderContext = frc;
+    }
 
-	public Shape createStrokedShape( Shape shape, FontRenderContext frc ) {
-		GlyphVector glyphVector = font.createGlyphVector(frc, text);
+    public Shape createStrokedShape(Shape shape) {
+        GlyphVector glyphVector = font.createGlyphVector(fontRenderContext, text);
 
-		GeneralPath result = new GeneralPath();
-		PathIterator it = new FlatteningPathIterator( shape.getPathIterator( null ), FLATNESS );
-		float points[] = new float[6];
-		float moveX = 0, moveY = 0;
-		float lastX = 0, lastY = 0;
-		float thisX = 0, thisY = 0;
-		int type = 0;
-		boolean first = false;
-		float next = 0;
-		int currentChar = 0;
-		int length = glyphVector.getNumGlyphs();
+        GeneralPath result = new GeneralPath();
+        PathIterator it = new FlatteningPathIterator(shape.getPathIterator(null), FLATNESS);
+        float points[] = new float[6];
+        float moveX = 0, moveY = 0;
+        float lastX = 0, lastY = 0;
+        float thisX = 0, thisY = 0;
+        int type = 0;
+        boolean first = false;
+        float next = 0;
+        int currentChar = 0;
+        int length = glyphVector.getNumGlyphs();
 
-		if ( length == 0 )
+        if (length == 0)
             return result;
 
-        float factor = stretchToFit ? measurePathLength( shape )/(float)glyphVector.getLogicalBounds().getWidth() : 1.0f;
+        float factor = stretchToFit ? measurePathLength(shape) / (float) glyphVector.getLogicalBounds().getWidth() : 1.0f;
         float nextAdvance = 0;
 
-		while ( currentChar < length && !it.isDone() ) {
-			type = it.currentSegment( points );
-			switch( type ){
-			case PathIterator.SEG_MOVETO:
-				moveX = lastX = points[0];
-				moveY = lastY = points[1];
-				result.moveTo( moveX, moveY );
-				first = true;
-                nextAdvance = glyphVector.getGlyphMetrics( currentChar ).getAdvance() * 0.5f;
-                next = nextAdvance;
-				break;
+        while (currentChar < length && !it.isDone()) {
+            type = it.currentSegment(points);
+            switch (type) {
+                case PathIterator.SEG_MOVETO:
+                    moveX = lastX = points[0];
+                    moveY = lastY = points[1];
+                    result.moveTo(moveX, moveY);
+                    nextAdvance = glyphVector.getGlyphMetrics(currentChar).getAdvance() * 0.5f;
+                    next = nextAdvance;
+                    break;
 
-			case PathIterator.SEG_CLOSE:
-				points[0] = moveX;
-				points[1] = moveY;
-				// Fall into....
+                case PathIterator.SEG_CLOSE:
+                    points[0] = moveX;
+                    points[1] = moveY;
+                    // Fall into....
 
-			case PathIterator.SEG_LINETO:
-				thisX = points[0];
-				thisY = points[1];
-				float dx = thisX-lastX;
-				float dy = thisY-lastY;
-				float distance = (float)Math.sqrt( dx*dx + dy*dy );
-				if ( distance >= next ) {
-					float r = 1.0f/distance;
-					float angle = (float)Math.atan2( dy, dx );
-					while ( currentChar < length && distance >= next ) {
-						Shape glyph = glyphVector.getGlyphOutline( currentChar );
-						Point2D p = glyphVector.getGlyphPosition(currentChar);
-						float px = (float)p.getX();
-						float py = (float)p.getY();
-						float x = lastX + next*dx*r;
-						float y = lastY + next*dy*r;
-                        float advance = nextAdvance;
-                        nextAdvance = currentChar < length-1 ? glyphVector.getGlyphMetrics(currentChar+1).getAdvance() * 0.5f : 0;
-						t.setToTranslation( x, y );
-						t.rotate( angle );
-                        t.translate( -px-advance, -py );
-                        t.translate(0, glyphVector.getVisualBounds().getHeight() / 2); // move slightly down to 
-						result.append( t.createTransformedShape( glyph ), false );
-						next += (advance+nextAdvance) * factor;
-						currentChar++;
-						if ( repeat )
-							currentChar %= length;
-					}
-				}
-                next -= distance;
-				first = false;
-				lastX = thisX;
-				lastY = thisY;
-				break;
-			}
-			it.next();
-		}
+                case PathIterator.SEG_LINETO:
+                    thisX = points[0];
+                    thisY = points[1];
+                    float dx = thisX - lastX;
+                    float dy = thisY - lastY;
+                    float distance = (float) Math.sqrt(dx * dx + dy * dy);
+                    if (distance >= next) {
+                        float r = 1.0f / distance;
+                        float angle = (float) Math.atan2(dy, dx);
+                        while (currentChar < length && distance >= next) {
+                            Shape glyph = glyphVector.getGlyphOutline(currentChar);
+                            Point2D p = glyphVector.getGlyphPosition(currentChar);
+                            float px = (float) p.getX();
+                            float py = (float) p.getY();
+                            float x = lastX + next * dx * r;
+                            float y = lastY + next * dy * r;
+                            float advance = nextAdvance;
+                            nextAdvance = currentChar < length - 1 ? glyphVector.getGlyphMetrics(currentChar + 1).getAdvance() * 0.5f : 0;
+                            t.setToTranslation(x, y);
+                            t.rotate(angle);
+                            t.translate(-px - advance, -py);
+                            t.translate(0, glyphVector.getVisualBounds().getHeight() / 2); // move slightly down to
+                            result.append(t.createTransformedShape(glyph), false);
+                            next += (advance + nextAdvance) * factor;
+                            currentChar++;
+                            if (repeat)
+                                currentChar %= length;
+                        }
+                    }
+                    next -= distance;
+                    lastX = thisX;
+                    lastY = thisY;
+                    break;
+            }
+            it.next();
+        }
 
-		return result;
-	}
+        return result;
+    }
 
-	public float measurePathLength( Shape shape ) {
-		PathIterator it = new FlatteningPathIterator( shape.getPathIterator( null ), FLATNESS );
-		float points[] = new float[6];
-		float moveX = 0, moveY = 0;
-		float lastX = 0, lastY = 0;
-		float thisX = 0, thisY = 0;
-		int type = 0;
+    public float measurePathLength(Shape shape) {
+        PathIterator it = new FlatteningPathIterator(shape.getPathIterator(null), FLATNESS);
+        float points[] = new float[6];
+        float moveX = 0, moveY = 0;
+        float lastX = 0, lastY = 0;
+        float thisX = 0, thisY = 0;
+        int type = 0;
         float total = 0;
 
-		while ( !it.isDone() ) {
-			type = it.currentSegment( points );
-			switch( type ){
-			case PathIterator.SEG_MOVETO:
-				moveX = lastX = points[0];
-				moveY = lastY = points[1];
-				break;
+        while (!it.isDone()) {
+            type = it.currentSegment(points);
+            switch (type) {
+                case PathIterator.SEG_MOVETO:
+                    moveX = lastX = points[0];
+                    moveY = lastY = points[1];
+                    break;
 
-			case PathIterator.SEG_CLOSE:
-				points[0] = moveX;
-				points[1] = moveY;
-				// Fall into....
+                case PathIterator.SEG_CLOSE:
+                    points[0] = moveX;
+                    points[1] = moveY;
+                    // Fall into....
 
-			case PathIterator.SEG_LINETO:
-				thisX = points[0];
-				thisY = points[1];
-				float dx = thisX-lastX;
-				float dy = thisY-lastY;
-				total += (float)Math.sqrt( dx*dx + dy*dy );
-				lastX = thisX;
-				lastY = thisY;
-				break;
-			}
-			it.next();
-		}
+                case PathIterator.SEG_LINETO:
+                    thisX = points[0];
+                    thisY = points[1];
+                    float dx = thisX - lastX;
+                    float dy = thisY - lastY;
+                    total += (float) Math.sqrt(dx * dx + dy * dy);
+                    lastX = thisX;
+                    lastY = thisY;
+                    break;
+            }
+            it.next();
+        }
 
-		return total;
-	}
+        return total;
+    }
 
 }

--- a/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/graphics/TextStroke.java
+++ b/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/graphics/TextStroke.java
@@ -1,0 +1,161 @@
+// This code was taken from http://www.jhlabs.com/java/java2d/strokes/
+/*
+Copyright 2006 Jerry Huxtable
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package org.mapsforge.map.awt.graphics;
+
+import java.awt.*;
+import java.awt.font.*;
+import java.awt.geom.*;
+
+public class TextStroke {
+	private String text;
+	private Font font;
+	private boolean stretchToFit = false;
+	private boolean repeat = false;
+	private AffineTransform t = new AffineTransform();
+
+	private static final float FLATNESS = 1;
+
+	public TextStroke( String text, Font font ) {
+		this( text, font, true, false );
+	}
+
+	public TextStroke( String text, Font font, boolean stretchToFit, boolean repeat ) {
+		this.text = text;
+		this.font = font;
+		this.stretchToFit = stretchToFit;
+		this.repeat = repeat;
+	}
+
+	public Shape createStrokedShape( Shape shape, FontRenderContext frc ) {
+		GlyphVector glyphVector = font.createGlyphVector(frc, text);
+
+		GeneralPath result = new GeneralPath();
+		PathIterator it = new FlatteningPathIterator( shape.getPathIterator( null ), FLATNESS );
+		float points[] = new float[6];
+		float moveX = 0, moveY = 0;
+		float lastX = 0, lastY = 0;
+		float thisX = 0, thisY = 0;
+		int type = 0;
+		boolean first = false;
+		float next = 0;
+		int currentChar = 0;
+		int length = glyphVector.getNumGlyphs();
+
+		if ( length == 0 )
+            return result;
+
+        float factor = stretchToFit ? measurePathLength( shape )/(float)glyphVector.getLogicalBounds().getWidth() : 1.0f;
+        float nextAdvance = 0;
+
+		while ( currentChar < length && !it.isDone() ) {
+			type = it.currentSegment( points );
+			switch( type ){
+			case PathIterator.SEG_MOVETO:
+				moveX = lastX = points[0];
+				moveY = lastY = points[1];
+				result.moveTo( moveX, moveY );
+				first = true;
+                nextAdvance = glyphVector.getGlyphMetrics( currentChar ).getAdvance() * 0.5f;
+                next = nextAdvance;
+				break;
+
+			case PathIterator.SEG_CLOSE:
+				points[0] = moveX;
+				points[1] = moveY;
+				// Fall into....
+
+			case PathIterator.SEG_LINETO:
+				thisX = points[0];
+				thisY = points[1];
+				float dx = thisX-lastX;
+				float dy = thisY-lastY;
+				float distance = (float)Math.sqrt( dx*dx + dy*dy );
+				if ( distance >= next ) {
+					float r = 1.0f/distance;
+					float angle = (float)Math.atan2( dy, dx );
+					while ( currentChar < length && distance >= next ) {
+						Shape glyph = glyphVector.getGlyphOutline( currentChar );
+						Point2D p = glyphVector.getGlyphPosition(currentChar);
+						float px = (float)p.getX();
+						float py = (float)p.getY();
+						float x = lastX + next*dx*r;
+						float y = lastY + next*dy*r;
+                        float advance = nextAdvance;
+                        nextAdvance = currentChar < length-1 ? glyphVector.getGlyphMetrics(currentChar+1).getAdvance() * 0.5f : 0;
+						t.setToTranslation( x, y );
+						t.rotate( angle );
+                        t.translate( -px-advance, -py );
+                        t.translate(0, glyphVector.getVisualBounds().getHeight() / 2); // move slightly down to 
+						result.append( t.createTransformedShape( glyph ), false );
+						next += (advance+nextAdvance) * factor;
+						currentChar++;
+						if ( repeat )
+							currentChar %= length;
+					}
+				}
+                next -= distance;
+				first = false;
+				lastX = thisX;
+				lastY = thisY;
+				break;
+			}
+			it.next();
+		}
+
+		return result;
+	}
+
+	public float measurePathLength( Shape shape ) {
+		PathIterator it = new FlatteningPathIterator( shape.getPathIterator( null ), FLATNESS );
+		float points[] = new float[6];
+		float moveX = 0, moveY = 0;
+		float lastX = 0, lastY = 0;
+		float thisX = 0, thisY = 0;
+		int type = 0;
+        float total = 0;
+
+		while ( !it.isDone() ) {
+			type = it.currentSegment( points );
+			switch( type ){
+			case PathIterator.SEG_MOVETO:
+				moveX = lastX = points[0];
+				moveY = lastY = points[1];
+				break;
+
+			case PathIterator.SEG_CLOSE:
+				points[0] = moveX;
+				points[1] = moveY;
+				// Fall into....
+
+			case PathIterator.SEG_LINETO:
+				thisX = points[0];
+				thisY = points[1];
+				float dx = thisX-lastX;
+				float dy = thisY-lastY;
+				total += (float)Math.sqrt( dx*dx + dy*dy );
+				lastX = thisX;
+				lastY = thisY;
+				break;
+			}
+			it.next();
+		}
+
+		return total;
+	}
+
+}

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/StandardRenderer.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/StandardRenderer.java
@@ -168,7 +168,7 @@ public class StandardRenderer implements RenderCallback {
     public void renderWayText(final RenderContext renderContext, Display display, int priority, String textKey, float dy, Paint fill, Paint stroke,
                               boolean repeat, float repeatGap, float repeatStart, boolean rotate, PolylineContainer way) {
         if (renderLabels) {
-            WayDecorator.renderText(way.getUpperLeft(), way.getLowerRight(), textKey, display, priority, dy, fill, stroke,
+            WayDecorator.renderText(graphicFactory, way.getUpperLeft(), way.getLowerRight(), textKey, display, priority, dy, fill, stroke,
                     repeat, repeatGap, repeatStart, rotate, way.getCoordinatesAbsolute(), renderContext.labels);
         }
     }

--- a/mapsforge-themes/src/main/resources/assets/mapsforge/default.xml
+++ b/mapsforge-themes/src/main/resources/assets/mapsforge/default.xml
@@ -654,19 +654,19 @@
     <!-- highway captions etc. -->
     <rule e="way" k="tunnel" v="~|no|false">
         <rule e="way" k="highway" v="footway|path|track|bridleway|steps|byway" zoom-min="14">
-            <pathText display="always" fill="#606060" font-size="12" font-style="bold" k="name"
+            <pathText fill="#606060" font-size="12" font-style="bold" k="name"
                 priority="-8" stroke="#FFFFFF" stroke-width="2" />
         </rule>
         <rule e="way" k="highway"
             v="cycleway|service|construction|road|pedestrian|unclassified|residential|living_street|tertiary|tertiary_link"
             zoom-min="16">
-            <pathText display="always" fill="#000000" font-size="10" font-style="bold" k="name"
+            <pathText fill="#000000" font-size="10" font-style="bold" k="name"
                 priority="-7" stroke="#FFFFFF" stroke-width="2.0" />
         </rule>
         <rule e="way" k="highway"
             v="secondary_link|primary_link|trunk_link|motorway_link|secondary|primary"
             zoom-min="15">
-            <pathText display="always" fill="#000000" font-size="12" font-style="bold" k="name"
+            <pathText fill="#000000" font-size="12" font-style="bold" k="name"
                 priority="-6" stroke="#FFFFFF" stroke-width="2.0" />
         </rule>
         <rule e="any" k="highway" v="trunk|primary|secondary|tertiary" zoom-min="12">


### PR DESCRIPTION
Hi,
first try of an implementation to fix #885.
Current remaining issues:
- TextStroke is taken from here: http://www.jhlabs.com/java/java2d/strokes/
Interestingly, the websites title is "Fun with Java2D". Weird. I can't feel the fun at all ;)
It does currently not obey the MapsForge coding style. Also I have changed two or three lines in the file to make it work correctly for this purpose. How should I go about this?...
- Sometimes, there is some label collision happening. E.g. for multi-lane highways. No idea why:
![grafik](https://user-images.githubusercontent.com/1858945/55188778-6acbcd00-519c-11e9-93de-c63b065fc9e3.png)
- Unit tests. I can't seem to get them working. For Android, I use Android Studio. For the AWT version no idea what to use. I'm debugging with VSCode, but it somehow can't find JUnit, so I can't run the unit tests. How to do a proper dev environment setup for AWT?

Other than that, it looks quite decent. Finally, one can also read some street names in the lower zoom levels. Personally, I'd even go one lower with the min-levels in the default render theme (but let them repeat less often).

Take this as an RFC, not a final patch.