### PR TITLE
POI - Deal properly with equal sign in tag values

### DIFF
--- a/mapsforge-poi-writer/src/main/java/org/mapsforge/poi/writer/PoiWriter.java
+++ b/mapsforge-poi-writer/src/main/java/org/mapsforge/poi/writer/PoiWriter.java
@@ -576,11 +576,11 @@ public final class PoiWriter {
     Map<String, String> stringToTags(String tagsmapstring) {
         String[] sb = tagsmapstring.split("\\r");
         Map<String, String> map = new HashMap<>();
-        for (String key : sb) {
-            if (key.contains("=")) {
-                String[] set = key.split("=");
-                if (set.length == 2)
-                    map.put(set[0], set[1]);
+        for (String set : sb){
+            if (set.contains("=")){
+                String key = set.split("=")[0];
+                String value = set.substring(key.length() + 1);
+                map.put(key, value);
             }
         }
         return map;

--- a/mapsforge-poi/src/main/java/org/mapsforge/poi/storage/AbstractPoiPersistenceManager.java
+++ b/mapsforge-poi/src/main/java/org/mapsforge/poi/storage/AbstractPoiPersistenceManager.java
@@ -126,10 +126,9 @@ public abstract class AbstractPoiPersistenceManager implements PoiPersistenceMan
         String[] split = data.split("\r");
         for (String s : split) {
             if (s.indexOf(Tag.KEY_VALUE_SEPARATOR) > -1) {
-                String[] keyValue = s.split(String.valueOf(Tag.KEY_VALUE_SEPARATOR));
-                if (keyValue.length == 2) {
-                    tags.add(new Tag(keyValue[0], keyValue[1]));
-                }
+                String key = s.split(String.valueOf(Tag.KEY_VALUE_SEPARATOR))[0];
+                String value = s.substring(key.length() + String.valueOf(Tag.KEY_VALUE_SEPARATOR).length());
+                tags.add(new Tag(key, value));
             }
         }
         return tags;


### PR DESCRIPTION
stringToTags method was silently ignoring tags whose value contains equal signs.

However, such values are legit in OSM. They may appear ie in urls containing query strings.

This PR fix that behaviour.

Discussion: https://github.com/mapsforge/mapsforge/discussions/1279