### PR TITLE
ConsumableEvent for InputListener

### DIFF
--- a/mapsforge-map-android/src/main/java/org/mapsforge/map/android/input/MapZoomControls.java
+++ b/mapsforge-map-android/src/main/java/org/mapsforge/map/android/input/MapZoomControls.java
@@ -32,6 +32,7 @@ import android.widget.ZoomControls;
 import org.mapsforge.map.android.util.AndroidUtil;
 import org.mapsforge.map.android.view.MapView;
 import org.mapsforge.map.model.common.Observer;
+import org.mapsforge.map.util.ConsumableEvent;
 
 /**
  * A MapZoomControls instance displays buttons for zooming in and out in a map.
@@ -149,14 +150,14 @@ public class MapZoomControls extends LinearLayout implements Observer {
         buttonZoomIn.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View view) {
-                mapView.onZoomEvent();
+                mapView.onZoomEvent(new ConsumableEvent());
                 MapZoomControls.this.mapView.getModel().mapViewPosition.zoomIn();
             }
         });
         buttonZoomOut.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View view) {
-                mapView.onZoomEvent();
+                mapView.onZoomEvent(new ConsumableEvent());
                 MapZoomControls.this.mapView.getModel().mapViewPosition.zoomOut();
             }
         });

--- a/mapsforge-map-android/src/main/java/org/mapsforge/map/android/view/MapView.java
+++ b/mapsforge-map-android/src/main/java/org/mapsforge/map/android/view/MapView.java
@@ -47,6 +47,7 @@ import org.mapsforge.map.model.Model;
 import org.mapsforge.map.model.common.Observer;
 import org.mapsforge.map.scalebar.DefaultMapScaleBar;
 import org.mapsforge.map.scalebar.MapScaleBar;
+import org.mapsforge.map.util.ConsumableEvent;
 import org.mapsforge.map.util.MapPositionUtil;
 import org.mapsforge.map.util.MapViewProjection;
 import org.mapsforge.map.view.*;
@@ -424,9 +425,11 @@ public class MapView extends ViewGroup implements org.mapsforge.map.view.MapView
      * Note that this method may be called multiple times while the move has been started.
      * Also note that only manual moves get notified.
      */
