### PR TITLE
Fix: DPI auto scaling doesn't respect rendertheme's symbol-width and symbol-height

### DIFF
--- a/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/Symbol.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/Symbol.java
@@ -73,13 +73,13 @@ public class Symbol extends RenderInstruction {
             } else if (PRIORITY.equals(name)) {
                 this.priority = Integer.parseInt(value);
             } else if (SYMBOL_HEIGHT.equals(name)) {
-                this.height = XmlUtils.parseNonNegativeInteger(name, value) * displayModel.getScaleFactor();
+                this.height = XmlUtils.parseNonNegativeInteger(name, value);
             } else if (SYMBOL_PERCENT.equals(name)) {
                 this.percent = XmlUtils.parseNonNegativeInteger(name, value);
             } else if (SYMBOL_SCALING.equals(name)) {
                 // no-op
             } else if (SYMBOL_WIDTH.equals(name)) {
-                this.width = XmlUtils.parseNonNegativeInteger(name, value) * displayModel.getScaleFactor();
+                this.width = XmlUtils.parseNonNegativeInteger(name, value);
             } else {
                 throw XmlUtils.createXmlPullParserException(elementName, name, value, i);
             }


### PR DESCRIPTION
DPI scaling is already performed by GraphicUtils::imageSize.
Symbol.width and Symbol.height should just mirror their XML values.
Otherwise, setting explicit symbol-width and symbol-height values
is useless, because PNGs still get scaled nonetheless.

Related commit: b111d3b