### PR TITLE
POI writer: add optional support to create tag with normalize-name

### DIFF
--- a/docs/POI.md
+++ b/docs/POI.md
@@ -52,6 +52,7 @@ The `--poi-writer`, or short `--pw` task indicates that the POI writer plugin sh
 |`ways`|Also parse ways.|true/false|true|
 |`geo-tags`|Add geo tags.|true/false|false|
 |`filter-categories`|Drop empty categories.|true/false|true|
+|`normalize-names`|Add normalize-name (designed for accent-insensitive search by name).|true/false|false|
 
 ### Example
 

--- a/mapsforge-poi-writer/src/main/java/org/mapsforge/poi/writer/PoiWriter.java
+++ b/mapsforge-poi-writer/src/main/java/org/mapsforge/poi/writer/PoiWriter.java
@@ -45,6 +45,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
+import java.text.Normalizer;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -493,6 +494,13 @@ public final class PoiWriter {
                                 if (tagMap.isEmpty()) {
                                     for (Tag t : entity.getTags()) {
                                         tagMap.put(t.getKey().toLowerCase(Locale.ENGLISH), t.getValue());
+
+                                        // If normalize names is enabled and key == name
+                                        if (t.getKey().toLowerCase(Locale.ENGLISH).equals("name") && configuration.isNormalizeNames()) {
+                                            //LOGGER.info("Normalize name...");
+                                            String normalizeNameValue = deAccent(t.getValue().toLowerCase());
+                                            tagMap.put("normalize-name", normalizeNameValue);
+                                        }
                                     }
                                 }
                                 categories.add(pc);
@@ -757,5 +765,17 @@ public final class PoiWriter {
         } catch (SQLException e) {
             e.printStackTrace();
         }
+    }
+
+    /**
+     * Remove accents from
+     *
+     * @param str string with accents
+     * @return string without accents
+     */
+    private String deAccent(String str) {
+        String nfdNormalizedString = Normalizer.normalize(str, Normalizer.Form.NFD);
+        Pattern pattern = Pattern.compile("\\p{InCombiningDiacriticalMarks}+");
+        return pattern.matcher(nfdNormalizedString).replaceAll("");
     }
 }

--- a/mapsforge-poi-writer/src/main/java/org/mapsforge/poi/writer/model/PoiWriterConfiguration.java
+++ b/mapsforge-poi-writer/src/main/java/org/mapsforge/poi/writer/model/PoiWriterConfiguration.java
@@ -33,6 +33,7 @@ public class PoiWriterConfiguration {
     private int fileSpecificationVersion;
     private boolean filterCategories;
     private boolean names;
+    private boolean normalizeNames;
     private File outputFile;
     private String preferredLanguage;
     private boolean progressLogs;
@@ -149,6 +150,13 @@ public class PoiWriterConfiguration {
     }
 
     /**
+     * @return the normalize-names
+     */
+    public boolean isNormalizeNames() {
+        return normalizeNames;
+    }
+
+    /**
      * @return the progressLogs
      */
     public boolean isProgressLogs() {
@@ -240,6 +248,14 @@ public class PoiWriterConfiguration {
     public void setNames(boolean names) {
         this.names = names;
     }
+
+    /**
+     * @param normalizeNames the normalize-names to set
+     */
+    public void setNormalizeNames(boolean normalizeNames) {
+        this.normalizeNames = normalizeNames;
+    }
+
 
     /**
      * @param outputFile the output file to set

--- a/mapsforge-poi-writer/src/main/java/org/mapsforge/poi/writer/osmosis/PoiWriterFactory.java
+++ b/mapsforge-poi-writer/src/main/java/org/mapsforge/poi/writer/osmosis/PoiWriterFactory.java
@@ -38,6 +38,7 @@ public class PoiWriterFactory extends TaskManagerFactory {
     private static final String PARAM_FILTER_CATEGORIES = "filter-categories";
     private static final String PARAM_GEO_TAGS = "geo-tags";
     private static final String PARAM_NAMES = "names";
+    private static final String PARAM_NORMALIZE_NAMES = "normalize-names";
     private static final String PARAM_OUTFILE = "file";
     private static final String PARAM_PREFERRED_LANGUAGE = "preferred-language";
     private static final String PARAM_PROGRESS_LOGS = "progress-logs";
@@ -58,6 +59,7 @@ public class PoiWriterFactory extends TaskManagerFactory {
         configuration.setProgressLogs(getBooleanArgument(taskConfig, PARAM_PROGRESS_LOGS, true));
         configuration.loadTagMappingFile(getStringArgument(taskConfig, PARAM_TAG_MAPPING_FILE, null));
         configuration.setWays(getBooleanArgument(taskConfig, PARAM_WAYS, true));
+        configuration.setNormalizeNames(getBooleanArgument(taskConfig, PARAM_NORMALIZE_NAMES, false));
 
         // If set to true, progress messages will be forwarded to a GUI message handler
         // boolean guiMode = getBooleanArgument(taskConfig, "gui-mode", false);


### PR DESCRIPTION
This change add support for PoiWriter.java class to create normalize-name from name value designed for accent-insensitive search by name. Command line parameter is described in POI.md