-    public void onMoveEvent() {
+    public void onMoveEvent(ConsumableEvent e) {
         for (InputListener listener : inputListeners) {
-            listener.onMoveEvent();
+            listener.onMoveEvent(e);
+            if(e.isConsumed())
+                return;
         }
     }
 
@@ -459,9 +462,11 @@ public class MapView extends ViewGroup implements org.mapsforge.map.view.MapView
      * Note that this method may be called multiple times while the zoom has been started.
      * Also note that only manual zooms get notified.
      */
-    public void onZoomEvent() {
+    public void onZoomEvent(ConsumableEvent e) {
         for (InputListener listener : inputListeners) {
-            listener.onZoomEvent();
+            listener.onZoomEvent(e);
+            if(e.isConsumed())
+                return;
         }
     }
 

--- a/mapsforge-map-android/src/main/java/org/mapsforge/map/android/view/MapView.java
+++ b/mapsforge-map-android/src/main/java/org/mapsforge/map/android/view/MapView.java
@@ -515,6 +515,11 @@ public class MapView extends ViewGroup implements org.mapsforge.map.view.MapView
     }
 
     @Override
+    public byte getZoomLevel() {
+        return this.model.mapViewPosition.getZoomLevel();
+    }
+
+    @Override
     public void setZoomLevelMax(byte zoomLevelMax) {
         this.model.mapViewPosition.setZoomLevelMax(zoomLevelMax);
         this.mapZoomControls.setZoomLevelMax(zoomLevelMax);

--- a/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/input/MouseEventListener.java
+++ b/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/input/MouseEventListener.java
@@ -19,6 +19,7 @@ package org.mapsforge.map.awt.input;
 import org.mapsforge.core.model.LatLong;
 import org.mapsforge.map.awt.view.MapView;
 import org.mapsforge.map.layer.Layer;
+import org.mapsforge.map.util.ConsumableEvent;
 
 import java.awt.Point;
 import java.awt.event.MouseAdapter;
@@ -55,10 +56,16 @@ public class MouseEventListener extends MouseAdapter {
 
     @Override
     public void mouseDragged(MouseEvent e) {
+        ConsumableEvent mEvent = new ConsumableEvent(e);
+        this.mapView.onMoveEvent(mEvent);
+        if(mEvent.isConsumed()) {
+            e.consume();
+            this.lastDragPoint = null;
+            return;
+        }
         if (SwingUtilities.isLeftMouseButton(e)) {
             Point point = e.getPoint();
             if (this.lastDragPoint != null) {
-                this.mapView.onMoveEvent();
                 int moveHorizontal = point.x - this.lastDragPoint.x;
                 int moveVertical = point.y - this.lastDragPoint.y;
                 this.mapView.getModel().mapViewPosition.moveCenter(moveHorizontal, moveVertical);
@@ -81,7 +88,12 @@ public class MouseEventListener extends MouseAdapter {
 
     @Override
     public void mouseWheelMoved(MouseWheelEvent e) {
-        this.mapView.onZoomEvent();
+        ConsumableEvent mEvent = new ConsumableEvent(e);
+        this.mapView.onZoomEvent(mEvent);
+        if(mEvent.isConsumed()) {
+            e.consume();
+            return;
+        }
         byte zoomLevelDiff = (byte) -e.getWheelRotation();
         this.mapView.getModel().mapViewPosition.zoom(zoomLevelDiff);
     }

--- a/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/view/MapView.java
+++ b/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/view/MapView.java
@@ -38,6 +38,7 @@ import org.mapsforge.map.layer.renderer.TileRendererLayer;
 import org.mapsforge.map.model.Model;
 import org.mapsforge.map.scalebar.DefaultMapScaleBar;
 import org.mapsforge.map.scalebar.MapScaleBar;
+import org.mapsforge.map.util.ConsumableEvent;
 import org.mapsforge.map.util.MapPositionUtil;
 import org.mapsforge.map.util.MapViewProjection;
 import org.mapsforge.map.view.*;
@@ -194,10 +195,13 @@ public class MapView extends Container implements org.mapsforge.map.view.MapView
      * notify registered {@link InputListener} about the start of a manual move.
      * Note that this method may be called multiple times while the move has been started.
      * Also note that only manual moves get notified.
+     * @param e is the consumable mouse event
      */
-    public void onMoveEvent() {
+    public void onMoveEvent(ConsumableEvent e) {
         for (InputListener listener : inputListeners) {
-            listener.onMoveEvent();
+            listener.onMoveEvent(e);
+            if(e.isConsumed())
+                return;
         }
     }
 
@@ -206,10 +210,13 @@ public class MapView extends Container implements org.mapsforge.map.view.MapView
      * notify registered {@link InputListener} about the start of a manual zoom.
      * Note that this method may be called multiple times while the zoom has been started.
      * Also note that only manual zooms get notified.
+     * @param e is the consumable mouse event
      */
-    public void onZoomEvent() {
+    public void onZoomEvent(ConsumableEvent e) {
         for (InputListener listener : inputListeners) {
-            listener.onZoomEvent();
+            listener.onZoomEvent(e);
+            if(e.isConsumed())
+                return;
         }
     }
 

--- a/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/view/MapView.java
+++ b/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/view/MapView.java
@@ -253,6 +253,11 @@ public class MapView extends Container implements org.mapsforge.map.view.MapView
     }
 
     @Override
+    public byte getZoomLevel() {
+        return this.model.mapViewPosition.getZoomLevel();
+    }
+
+    @Override
     public void setZoomLevelMax(byte zoomLevelMax) {
         this.model.mapViewPosition.setZoomLevelMax(zoomLevelMax);
     }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/overlay/Circle.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/overlay/Circle.java
@@ -18,12 +18,14 @@ package org.mapsforge.map.layer.overlay;
 
 import org.mapsforge.core.graphics.Canvas;
 import org.mapsforge.core.graphics.Paint;
+import org.mapsforge.core.graphics.Style;
 import org.mapsforge.core.model.BoundingBox;
 import org.mapsforge.core.model.LatLong;
 import org.mapsforge.core.model.Point;
 import org.mapsforge.core.model.Rectangle;
 import org.mapsforge.core.util.MercatorProjection;
 import org.mapsforge.map.layer.Layer;
+import org.mapsforge.map.view.MapView;
 
 /**
  * A {@code Circle} consists of a center {@link LatLong} and a non-negative radius in meters.
@@ -67,6 +69,10 @@ public class Circle extends Layer {
         setRadiusInternal(radius);
         this.paintFill = paintFill;
         this.paintStroke = paintStroke;
+
+        // Set stroke as stroke.
+        if(paintStroke != null)
+            paintStroke.setStyle(Style.STROKE);
     }
 
     public synchronized boolean contains(Point center, Point point, double latitude, byte zoomLevel) {
@@ -74,6 +80,10 @@ public class Circle extends Layer {
         double distance = Math.max(20 / 2 * this.displayModel.getScaleFactor(),
                 getRadiusInPixels(latitude, zoomLevel));
         return center.distance(point) < distance;
+    }
+
+    public boolean contains(MapView mapView, Point point) {
+        return contains(mapView.getMapViewProjection().toPixels(latLong),point,radius,mapView.getZoomLevel());
     }
 
     @Override

--- a/mapsforge-map/src/main/java/org/mapsforge/map/util/ConsumableEvent.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/util/ConsumableEvent.java
@@ -1,0 +1,32 @@
+package org.mapsforge.map.util;
+
+public class ConsumableEvent {
+    private boolean consumed = false;
+
+    /**
+     * For Desktop can be MouseEvent or MouseWheelEvent
+     * <br>
+     * For Android can be MotionEvent or List of MotionEvents
+     * */
+    private final Object event;
+
+    public ConsumableEvent() {
+        this(null);
+    }
+
+    public ConsumableEvent(Object event) {
+        this.event = event;
+    }
+
+    public Object getEvent() {
+        return event;
+    }
+
+    public boolean isConsumed() {
+        return consumed;
+    }
+
+    public void consume() {
+        consumed = true;
+    }
+}

--- a/mapsforge-map/src/main/java/org/mapsforge/map/view/InputListener.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/view/InputListener.java
@@ -14,6 +14,8 @@
  */
 package org.mapsforge.map.view;
 
+import org.mapsforge.map.util.ConsumableEvent;
+
 /**
  * This listener can be used to get informed about manual changes of position or zoom.
  * It will not inform about automatic (software-driven) changes.
@@ -26,13 +28,15 @@ public interface InputListener {
      * A manual movement has been started. The user drags the map over the screen.
      * This method is called before any movement takes place.
      * There is no guarantee that this method is called just once per user intervention.
+     * @param e is the consumable mouse event
      */
-    void onMoveEvent();
+    void onMoveEvent(ConsumableEvent e);
 
     /**
      * A manual zoom has been started. The user uses pinch-to-zoom, uses its mouse wheel
      * or the ZoomControls. This method is called before any zoom takes place.
      * There is no guarantee that this method is called just once per user intervention.
+     * @param e is the consumable mouse event
      */
-    void onZoomEvent();
+    void onZoomEvent(ConsumableEvent e);
 }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/view/MapView.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/view/MapView.java
@@ -73,6 +73,8 @@ public interface MapView {
 
     void setZoomLevel(byte zoomLevel);
 
+    byte getZoomLevel();
+
     void setZoomLevelMax(byte zoomLevelMax);
 
     void setZoomLevelMin(byte zoomLevelMin);

--- a/mapsforge-map/src/test/java/org/mapsforge/map/controller/DummyMapView.java
+++ b/mapsforge-map/src/test/java/org/mapsforge/map/controller/DummyMapView.java
@@ -124,4 +124,8 @@ public class DummyMapView implements MapView {
     public void setZoomLevelMin(byte zoomLevelMin) {
         // no-op
     }
+    @Override
+    public byte getZoomLevel() {
+        return 0;
+    }
 }


### PR DESCRIPTION
Added alternative way to check Circle.contains: "Circle.contains(MapView, Point)".
Implemented Consumable Event for onMove and onZoom events.

I needed these functions while working with 'java.awt', figured people also may need them.