### PR TITLE
Zipped hgt

### DIFF
--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/AbsShadingAlgorithmDefaults.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/AbsShadingAlgorithmDefaults.java
@@ -1,0 +1,83 @@
+package org.mapsforge.map.layer.hills;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+public abstract class AbsShadingAlgorithmDefaults implements ShadingAlgorithm {
+    private static final Logger LOGGER = Logger.getLogger(org.mapsforge.map.layer.hills.AbsShadingAlgorithmDefaults.class.getName());
+
+    @Override
+    public RawShadingResult transformToByteBuffer(HgtCache.HgtFileInfo source, int padding) {
+        int axisLength = getAxisLenght(source);
+        int rowLen = axisLength + 1;
+        InputStream stream = null;
+        FileChannel channel = null;
+        try {
+            ByteBuffer map = null;
+            File file = source.getFile();
+            String nameLowerCase = file.getName().toLowerCase();
+            if (nameLowerCase.endsWith(".zip")) {
+
+                ZipInputStream zipInputStream = new ZipInputStream(new FileInputStream(file));
+                ZipEntry entry;
+                String expectedNameLC = nameLowerCase.substring(0, nameLowerCase.length() - 4) + ".hgt";
+                while (null != (entry = zipInputStream.getNextEntry())) {
+                    if (!expectedNameLC.equals(entry.getName().toLowerCase())) continue;
+
+                    map = ByteBuffer.allocate((int) entry.getSize());
+                    int todo = (int) entry.getSize();
+                    int done = 0;
+                    while (todo > 0) {
+                        int read = zipInputStream.read(map.array(), done, todo);
+                        if (read == 0) {
+                            LOGGER.log(Level.SEVERE, "failed to read entire .hgt in " + file.getName() + " " + done + " of " + todo + " done");
+                            return null;
+                        }
+                        done += read;
+                        todo -= read;
+                    }
+                    map.order(ByteOrder.BIG_ENDIAN);
+                    break;
+                }
+                if (map == null) {
+                    LOGGER.log(Level.SEVERE, "no matching .hgt in " + file.getName());
+                    return null;
+                }
+            } else {
+                FileInputStream fileInputStream = new FileInputStream(file);
+                channel = fileInputStream.getChannel();
+                stream = fileInputStream;
+                map = channel.map(FileChannel.MapMode.READ_ONLY, 0, file.length());
+                map.order(ByteOrder.BIG_ENDIAN);
+            }
+
+            byte[] bytes = convert(map, axisLength, rowLen, padding, source);
+            return new RawShadingResult(bytes, axisLength, axisLength, padding);
+        } catch (IOException e) {
+            LOGGER.log(Level.SEVERE, e.getMessage(), e);
+            return null;
+        } finally {
+            if (channel != null) try {
+                channel.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+            if (stream != null) try {
+                stream.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    protected abstract byte[] convert(ByteBuffer map, int axisLength, int rowLen, int padding, HgtCache.HgtFileInfo source) throws IOException;
+}

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/DiffuseLightShadingAlgorithm.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/DiffuseLightShadingAlgorithm.java
@@ -16,14 +16,8 @@ package org.mapsforge.map.layer.hills;
 
 import org.mapsforge.core.util.MercatorProjection;
 
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.nio.MappedByteBuffer;
-import java.nio.channels.FileChannel;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -33,7 +27,7 @@ import java.util.logging.Logger;
  * <p>
  * <p>More accurate than {@link SimpleShadingAlgorithm}, but maybe not as useful for visualizing both softly rolling hills and dramatic mountain ranges at the same time.</p>
  */
-public class DiffuseLightShadingAlgorithm implements ShadingAlgorithm {
+public class DiffuseLightShadingAlgorithm extends AbsShadingAlgorithmDefaults {
 
     private static final Logger LOGGER = Logger.getLogger(DiffuseLightShadingAlgorithm.class.getName());
     private static final double halfPi = Math.PI / 2d;
@@ -87,39 +81,8 @@ public class DiffuseLightShadingAlgorithm implements ShadingAlgorithm {
         return rowLen - 1;
     }
 
-    @Override
-    public RawShadingResult transformToByteBuffer(HgtCache.HgtFileInfo source, int padding) {
-        int axisLength = getAxisLenght(source);
-        int rowLen = axisLength + 1;
-        FileInputStream stream = null;
-        FileChannel channel = null;
-        try {
-            File file = source.getFile();
-            stream = new FileInputStream(file);
-            channel = stream.getChannel();
-            MappedByteBuffer map = channel.map(FileChannel.MapMode.READ_ONLY, 0, file.length());
-            map.order(ByteOrder.BIG_ENDIAN);
-            byte[] bytes = convert(map, axisLength, rowLen, padding, source);
 
-            return new RawShadingResult(bytes, axisLength, axisLength, padding);
-        } catch (IOException e) {
-            LOGGER.log(Level.SEVERE, e.getMessage(), e);
-            return null;
-        } finally {
-            if (channel != null) try {
-                channel.close();
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-            if (stream != null) try {
-                stream.close();
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-        }
-    }
-
-    private byte[] convert(MappedByteBuffer din, int axisLength, int rowLen, int padding, HgtCache.HgtFileInfo fileInfo) throws IOException {
+    protected byte[] convert(ByteBuffer din, int axisLength, int rowLen, int padding, HgtCache.HgtFileInfo fileInfo) throws IOException {
         byte[] bytes;
 
         short[] ringbuffer = new short[rowLen];

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/HgtCache.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/HgtCache.java
@@ -21,12 +21,16 @@ import org.mapsforge.core.graphics.HillshadingBitmap;
 import org.mapsforge.core.model.BoundingBox;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
 import java.lang.ref.WeakReference;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
 
 
 /**
@@ -148,7 +152,7 @@ class HgtCache {
             @Override
             protected Map<TileKey, HgtFileInfo> calculate() {
                 Map<TileKey, HgtFileInfo> map = new HashMap<>();
-                Matcher matcher = Pattern.compile("([ns])(\\d{1,2})([ew])(\\d{1,3})\\.hgt", Pattern.CASE_INSENSITIVE).matcher("");
+                Matcher matcher = Pattern.compile("([ns])(\\d{1,2})([ew])(\\d{1,3})\\.(?:(hgt)|(zip))", Pattern.CASE_INSENSITIVE).matcher("");
                 crawl(HgtCache.this.demFolder, matcher, map, problems);
                 return map;
             }
@@ -164,19 +168,46 @@ class HgtCache {
                             int north = "n".equals(matcher.group(1).toLowerCase()) ? northsouth : -northsouth;
                             int east = "e".equals(matcher.group(3).toLowerCase()) ? eastwest : -eastwest;
 
-                            long length = file.length();
+                            long length = 0;
+
+                            if(matcher.group(6)==null) {
+                                length = file.length();
+                            } else {
+                                // zip
+                                ZipInputStream zipInputStream = null;
+                                try {
+                                    zipInputStream = new ZipInputStream(new FileInputStream(file));
+                                    String expectedHgt = name.toLowerCase().substring(0, name.length() - 4)+".hgt";
+                                    ZipEntry entry;
+                                    while(null!=(entry=zipInputStream.getNextEntry())){
+                                        if(expectedHgt.equals(entry.getName().toLowerCase())) {
+                                            length = entry.getSize();
+                                            break;
+                                        }
+                                    }
+                                } catch(IOException e) {
+                                    problems.add("could not read zip file "+file.getName());
+                                }
+                                if(zipInputStream!=null){
+                                    try {
+                                        zipInputStream.close();
+                                    } catch (IOException e) {
+                                        e.printStackTrace();
+                                    }
+                                }
+                            }
                             long heights = length / 2;
                             long sqrt = (long) Math.sqrt(heights);
-                            if (sqrt * sqrt != heights) {
+                            if (heights==0 || sqrt * sqrt != heights) {
                                 if (problems != null)
                                     problems.add(file + " length in shorts (" + heights + ") is not a square number");
-                            } else {
-                                TileKey tileKey = new TileKey(north, east);
-                                HgtFileInfo existing = map.get(tileKey);
-                                if (existing == null || existing.size < length) {
-//                                hgtFiles.put(tileKey, new HgtFileInfo(file, east, north, east+1, north-1));
-                                    map.put(tileKey, new HgtFileInfo(file, north - 1, east, north, east + 1));
-                                }
+                                return;
+                            }
+
+                            TileKey tileKey = new TileKey(north, east);
+                            HgtFileInfo existing = map.get(tileKey);
+                            if (existing == null || existing.size < length) {
+                                map.put(tileKey, new HgtFileInfo(file, north - 1, east, north, east + 1, length));
                             }
                         }
                     } else if (file.isDirectory()) {
@@ -269,10 +300,10 @@ class HgtCache {
 
         final long size;
 
-        HgtFileInfo(File file, double minLatitude, double minLongitude, double maxLatitude, double maxLongitude) {
+        HgtFileInfo(File file, double minLatitude, double minLongitude, double maxLatitude, double maxLongitude, long size) {
             super(minLatitude, minLongitude, maxLatitude, maxLongitude);
             this.file = file;
-            size = file.length();
+            this.size = size;
         }
 
         Future<HillshadingBitmap> getBitmapFuture(double pxPerLat, double pxPerLng) {

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/SimpleShadingAlgorithm.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/SimpleShadingAlgorithm.java
@@ -14,14 +14,8 @@
  */
 package org.mapsforge.map.layer.hills;
 
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.nio.MappedByteBuffer;
-import java.nio.channels.FileChannel;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -29,7 +23,7 @@ import java.util.logging.Logger;
  * <p>
  * <p>variations can be created by overriding {@link #exaggerate(double)}</p>
  */
-public class SimpleShadingAlgorithm implements ShadingAlgorithm {
+public class SimpleShadingAlgorithm extends AbsShadingAlgorithmDefaults {
     private static final Logger LOGGER = Logger.getLogger(SimpleShadingAlgorithm.class.getName());
     public final double linearity;
     public final double scale;
@@ -86,39 +80,9 @@ public class SimpleShadingAlgorithm implements ShadingAlgorithm {
         return rowLen - 1;
     }
 
-    @Override
-    public RawShadingResult transformToByteBuffer(HgtCache.HgtFileInfo source, int padding) {
-        int axisLength = getAxisLenght(source);
-        int rowLen = axisLength + 1;
-        FileInputStream stream = null;
-        FileChannel channel = null;
-        try {
-            File file = source.getFile();
-            stream = new FileInputStream(file);
-            channel = stream.getChannel();
-            MappedByteBuffer map = channel.map(FileChannel.MapMode.READ_ONLY, 0, file.length());
-            map.order(ByteOrder.BIG_ENDIAN);
-            byte[] bytes = convert(map, axisLength, rowLen, padding);
 
-            return new RawShadingResult(bytes, axisLength, axisLength, padding);
-        } catch (IOException e) {
-            LOGGER.log(Level.SEVERE, e.getMessage(), e);
-            return null;
-        } finally {
-            if (channel != null) try {
-                channel.close();
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-            if (stream != null) try {
-                stream.close();
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-        }
-    }
 
-    private byte[] convert(MappedByteBuffer din, int axisLength, int rowLen, int padding) throws IOException {
+    protected byte[] convert(ByteBuffer din, int axisLength, int rowLen, int padding, HgtCache.HgtFileInfo fileInfo) throws IOException {
         byte[] bytes;
 
         short[] ringbuffer = new short[rowLen];


### PR DESCRIPTION
Extended hillshading file reading to also support zipped .hgt, more specifically zips that follow the same tile naming convention as .hgt and contain an .hgt file with the appropriate name. All other .zips and all other contained files are ignored (e.g. no support for multiple tiles in one zip).

Rationale: distinguished tile librarian Sonny is offering downloads in the form of single-tile zips (which isn't very convenient when done manually) or a zip of single-tile zips. Manually unzipping the single tiles would be burdensome, waste disk space on uncompressed volumes. As an unintended side effect, in many cases (particularly on tiles that contain a lot of ocean) CPU for decryption might be faster than the extra I/O bandwidth required for an uncompressed read. If both versions exist, the one with the bigger resolution (internal file size) will win, first by filesystem iteration order on tie.