### PR TITLE
Fix for #1176: apply shader bitmap shift at drawing stage, not at processing stage

### DIFF
--- a/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/Area.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/Area.java
@@ -2,6 +2,7 @@
  * Copyright 2010, 2011, 2012, 2013 mapsforge.org
  * Copyright 2014-2015 Ludwig M Brinckmann
  * Copyright 2014-2019 devemux86
+ * Copyright 2020 Adrian Batzill
  *
  * This program is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
@@ -143,9 +144,6 @@ public class Area extends RenderInstruction {
                     bitmapInvalid = true;
                 }
             }
-
-            fillPaint.setBitmapShaderShift(way.getUpperLeft().getOrigin());
-
             renderCallback.renderArea(renderContext, fillPaint, getStrokePaint(renderContext.rendererJob.tile.zoomLevel), this.level, way);
         }
     }


### PR DESCRIPTION
Note that the setBitmapShaderShift method does indeed do some allocations, but this was done on a per-geometry basis previously as well (but then potentially overwritten by other threads), so nothing is lost here.