### PR TITLE
Get rid of max aspect ratio check in frame buffer controller

### DIFF
--- a/mapsforge-map/src/main/java/org/mapsforge/map/controller/FrameBufferController.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/controller/FrameBufferController.java
@@ -28,8 +28,6 @@ import org.mapsforge.map.view.FrameBuffer;
 
 public final class FrameBufferController implements Observer {
 
-    private static float maxAspectRatio = 2;
-
     public static FrameBufferController create(FrameBuffer frameBuffer, Model model) {
         FrameBufferController frameBufferController = new FrameBufferController(frameBuffer, model);
 
@@ -45,11 +43,8 @@ public final class FrameBufferController implements Observer {
         int width = (int) (mapViewDimension.width * overdrawFactor);
         int height = (int) (mapViewDimension.height * overdrawFactor);
         if (Parameters.SQUARE_FRAME_BUFFER) {
-            float aspectRatio = ((float) mapViewDimension.width) / mapViewDimension.height;
-            if (aspectRatio < maxAspectRatio && aspectRatio > 1 / maxAspectRatio) {
-                width = Math.max(width, height);
-                height = width;
-            }
+            width = Math.max(width, height);
+            height = width;
         }
         return new Dimension(width, height);
     }


### PR DESCRIPTION
Got rid of max aspect ratio check in frame buffer controller to avoid issues with large aspect ratio devices and also because the check seems to be unnecessary.