### PR TITLE
Fixes svg cache hashing algo when working with resource providers

### DIFF
--- a/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/XmlUtils.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/XmlUtils.java
@@ -62,7 +62,7 @@ public final class XmlUtils {
             // we also need to include the resourceProvider as different providers may give different input streams for same source
             StringBuilder sb = new StringBuilder().append(absoluteName).append(width).append(height).append(percent);
             if (resourceProvider != null)
-                sb.append(resourceProvider.hashCode());
+                sb.append(resourceProvider.getClass().getName());
             int hash = sb.toString().hashCode();
             if (src.toLowerCase(Locale.ENGLISH).endsWith(".svg")) {
                 try {


### PR DESCRIPTION
Fixes svg cache hashing algo when working with resource providers

We discovered a problem in c:geo with the caching of svg images from XML render themes when using resource providers. Reason is that the hash calculated for the cache file relies on hashCode of the resource provider, but the resource providers don't implement this. Thus the hashCode is different on each app startup and hash value is different too on each startup -> rendering the caching useless across app restarts.

A detailled description of the resulting problem can be found here: https://github.com/cgeo/cgeo/issues/12145 

This PR will change this by using resource provider class name instead of hashCode().

@devemux86 : it seems I introduced this bug myself back when I created the resource provider things. Sorry for that.