### PR TITLE
Fix for hill shading issues on Android API 28+

### DIFF
--- a/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidCanvas.java
+++ b/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidCanvas.java
@@ -263,13 +263,13 @@ class AndroidCanvas implements Canvas {
 
     @Override
     public void resetClip() {
-        // if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-        //     this.canvas.save();
-        //     this.canvas.clipRect(0, 0, getWidth(), getHeight());
-        //     this.canvas.restore();
-        // } else {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            // this.canvas.save();
+            this.canvas.clipRect(0, 0, getWidth(), getHeight());
+            // this.canvas.restore();
+        } else {
             this.canvas.clipRect(0, 0, getWidth(), getHeight(), Region.Op.REPLACE);
-        // }
+        }
     }
 
     @Override
@@ -284,13 +284,13 @@ class AndroidCanvas implements Canvas {
 
     @Override
     public void setClip(int left, int top, int width, int height) {
-        // if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-        //     this.canvas.save();
-        //     this.canvas.clipRect(left, top, left + width, top + height);
-        //     this.canvas.restore();
-        // } else {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            // this.canvas.save();
+            this.canvas.clipRect(left, top, left + width, top + height);
+            // this.canvas.restore();
+        } else {
             this.setClipInternal(left, top, width, height, Region.Op.REPLACE);
-        // }
+        }
     }
 
     @Override
@@ -320,13 +320,13 @@ class AndroidCanvas implements Canvas {
 
         if (bitmap == null) {
             if (tileRect != null) {
-                // if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                //     this.canvas.save();
-                //     this.canvas.clipRect((float) tileRect.left, (float) tileRect.top, (float) tileRect.right, (float) tileRect.bottom);
-                //     this.canvas.restore();
-                // } else {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    // this.canvas.save();
+                    this.canvas.clipRect((float) tileRect.left, (float) tileRect.top, (float) tileRect.right, (float) tileRect.bottom);
+                    // this.canvas.restore();
+                } else {
                     this.canvas.clipRect((float) tileRect.left, (float) tileRect.top, (float) tileRect.right, (float) tileRect.bottom, Region.Op.REPLACE);
-                // }
+                }
             }
             // scale a dummy pixel over the canvas - just drawing a paint would probably be faster, but the resulting colors can be inconsistent with the bitmap draw (maybe only on some devices?)
             this.canvas.drawBitmap(hillshadingTemps.useNeutralShadingPixel(), hillshadingTemps.useAsr(0, 0, 1, 1), hillshadingTemps.useAdr(0, 0, canvas.getWidth(), canvas.getHeight()), shadePaint);
@@ -341,13 +341,13 @@ class AndroidCanvas implements Canvas {
 
         if (horizontalScale < 1 && verticalScale < 1) {
             // fast path for wide zoom (downscaling)
-            // if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            //     this.canvas.save();
-            //     this.canvas.clipRect((float) tileRect.left, (float) tileRect.top, (float) tileRect.right, (float) tileRect.bottom);
-            //     this.canvas.restore();
-            // } else {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                // this.canvas.save();
+                this.canvas.clipRect((float) tileRect.left, (float) tileRect.top, (float) tileRect.right, (float) tileRect.bottom);
+                // this.canvas.restore();
+            } else {
                 this.canvas.clipRect((float) tileRect.left, (float) tileRect.top, (float) tileRect.right, (float) tileRect.bottom, Region.Op.REPLACE);
-            // }
+            }
             android.graphics.Matrix transform = temps.useMatrix();
             transform.preTranslate((float) tileRect.left, (float) tileRect.top);
             transform.preScale((float) horizontalScale, (float) verticalScale);

--- a/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidCanvas.java
+++ b/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidCanvas.java
@@ -25,7 +25,6 @@ import android.graphics.ColorMatrixColorFilter;
 import android.graphics.PorterDuff;
 import android.graphics.Rect;
 import android.graphics.Region;
-import android.os.Build;
 
 import org.mapsforge.core.graphics.Bitmap;
 import org.mapsforge.core.graphics.Canvas;
@@ -264,13 +263,13 @@ class AndroidCanvas implements Canvas {
 
     @Override
     public void resetClip() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            this.canvas.save();
-            this.canvas.clipRect(0, 0, getWidth(), getHeight());
-            this.canvas.restore();
-        } else {
+        // if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        //     this.canvas.save();
+        //     this.canvas.clipRect(0, 0, getWidth(), getHeight());
+        //     this.canvas.restore();
+        // } else {
             this.canvas.clipRect(0, 0, getWidth(), getHeight(), Region.Op.REPLACE);
-        }
+        // }
     }
 
     @Override
@@ -285,13 +284,13 @@ class AndroidCanvas implements Canvas {
 
     @Override
     public void setClip(int left, int top, int width, int height) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            this.canvas.save();
-            this.canvas.clipRect(left, top, left + width, top + height);
-            this.canvas.restore();
-        } else {
+        // if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        //     this.canvas.save();
+        //     this.canvas.clipRect(left, top, left + width, top + height);
+        //     this.canvas.restore();
+        // } else {
             this.setClipInternal(left, top, width, height, Region.Op.REPLACE);
-        }
+        // }
     }
 
     @Override
