### PR TITLE
fix: cache invalidation doesn't happen if tile size changes

### DIFF
--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/TileLayer.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/TileLayer.java
@@ -107,6 +107,9 @@ public abstract class TileLayer<T extends Job> extends Layer {
                     drawParentTileBitmap(canvas, point, tile);
                 }
             } else {
+                if (tileSizeHasChanged(tile, bitmap)) {
+                    this.tileCache.purge();
+                }
                 if (isTileStale(tile, bitmap) && this.hasJobQueue && !this.tileCache.containsKey(job)) {
                     this.jobQueue.add(job);
                 }
@@ -118,6 +121,10 @@ public abstract class TileLayer<T extends Job> extends Layer {
         if (this.hasJobQueue) {
             this.jobQueue.notifyWorkers();
         }
+    }
+
+    private boolean tileSizeHasChanged(Tile tile, TileBitmap bitmap) {
+        return tile.tileSize != bitmap.getWidth() || tile.tileSize != bitmap.getHeight();
     }
 
     @Override


### PR DESCRIPTION
Purge the tile cache if tile size changes.

Some phones such as Huawei phones have dynamic screen resolution
and cached tiles generated via a different resolution should not
be reused.

Issue: ttps://github.com/mapsforge/mapsforge/issues/1151