### PR TITLE
Remove OSMapTuner which appears to be dead

### DIFF
--- a/docs/Mapsforge-Applications.md
+++ b/docs/Mapsforge-Applications.md
@@ -46,7 +46,6 @@
 | [Offline Maps](https://play.google.com/store/apps/developer?id=applantation.com) | Tourist Map | Proprietary/Commercial | Closed |
 | [OpenTrail](http://wiki.openstreetmap.org/wiki/OpenTrail) | Freemap for Android | GPL/Free | Open |
 | [OruxMaps](http://www.oruxmaps.com/) | Map Viewer | Proprietary/Free | Closed |
-| [OSMapTuner](http://osmaptuner.salzburgresearch.at/) | Map Viewer & Tag-Editor | Proprietary/Free | Closed |
 | [Pocket Coruna](https://play.google.com/store/apps/details?id=com.dolphinziyo.corunaentubolsillo) | Tourist guide | Proprietary/Free | Closed |
 | [Pocket Maps](https://github.com/junjunguo/PocketMaps) | Offline maps, routing & tracking functions | MIT/Free | Open |
 | [RouteConverter](http://www.routeconverter.com/) | GPS conversion and editing tool | GPL2/Free | Open |


### PR DESCRIPTION
The URL doesn't work anymore and I didn't find an alternative one that worked.