@@ -321,13 +320,13 @@ class AndroidCanvas implements Canvas {
 
         if (bitmap == null) {
             if (tileRect != null) {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                    this.canvas.save();
-                    this.canvas.clipRect((float) tileRect.left, (float) tileRect.top, (float) tileRect.right, (float) tileRect.bottom);
-                    this.canvas.restore();
-                } else {
+                // if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                //     this.canvas.save();
+                //     this.canvas.clipRect((float) tileRect.left, (float) tileRect.top, (float) tileRect.right, (float) tileRect.bottom);
+                //     this.canvas.restore();
+                // } else {
                     this.canvas.clipRect((float) tileRect.left, (float) tileRect.top, (float) tileRect.right, (float) tileRect.bottom, Region.Op.REPLACE);
-                }
+                // }
             }
             // scale a dummy pixel over the canvas - just drawing a paint would probably be faster, but the resulting colors can be inconsistent with the bitmap draw (maybe only on some devices?)
             this.canvas.drawBitmap(hillshadingTemps.useNeutralShadingPixel(), hillshadingTemps.useAsr(0, 0, 1, 1), hillshadingTemps.useAdr(0, 0, canvas.getWidth(), canvas.getHeight()), shadePaint);
@@ -342,13 +341,13 @@ class AndroidCanvas implements Canvas {
 
         if (horizontalScale < 1 && verticalScale < 1) {
             // fast path for wide zoom (downscaling)
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                this.canvas.save();
-                this.canvas.clipRect((float) tileRect.left, (float) tileRect.top, (float) tileRect.right, (float) tileRect.bottom);
-                this.canvas.restore();
-            } else {
+            // if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            //     this.canvas.save();
+            //     this.canvas.clipRect((float) tileRect.left, (float) tileRect.top, (float) tileRect.right, (float) tileRect.bottom);
+            //     this.canvas.restore();
+            // } else {
                 this.canvas.clipRect((float) tileRect.left, (float) tileRect.top, (float) tileRect.right, (float) tileRect.bottom, Region.Op.REPLACE);
-            }
+            // }
             android.graphics.Matrix transform = temps.useMatrix();
             transform.preTranslate((float) tileRect.left, (float) tileRect.top);
             transform.preScale((float) horizontalScale, (float) verticalScale);


### PR DESCRIPTION
Canvas.save() and restore() calls (being made on Android API 28 and up) cause intermittent hill shading issues: After zooming the map in/out a few times, some tiles (somewhat randomly chosen) loose their hill shading. Tested on Android 6 (which had no problems), 8, and 9. Removing those calls fixes the issue, and apparently without any side-effects.