### PR TITLE
#1355 use "tile.openstreetmap.org" as tile server as requested by OSM project

### DIFF
--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/download/tilesource/OpenStreetMapMapnik.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/download/tilesource/OpenStreetMapMapnik.java
@@ -33,8 +33,7 @@ import java.net.URL;
  * Requires a valid HTTP User-Agent identifying application: https://operations.osmfoundation.org/policies/tiles/
  */
 public class OpenStreetMapMapnik extends AbstractTileSource {
-    public static final OpenStreetMapMapnik INSTANCE = new OpenStreetMapMapnik(new String[]{
-            "a.tile.openstreetmap.org", "b.tile.openstreetmap.org", "c.tile.openstreetmap.org"}, 443);
+    public static final OpenStreetMapMapnik INSTANCE = new OpenStreetMapMapnik(new String[]{"tile.openstreetmap.org"}, 443);
     private static final int PARALLEL_REQUESTS_LIMIT = 8;
     private static final String PROTOCOL = "https";
     private static final int ZOOM_LEVEL_MAX = 18;

--- a/mapsforge-samples-android/src/main/java/org/mapsforge/samples/android/DownloadCustomLayerViewer.java
+++ b/mapsforge-samples-android/src/main/java/org/mapsforge/samples/android/DownloadCustomLayerViewer.java
@@ -24,9 +24,7 @@ import org.mapsforge.map.layer.download.tilesource.OnlineTileSource;
 public class DownloadCustomLayerViewer extends DownloadLayerViewer {
     @Override
     protected void createLayers() {
-        OnlineTileSource onlineTileSource = new OnlineTileSource(new String[]{
-                "a.tile.openstreetmap.fr", "b.tile.openstreetmap.fr", "c.tile.openstreetmap.fr"},
-                443);
+        OnlineTileSource onlineTileSource = new OnlineTileSource(new String[]{"tile.openstreetmap.fr"}, 443);
         onlineTileSource.setName("Humanitarian").setAlpha(false)
                 .setBaseUrl("/hot/")
                 .setParallelRequestsLimit(8).setProtocol("https").setTileSize(256)


### PR DESCRIPTION
OSM requests that apps stop using the tileservers "a/b/c.tile.openstreetmap.org" and instead use "tile.openstreetmap.org" only
https://github.com/openstreetmap/operations/issues/737 

fixes #1355