### PR TITLE
ZipXmlThemeResourceProvider: add method to just scan zip for xmlthemes

### DIFF
--- a/mapsforge-map/src/test/java/org/mapsforge/map/rendertheme/ZipXmlThemeResourceProviderTest.java
+++ b/mapsforge-map/src/test/java/org/mapsforge/map/rendertheme/ZipXmlThemeResourceProviderTest.java
@@ -83,4 +83,19 @@ public class ZipXmlThemeResourceProviderTest {
     public void openEmpty() throws IOException {
         Assert.assertTrue(new ZipXmlThemeResourceProvider(null).getXmlThemes().isEmpty());
     }
+
+    @Test
+    public void scanZipForXmlThemes() throws IOException {
+        ZipInputStream zis = new ZipInputStream(new BufferedInputStream(ZipXmlThemeResourceProviderTest.class.getResourceAsStream("/xmlthemetest.zip")));
+        Assert.assertNotNull(zis);
+
+        List<String> xmlThemes = ZipXmlThemeResourceProvider.getXmlThemesIn(zis);
+
+        Assert.assertEquals(4, xmlThemes.size());
+        Assert.assertTrue(xmlThemes.contains("one.xml"));
+        Assert.assertTrue(xmlThemes.contains("two.xml"));
+        Assert.assertTrue(xmlThemes.contains("res/three.xml"));
+        Assert.assertTrue(xmlThemes.contains("res/sub/four.xml"));
+    }
+
 }


### PR DESCRIPTION
We have the use case that when we have multiple Zip files in a directory, each containing XmlThemes, then we want to offer the user a selection for one of those XmlThemes. 

**Current situation:**
In order to get a complete list of all available XmlThemes we have to create an instance of `ZipXmlThemeResourceProvider ` for each Zip file, then to use the `getXmlThemes `method on them, then release this instance again.

However, this reads all of those zip files content into memory (including e.g. all image contents) and just throws this away afterwards. This takes long time and does not use memory well.

**Improvement:**
This PR adds a static method `ZipXmlThemeResourceProvider.getXmlThemesIn` which can be used to just scan a Zip file for contained XML Theme files without reading the whole Zip and contained resources into memory
