### PR TITLE
Bugfix in ContentResolverResourceProvider: honor also absolute file references in Theme (as eg used by Freizeitkarte)

### DIFF
--- a/mapsforge-map-android/src/main/java/org/mapsforge/map/android/rendertheme/ContentResolverResourceProvider.java
+++ b/mapsforge-map-android/src/main/java/org/mapsforge/map/android/rendertheme/ContentResolverResourceProvider.java
@@ -98,7 +98,9 @@ public class ContentResolverResourceProvider implements XmlThemeResourceProvider
             if (doc.isDirectory) {
                 buildCacheLevel(prefix + doc.name + "/", doc.uri);
             } else {
-                resourceUriCache.put(prefix + doc.name, doc.uri);
+                //store both relative Urls (e.g. used by OpenAndroMaps/Elevate-Theme) and absolute Urls (e.g. used by Freizeitkarte)
+                resourceUriCache.put(XmlUtils.PREFIX_FILE + prefix + doc.name, doc.uri);
+                resourceUriCache.put(XmlUtils.PREFIX_FILE + "/" + prefix + doc.name, doc.uri);
             }
         }
     }
@@ -172,6 +174,6 @@ public class ContentResolverResourceProvider implements XmlThemeResourceProvider
             // Convert "tree uri" to a "document uri"
             dirUri = DocumentsContract.buildDocumentUriUsingTree(dirUri, DocumentsContract.getTreeDocumentId(dirUri));
         }
-        buildCacheLevel(XmlUtils.PREFIX_FILE, dirUri);
+        buildCacheLevel("", dirUri);
     }
 }


### PR DESCRIPTION
This PR fixes a bug in ContentResolverResourceProvider. 

Today it only works for "relative" File References (as eg used by OpenAndroMaps/Elevate-Theme), Example: 
`src="file:patterns/fels.svg"`

This PR makes it work also for "absolute" File References (as eg used by Freizeitkarte), Example:
`src="file:/patterns/fels.svg"`

This was found in c:geo as a bug: https://github.com/cgeo/cgeo/issues/10295