### PR TITLE
Allow setting "position" attribute to symbol and lineSymbol rendering instructions

### DIFF
--- a/mapsforge-core/src/main/java/org/mapsforge/core/graphics/Position.java
+++ b/mapsforge-core/src/main/java/org/mapsforge/core/graphics/Position.java
@@ -45,4 +45,20 @@ public enum Position {
         throw new IllegalArgumentException("Invalid value for Position: " + value);
     }
 
+    public boolean isOnLeftSide() {
+        return this == LEFT || this == ABOVE_LEFT || this == BELOW_LEFT;
+    }
+
+    public boolean isOnRightSide() {
+        return this == RIGHT || this == ABOVE_RIGHT || this == BELOW_RIGHT;
+    }
+
+    public boolean isOnUpperSide() {
+        return this == ABOVE || this == ABOVE_LEFT || this == ABOVE_RIGHT;
+    }
+
+    public boolean isOnLowerSide() {
+        return this == BELOW || this == BELOW_LEFT || this == BELOW_RIGHT;
+    }
+
 }

--- a/mapsforge-core/src/main/java/org/mapsforge/core/mapelements/SymbolContainer.java
+++ b/mapsforge-core/src/main/java/org/mapsforge/core/mapelements/SymbolContainer.java
@@ -23,40 +23,22 @@ import org.mapsforge.core.model.Rectangle;
 public class SymbolContainer extends MapElementContainer {
     public Bitmap symbol;
     public final float theta;
-    public Position position;
 
-    public SymbolContainer(Point point, Display display, int priority, Position position, Bitmap symbol) {
-        this(point, display, priority, position, symbol, 0);
+    public SymbolContainer(Point point, Display display, int priority, Rectangle symbolBoundary, Bitmap symbol) {
+        this(point, display, priority, symbolBoundary, symbol, 0);
     }
 
-    public SymbolContainer(Point point, Display display, int priority, Position position, Bitmap symbol, float theta) {
+    public SymbolContainer(Point point, Display display, int priority, Rectangle symbolBoundary, Bitmap symbol, float theta) {
         super(point, display, priority);
         this.symbol = symbol;
         this.theta = theta;
-        this.position = position;
-        computeBoundary();
+        this.boundary = symbolBoundary;
+        if (this.boundary == null) {
+            int width = symbol.getWidth();
+            int height = symbol.getHeight();
+            this.boundary = new Rectangle(-width / 2.0, -height / 2.0, width / 2.0, height / 2.0);
+        }
         this.symbol.incrementRefCount();
-    }
-
-    private void computeBoundary() {
-        // Center by default
-        double xfactor = -0.5, yfactor = -0.5;
-
-        if (position == Position.ABOVE_LEFT || position == Position.LEFT || position == Position.BELOW_LEFT)
-            xfactor = -1;
-        else if (position == Position.ABOVE_RIGHT || position == Position.RIGHT || position == Position.BELOW_RIGHT)
-            xfactor = 0;
-
-        if (position == Position.ABOVE_LEFT || position == Position.ABOVE || position == Position.ABOVE_RIGHT)
-            yfactor = -1;
-        else if (position == Position.BELOW_LEFT || position == Position.BELOW || position == Position.BELOW_RIGHT)
-            yfactor = 0;
-
-        int width = this.symbol.getWidth();
-        int height = this.symbol.getHeight();
-        double left = xfactor * width;
-        double top = yfactor * width;
-        this.boundary = new Rectangle(left, top, left + width, top + height);
     }
 
     @Override

--- a/mapsforge-map-awt/src/test/java/org/mapsforge/map/rendertheme/rule/DummyRenderCallback.java
+++ b/mapsforge-map-awt/src/test/java/org/mapsforge/map/rendertheme/rule/DummyRenderCallback.java
@@ -50,7 +50,7 @@ class DummyRenderCallback implements RenderCallback {
     }
 
     @Override
-    public void renderPointOfInterestSymbol(final RenderContext renderContext, Display display, int priority, Bitmap symbol, PointOfInterest poi) {
+    public void renderPointOfInterestSymbol(final RenderContext renderContext, Display display, int priority, Position position, Bitmap symbol, PointOfInterest poi) {
         // do nothing
     }
 
@@ -60,7 +60,7 @@ class DummyRenderCallback implements RenderCallback {
     }
 
     @Override
-    public void renderWaySymbol(final RenderContext renderContext, Display display, int priority, Bitmap symbol, float dy, boolean alignCenter, boolean repeat, float repeatGap, float repeatStart, boolean rotate, PolylineContainer way) {
+    public void renderWaySymbol(final RenderContext renderContext, Display display, int priority, Bitmap symbol, float dy, Position position, boolean repeat, float repeatGap, float repeatStart, boolean rotate, PolylineContainer way) {
         // do nothing
     }
 

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/StandardRenderer.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/StandardRenderer.java
@@ -25,6 +25,7 @@ import org.mapsforge.core.graphics.Position;
 import org.mapsforge.core.mapelements.SymbolContainer;
 import org.mapsforge.core.model.LatLong;
 import org.mapsforge.core.model.Point;
+import org.mapsforge.core.model.Rectangle;
 import org.mapsforge.core.model.Tag;
 import org.mapsforge.core.util.MercatorProjection;
 import org.mapsforge.map.datastore.MapDataStore;
@@ -122,7 +123,7 @@ public class StandardRenderer implements RenderCallback {
     public void renderAreaSymbol(final RenderContext renderContext, Display display, int priority, Bitmap symbol, PolylineContainer way) {
         if (renderLabels) {
             Point centerPosition = way.getCenterAbsolute();
-            renderContext.labels.add(new SymbolContainer(centerPosition, display, priority, Position.CENTER, symbol));
+            renderContext.labels.add(new SymbolContainer(centerPosition, display, priority, null, symbol));
         }
     }
 
@@ -144,10 +145,10 @@ public class StandardRenderer implements RenderCallback {
     }
 
     @Override
-    public void renderPointOfInterestSymbol(final RenderContext renderContext, Display display, int priority, Position position, Bitmap symbol, PointOfInterest poi) {
+    public void renderPointOfInterestSymbol(final RenderContext renderContext, Display display, int priority, Rectangle symbolBoundary, Bitmap symbol, PointOfInterest poi) {
         if (renderLabels) {
             Point poiPosition = MercatorProjection.getPixelAbsolute(poi.position, renderContext.rendererJob.tile.mapSize);
-            renderContext.labels.add(new SymbolContainer(poiPosition, display, priority, position, symbol));
+            renderContext.labels.add(new SymbolContainer(poiPosition, display, priority, symbolBoundary, symbol));
         }
     }
 
@@ -157,9 +158,9 @@ public class StandardRenderer implements RenderCallback {
     }
 
     @Override
-    public void renderWaySymbol(final RenderContext renderContext, Display display, int priority, Bitmap symbol, float dy, Position position, boolean repeat, float repeatGap, float repeatStart, boolean rotate, PolylineContainer way) {
+    public void renderWaySymbol(final RenderContext renderContext, Display display, int priority, Bitmap symbol, float dy, Rectangle symbolBoundary, boolean repeat, float repeatGap, float repeatStart, boolean rotate, PolylineContainer way) {
         if (renderLabels) {
-            WayDecorator.renderSymbol(symbol, display, priority, dy, position, repeat, repeatGap,
+            WayDecorator.renderSymbol(symbol, display, priority, dy, symbolBoundary, repeat, repeatGap,
                     repeatStart, rotate, way.getCoordinatesAbsolute(), renderContext.labels);
         }
     }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/StandardRenderer.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/StandardRenderer.java
@@ -122,7 +122,7 @@ public class StandardRenderer implements RenderCallback {
     public void renderAreaSymbol(final RenderContext renderContext, Display display, int priority, Bitmap symbol, PolylineContainer way) {
         if (renderLabels) {
             Point centerPosition = way.getCenterAbsolute();
-            renderContext.labels.add(new SymbolContainer(centerPosition, display, priority, symbol));
+            renderContext.labels.add(new SymbolContainer(centerPosition, display, priority, Position.CENTER, symbol));
         }
     }
 
@@ -144,10 +144,10 @@ public class StandardRenderer implements RenderCallback {
     }
 
     @Override
-    public void renderPointOfInterestSymbol(final RenderContext renderContext, Display display, int priority, Bitmap symbol, PointOfInterest poi) {
+    public void renderPointOfInterestSymbol(final RenderContext renderContext, Display display, int priority, Position position, Bitmap symbol, PointOfInterest poi) {
         if (renderLabels) {
             Point poiPosition = MercatorProjection.getPixelAbsolute(poi.position, renderContext.rendererJob.tile.mapSize);
-            renderContext.labels.add(new SymbolContainer(poiPosition, display, priority, symbol));
+            renderContext.labels.add(new SymbolContainer(poiPosition, display, priority, position, symbol));
         }
     }
 
@@ -157,9 +157,9 @@ public class StandardRenderer implements RenderCallback {
     }
 
     @Override
-    public void renderWaySymbol(final RenderContext renderContext, Display display, int priority, Bitmap symbol, float dy, boolean alignCenter, boolean repeat, float repeatGap, float repeatStart, boolean rotate, PolylineContainer way) {
+    public void renderWaySymbol(final RenderContext renderContext, Display display, int priority, Bitmap symbol, float dy, Position position, boolean repeat, float repeatGap, float repeatStart, boolean rotate, PolylineContainer way) {
         if (renderLabels) {
-            WayDecorator.renderSymbol(symbol, display, priority, dy, alignCenter, repeat, repeatGap,
+            WayDecorator.renderSymbol(symbol, display, priority, dy, position, repeat, repeatGap,
                     repeatStart, rotate, way.getCoordinatesAbsolute(), renderContext.labels);
         }
     }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/WayDecorator.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/WayDecorator.java
@@ -19,6 +19,7 @@ import org.mapsforge.core.graphics.Bitmap;
 import org.mapsforge.core.graphics.Display;
 import org.mapsforge.core.graphics.GraphicFactory;
 import org.mapsforge.core.graphics.Paint;
+import org.mapsforge.core.graphics.Position;
 import org.mapsforge.core.mapelements.MapElementContainer;
 import org.mapsforge.core.mapelements.SymbolContainer;
 import org.mapsforge.core.mapelements.WayTextContainer;
@@ -33,7 +34,7 @@ final class WayDecorator {
 
     private static final double MAX_LABEL_CORNER_ANGLE = 45;
 
-    static void renderSymbol(Bitmap symbolBitmap, Display display, int priority, float dy, boolean alignCenter,
+    static void renderSymbol(Bitmap symbolBitmap, Display display, int priority, float dy, Position position,
                              boolean repeatSymbol, float repeatGap, float repeatStart,
                              boolean rotate, Point[][] coordinates,
                              List<MapElementContainer> currentItems) {
@@ -81,7 +82,7 @@ final class WayDecorator {
 
                 Point point = new Point(previousX, previousY);
 
-                currentItems.add(new SymbolContainer(point, display, priority, symbolBitmap, theta, alignCenter));
+                currentItems.add(new SymbolContainer(point, display, priority, position, symbolBitmap, theta));
 
                 // check if the symbolContainer should only be rendered once
                 if (!repeatSymbol) {

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/WayDecorator.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/WayDecorator.java
@@ -26,6 +26,7 @@ import org.mapsforge.core.mapelements.WayTextContainer;
 import org.mapsforge.core.model.LineSegment;
 import org.mapsforge.core.model.LineString;
 import org.mapsforge.core.model.Point;
+import org.mapsforge.core.model.Rectangle;
 import org.mapsforge.core.model.Tile;
 
 import java.util.List;
@@ -34,7 +35,7 @@ final class WayDecorator {
 
     private static final double MAX_LABEL_CORNER_ANGLE = 45;
 
-    static void renderSymbol(Bitmap symbolBitmap, Display display, int priority, float dy, Position position,
+    static void renderSymbol(Bitmap symbolBitmap, Display display, int priority, float dy, Rectangle symbolBoundary,
                              boolean repeatSymbol, float repeatGap, float repeatStart,
                              boolean rotate, Point[][] coordinates,
                              List<MapElementContainer> currentItems) {
@@ -82,7 +83,7 @@ final class WayDecorator {
 
                 Point point = new Point(previousX, previousY);
 
-                currentItems.add(new SymbolContainer(point, display, priority, position, symbolBitmap, theta));
+                currentItems.add(new SymbolContainer(point, display, priority, symbolBoundary, symbolBitmap, theta));
 
                 // check if the symbolContainer should only be rendered once
                 if (!repeatSymbol) {

--- a/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/RenderCallback.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/RenderCallback.java
@@ -18,6 +18,7 @@ import org.mapsforge.core.graphics.Bitmap;
 import org.mapsforge.core.graphics.Display;
 import org.mapsforge.core.graphics.Paint;
 import org.mapsforge.core.graphics.Position;
+import org.mapsforge.core.model.Rectangle;
 import org.mapsforge.map.datastore.PointOfInterest;
 import org.mapsforge.map.layer.renderer.PolylineContainer;
 
@@ -90,7 +91,7 @@ public interface RenderCallback {
      * @param renderContext
      * @param symbol
      */
-    void renderPointOfInterestSymbol(final RenderContext renderContext, Display display, int priority, Position position, Bitmap symbol, PointOfInterest poi);
+    void renderPointOfInterestSymbol(final RenderContext renderContext, Display display, int priority, Rectangle symbolBoundary, Bitmap symbol, PointOfInterest poi);
 
     /**
      * Renders a way with the given parameters.
@@ -113,7 +114,7 @@ public interface RenderCallback {
      * @param repeatGap     distance between repetitions.
      * @param repeatStart
      */
-    void renderWaySymbol(final RenderContext renderContext, Display display, int priority, Bitmap symbol, float dy, Position position, boolean repeat, float repeatGap, float repeatStart, boolean rotate, PolylineContainer way);
+    void renderWaySymbol(final RenderContext renderContext, Display display, int priority, Bitmap symbol, float dy, Rectangle symbolBoundary, boolean repeat, float repeatGap, float repeatStart, boolean rotate, PolylineContainer way);
 
     /**
      * Renders a way with the given text along the way path.

--- a/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/RenderCallback.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/RenderCallback.java
@@ -90,7 +90,7 @@ public interface RenderCallback {
      * @param renderContext
      * @param symbol
      */
-    void renderPointOfInterestSymbol(final RenderContext renderContext, Display display, int priority, Bitmap symbol, PointOfInterest poi);
+    void renderPointOfInterestSymbol(final RenderContext renderContext, Display display, int priority, Position position, Bitmap symbol, PointOfInterest poi);
 
     /**
      * Renders a way with the given parameters.
@@ -108,12 +108,12 @@ public interface RenderCallback {
      * @param renderContext
      * @param symbol        the symbol to be rendered.
      * @param dy            the offset of the way.
-     * @param alignCenter   true if the symbol should be centered, false otherwise.
+     * @param position      Relative positioning of the symbol
      * @param repeat        true if the symbol should be repeated, false otherwise.
      * @param repeatGap     distance between repetitions.
      * @param repeatStart
      */
-    void renderWaySymbol(final RenderContext renderContext, Display display, int priority, Bitmap symbol, float dy, boolean alignCenter, boolean repeat, float repeatGap, float repeatStart, boolean rotate, PolylineContainer way);
+    void renderWaySymbol(final RenderContext renderContext, Display display, int priority, Bitmap symbol, float dy, Position position, boolean repeat, float repeatGap, float repeatStart, boolean rotate, PolylineContainer way);
 
     /**
      * Renders a way with the given text along the way path.

--- a/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/LineSymbol.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/LineSymbol.java
@@ -19,6 +19,7 @@ package org.mapsforge.map.rendertheme.renderinstruction;
 import org.mapsforge.core.graphics.Bitmap;
 import org.mapsforge.core.graphics.Display;
 import org.mapsforge.core.graphics.GraphicFactory;
+import org.mapsforge.core.graphics.Position;
 import org.mapsforge.map.datastore.PointOfInterest;
 import org.mapsforge.map.layer.renderer.PolylineContainer;
 import org.mapsforge.map.model.DisplayModel;
@@ -39,7 +40,7 @@ public class LineSymbol extends RenderInstruction {
     private static final float REPEAT_GAP_DEFAULT = 200f;
     private static final float REPEAT_START_DEFAULT = 30f;
 
-    private boolean alignCenter;
+    private Position position;
     private Bitmap bitmap;
     private boolean bitmapInvalid;
     private Display display;
@@ -62,6 +63,8 @@ public class LineSymbol extends RenderInstruction {
         this.rotate = true;
         this.relativePathPrefix = relativePathPrefix;
         this.dyScaled = new HashMap<>();
+        // Probably not a good default, but backwards compatible
+        this.position = Position.BELOW_RIGHT;
 
         extractValues(elementName, pullParser);
     }
@@ -84,7 +87,10 @@ public class LineSymbol extends RenderInstruction {
             if (SRC.equals(name)) {
                 this.src = value;
             } else if (ALIGN_CENTER.equals(name)) {
-                this.alignCenter = Boolean.parseBoolean(value);
+                // Deprecated way to say position="center"
+                boolean center = Boolean.parseBoolean(value);
+                if (center)
+                    this.position = Position.CENTER;
             } else if (CAT.equals(name)) {
                 this.category = value;
             } else if (DISPLAY.equals(name)) {
@@ -111,6 +117,8 @@ public class LineSymbol extends RenderInstruction {
                 // no-op
             } else if (SYMBOL_WIDTH.equals(name)) {
                 this.width = XmlUtils.parseNonNegativeInteger(name, value) * displayModel.getScaleFactor();
+            } else if (POSITION.equals(name)) {
+                this.position = Position.fromString(value);
             } else {
                 throw XmlUtils.createXmlPullParserException(elementName, name, value, i);
             }
@@ -142,7 +150,7 @@ public class LineSymbol extends RenderInstruction {
         }
 
         if (this.bitmap != null) {
-            renderCallback.renderWaySymbol(renderContext, this.display, this.priority, this.bitmap, dyScale, this.alignCenter,
+            renderCallback.renderWaySymbol(renderContext, this.display, this.priority, this.bitmap, dyScale, this.position,
                     this.repeat, this.repeatGap, this.repeatStart, this.rotate, way);
         }
     }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/LineSymbol.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/LineSymbol.java
@@ -20,6 +20,7 @@ import org.mapsforge.core.graphics.Bitmap;
 import org.mapsforge.core.graphics.Display;
 import org.mapsforge.core.graphics.GraphicFactory;
 import org.mapsforge.core.graphics.Position;
+import org.mapsforge.core.model.Rectangle;
 import org.mapsforge.map.datastore.PointOfInterest;
 import org.mapsforge.map.layer.renderer.PolylineContainer;
 import org.mapsforge.map.model.DisplayModel;
@@ -150,7 +151,8 @@ public class LineSymbol extends RenderInstruction {
         }
 
         if (this.bitmap != null) {
-            renderCallback.renderWaySymbol(renderContext, this.display, this.priority, this.bitmap, dyScale, this.position,
+            Rectangle boundary = computeImageBoundary(this.bitmap.getWidth(), this.bitmap.getHeight(), this.position);
+            renderCallback.renderWaySymbol(renderContext, this.display, this.priority, this.bitmap, dyScale, boundary,
                     this.repeat, this.repeatGap, this.repeatStart, this.rotate, way);
         }
     }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/RenderInstruction.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/RenderInstruction.java
@@ -18,6 +18,8 @@ package org.mapsforge.map.rendertheme.renderinstruction;
 
 import org.mapsforge.core.graphics.Bitmap;
 import org.mapsforge.core.graphics.GraphicFactory;
+import org.mapsforge.core.graphics.Position;
+import org.mapsforge.core.model.Rectangle;
 import org.mapsforge.map.datastore.PointOfInterest;
 import org.mapsforge.map.layer.renderer.PolylineContainer;
 import org.mapsforge.map.model.DisplayModel;
@@ -120,6 +122,25 @@ public abstract class RenderInstruction {
             return Scale.NONE;
         }
         return Scale.STROKE;
+    }
+
+    protected Rectangle computeImageBoundary(int width, int height, Position position) {
+        // Center by default
+        double xfactor = -0.5, yfactor = -0.5;
+
+        if (position == Position.ABOVE_LEFT || position == Position.LEFT || position == Position.BELOW_LEFT)
+            xfactor = -1;
+        else if (position == Position.ABOVE_RIGHT || position == Position.RIGHT || position == Position.BELOW_RIGHT)
+            xfactor = 0;
+
+        if (position == Position.ABOVE_LEFT || position == Position.ABOVE || position == Position.ABOVE_RIGHT)
+            yfactor = -1;
+        else if (position == Position.BELOW_LEFT || position == Position.BELOW || position == Position.BELOW_RIGHT)
+            yfactor = 0;
+
+        double left = xfactor * width;
+        double top = yfactor * width;
+        return new Rectangle(left, top, left + width, top + height);
     }
 
     /**

--- a/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/Symbol.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/Symbol.java
@@ -20,6 +20,7 @@ import org.mapsforge.core.graphics.Bitmap;
 import org.mapsforge.core.graphics.Display;
 import org.mapsforge.core.graphics.GraphicFactory;
 import org.mapsforge.core.graphics.Position;
+import org.mapsforge.core.model.Rectangle;
 import org.mapsforge.map.datastore.PointOfInterest;
 import org.mapsforge.map.layer.renderer.PolylineContainer;
 import org.mapsforge.map.model.DisplayModel;
@@ -43,6 +44,7 @@ public class Symbol extends RenderInstruction {
     private final String relativePathPrefix;
     private String src;
     private Position position;
+    private Rectangle symbolBoundary;
 
     public Symbol(GraphicFactory graphicFactory, DisplayModel displayModel, String elementName,
                   XmlPullParser pullParser, String relativePathPrefix) throws IOException, XmlPullParserException {
@@ -51,6 +53,9 @@ public class Symbol extends RenderInstruction {
         this.display = Display.IFSPACE;
         this.position = Position.CENTER;
         extractValues(elementName, pullParser);
+
+        Bitmap bitmap = getBitmap();
+        this.symbolBoundary = computeImageBoundary(bitmap.getWidth(), bitmap.getHeight(), this.position);
     }
 
     @Override
@@ -106,6 +111,10 @@ public class Symbol extends RenderInstruction {
         return this.id;
     }
 
+    public Rectangle getSymbolBoundary() {
+        return this.symbolBoundary;
+    }
+
     @Override
     public void renderNode(RenderCallback renderCallback, final RenderContext renderContext, PointOfInterest poi) {
         if (Display.NEVER == this.display) {
@@ -113,7 +122,7 @@ public class Symbol extends RenderInstruction {
         }
 
         if (getBitmap() != null) {
-            renderCallback.renderPointOfInterestSymbol(renderContext, this.display, this.priority, this.position, this.bitmap, poi);
+            renderCallback.renderPointOfInterestSymbol(renderContext, this.display, this.priority, this.symbolBoundary, this.bitmap, poi);
         }
     }
 

--- a/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/Symbol.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/Symbol.java
@@ -19,6 +19,7 @@ package org.mapsforge.map.rendertheme.renderinstruction;
 import org.mapsforge.core.graphics.Bitmap;
 import org.mapsforge.core.graphics.Display;
 import org.mapsforge.core.graphics.GraphicFactory;
+import org.mapsforge.core.graphics.Position;
 import org.mapsforge.map.datastore.PointOfInterest;
 import org.mapsforge.map.layer.renderer.PolylineContainer;
 import org.mapsforge.map.model.DisplayModel;
@@ -41,12 +42,14 @@ public class Symbol extends RenderInstruction {
     private int priority;
     private final String relativePathPrefix;
     private String src;
+    private Position position;
 
     public Symbol(GraphicFactory graphicFactory, DisplayModel displayModel, String elementName,
                   XmlPullParser pullParser, String relativePathPrefix) throws IOException, XmlPullParserException {
         super(graphicFactory, displayModel);
         this.relativePathPrefix = relativePathPrefix;
         this.display = Display.IFSPACE;
+        this.position = Position.CENTER;
         extractValues(elementName, pullParser);
     }
 
@@ -80,6 +83,8 @@ public class Symbol extends RenderInstruction {
                 // no-op
             } else if (SYMBOL_WIDTH.equals(name)) {
                 this.width = XmlUtils.parseNonNegativeInteger(name, value) * displayModel.getScaleFactor();
+            } else if (POSITION.equals(name)) {
+                this.position = Position.fromString(value);
             } else {
                 throw XmlUtils.createXmlPullParserException(elementName, name, value, i);
             }
@@ -108,7 +113,7 @@ public class Symbol extends RenderInstruction {
         }
 
         if (getBitmap() != null) {
-            renderCallback.renderPointOfInterestSymbol(renderContext, this.display, this.priority, this.bitmap, poi);
+            renderCallback.renderPointOfInterestSymbol(renderContext, this.display, this.priority, this.position, this.bitmap, poi);
         }
     }
 

--- a/mapsforge-themes/src/main/resources/assets/mapsforge/default.xml
+++ b/mapsforge-themes/src/main/resources/assets/mapsforge/default.xml
@@ -687,7 +687,7 @@
                 <line src="jar:patterns/access-private.png" stroke-width="1.0" />
             </rule>
             <rule e="way" k="oneway" v="yes|true|1" zoom-min="16">
-                <lineSymbol align-center="true" display="always" priority="-50" repeat="true"
+                <lineSymbol position="center" display="always" priority="-50" repeat="true"
                     src="jar:symbols/oneway.svg" />
             </rule>
         </rule>

--- a/mapsforge-themes/src/main/resources/assets/mapsforge/osmarender.xml
+++ b/mapsforge-themes/src/main/resources/assets/mapsforge/osmarender.xml
@@ -815,7 +815,7 @@
             <rule e="way" k="area" v="~|false|no">
                 <rule e="way" k="highway" v="*">
                     <rule e="way" k="oneway" v="yes|true" zoom-min="16">
-                        <lineSymbol align-center="true" repeat="true"
+                        <lineSymbol position="center" repeat="true"
                             src="jar:symbols/oneway.svg" />
                     </rule>
                 </rule>

--- a/resources/renderTheme.xsd
+++ b/resources/renderTheme.xsd
@@ -205,6 +205,7 @@
         <xs:attribute name="repeat-gap" default="200" type="xs:float" use="optional" />
         <xs:attribute name="repeat-start" default="30" type="xs:float" use="optional" />
         <xs:attribute name="rotate" default="true" type="xs:boolean" use="optional" />
+        <xs:attribute name="position" default="below_right" type="tns:position" use="optional" />
     </xs:complexType>
 
     <!-- style menu name element -->
@@ -246,6 +247,7 @@
         <xs:attribute name="symbol-width" type="xs:positiveInteger" use="optional" />
         <xs:attribute name="symbol-height" type="xs:positiveInteger" use="optional" />
         <xs:attribute name="symbol-percent" type="xs:positiveInteger" use="optional" />
+        <xs:attribute name="position" default="center" type="tns:position" use="optional" />
     </xs:complexType>
 
     <!-- rule elements -->


### PR DESCRIPTION
Hi,
This PR allows setting the "position" attribute to the `<symbol..>` and `<lineSymbol...>` rendering instructions.
This allows placing a Symbol explicitly above/below/left/right/... of the respective point (or line-center).
Therefore, it makes it possible to use symbols that have a specific hotspot, so only make sense if they are placed accordingly (such as a marker pin, an arrow, ...)

This also deprecates the `align-center` attribute for lineSymbol (which was only used for oneway roads in the default themes), as it is now replaced by `position="center"`. However, I left it in there for backwards compatibility.
The changes should be 100% backwards compatible.

Note that the default for `<symbol...` is center, while the default for `<lineSymbol...` is bottom_right. 
Even though this is not 100% intuitive, IMO, this is to maintain backwards compatibility for the cablecar tags in the default themes (and any other theme out in the wild).

Example: I tested with the (enlarged) traffic light icon in the sample app.
Default center:
![grafik](https://user-images.githubusercontent.com/1858945/95022677-fe773700-0678-11eb-9194-f0c574722012.png)
Right:
![grafik](https://user-images.githubusercontent.com/1858945/95022685-13ec6100-0679-11eb-8fb7-a11b075f42a2.png)
Above left:
![grafik](https://user-images.githubusercontent.com/1858945/95022698-26ff3100-0679-11eb-958a-fcd2f6c3cb29.png)

You get the idea :)