### PR TITLE
Use --release=7 for compiling the non-android  libraries on Java >= 9.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,5 +48,23 @@ subprojects {
         sourceCompatibility = JavaVersion.VERSION_1_7
         targetCompatibility = JavaVersion.VERSION_1_7
         options.encoding = 'UTF-8'
+        if (JavaVersion.current().isJava9Compatible()) {
+            // source and target 7 is insufficient with some seemingly compatible API extensions in ByteBuffer,
+            // causing builds that happen on a current SDK to be incompatible with actual old java (despite compiling fine)
+            // see https://github.com/gradle/gradle/issues/2510
+            if (project.properties.containsKey('android')) {
+                logger.debug("has android, skipping injection of --release=7 in {} -> {}", it.project.name, it.name)
+            } else {
+                def ver = '7'
+                if(project.name=='mapsforge-map-writer' || project.name=='mapsforge-poi-writer') {
+                    // guava JRE actually requires 1.8. Surely acceptable for the writers,
+                    // but it means that we can't compile with --release 7
+                    logger.lifecycle("guava in {} -> {} {}", it.project.name, it.name, project.dependencies)
+                    ver = '8'
+                }
+                logger.lifecycle("setting --release {} in {} -> {}", ver, it.project.name, it.name)
+                options.compilerArgs << '--release' << ver
+            }
+        }
     }
 }


### PR DESCRIPTION
 When compiled on JDK > 1.8 sourceCompatibility=1.7 and targetCompatibility=1.7 are insufficient for generating jars that will actually work on JRE 1.8 because of added return type narrowing overrides (e.g. ByteBuffer.clear()) that don't exist in the 1.8 library.

 Source level compatibility tricks exist and work (e.g. casting ByteBuffer to Buffer for calling .clear()), but they are confusing and risky because after removal of the cast both library and client will still compile but fail at runtime.

---

I discovered this issue while working on the hgt zip support: when the library is build on Java > 1.8, the resulting library jars will crash at runtime when run on JRE 1.8 (or 1.7)

Source level workarounds exist (see https://github.com/usrusr/mapsforge/commit/2654dc02406fadac3c5293b0b86e3c81e707576c ) but those are confusing and prone to get lost when someone touches the code because the libraries compile just fine without them. The gradle way seems much cleaner to me (tell JDK>1.8 to compile against the actual subset of the API that already existed in 1.7/1.8)

map-writer and poi-writer require 1.8 due to depending on a version of guava that only maintains 1.7 compatibility with android versions (recent guava have separate builds for android), but missing 1.7 compatibility of the writer modules is probably not really a goal