### PR TITLE
Fix of problem with incorrect handling of nested tags

### DIFF
--- a/mapsforge-map-awt/src/test/java/org/mapsforge/map/rendertheme/rule/KeyMatcherTest.java
+++ b/mapsforge-map-awt/src/test/java/org/mapsforge/map/rendertheme/rule/KeyMatcherTest.java
@@ -42,7 +42,7 @@ public class KeyMatcherTest {
         Tag tag2 = new Tag(KEY2, null);
         AttributeMatcher attributeMatcher = new KeyMatcher(Arrays.asList(KEY1));
 
-        Assert.assertTrue(attributeMatcher.matches(Arrays.asList(tag1)));
-        Assert.assertFalse(attributeMatcher.matches(Arrays.asList(tag2)));
+        Assert.assertTrue(attributeMatcher.matches(tag1));
+        Assert.assertFalse(attributeMatcher.matches(tag2));
     }
 }

--- a/mapsforge-map-awt/src/test/java/org/mapsforge/map/rendertheme/rule/ValueMatcherTest.java
+++ b/mapsforge-map-awt/src/test/java/org/mapsforge/map/rendertheme/rule/ValueMatcherTest.java
@@ -42,7 +42,7 @@ public class ValueMatcherTest {
         Tag tag2 = new Tag(null, VALUE2);
         AttributeMatcher attributeMatcher = new ValueMatcher(Arrays.asList(VALUE1));
 
-        Assert.assertTrue(attributeMatcher.matches(Arrays.asList(tag1)));
-        Assert.assertFalse(attributeMatcher.matches(Arrays.asList(tag2)));
+        Assert.assertTrue(attributeMatcher.matches(tag1));
+        Assert.assertFalse(attributeMatcher.matches(tag2));
     }
 }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/rule/AnyMatcher.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/rule/AnyMatcher.java
@@ -16,9 +16,8 @@ package org.mapsforge.map.rendertheme.rule;
 
 import org.mapsforge.core.model.Tag;
 
-import java.util.List;
-
 final class AnyMatcher implements ElementMatcher, AttributeMatcher, ClosedMatcher {
+
     static final AnyMatcher INSTANCE = new AnyMatcher();
 
     private AnyMatcher() {
@@ -51,7 +50,7 @@ final class AnyMatcher implements ElementMatcher, AttributeMatcher, ClosedMatche
     }
 
     @Override
-    public boolean matches(List<Tag> tags) {
+    public boolean matches(Tag tag) {
         return true;
     }
 }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/rule/AttributeMatcher.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/rule/AttributeMatcher.java
@@ -16,10 +16,9 @@ package org.mapsforge.map.rendertheme.rule;
 
 import org.mapsforge.core.model.Tag;
 
-import java.util.List;
-
 interface AttributeMatcher {
+
     boolean isCoveredBy(AttributeMatcher attributeMatcher);
 
-    boolean matches(List<Tag> tags);
+    boolean matches(Tag tag);
 }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/rule/KeyMatcher.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/rule/KeyMatcher.java
@@ -16,10 +16,10 @@ package org.mapsforge.map.rendertheme.rule;
 
 import org.mapsforge.core.model.Tag;
 
-import java.util.ArrayList;
 import java.util.List;
 
 class KeyMatcher implements AttributeMatcher {
+
     private final List<String> keys;
 
     KeyMatcher(List<String> keys) {
@@ -32,20 +32,16 @@ class KeyMatcher implements AttributeMatcher {
             return true;
         }
 
-        List<Tag> tags = new ArrayList<Tag>(this.keys.size());
         for (int i = 0, n = this.keys.size(); i < n; ++i) {
-            tags.add(new Tag(this.keys.get(i), null));
-        }
-        return attributeMatcher.matches(tags);
-    }
-
-    @Override
-    public boolean matches(List<Tag> tags) {
-        for (int i = 0, n = tags.size(); i < n; ++i) {
-            if (this.keys.contains(tags.get(i).key)) {
+            if (attributeMatcher.matches(new Tag(this.keys.get(i), null))) {
                 return true;
             }
         }
         return false;
+    }
+
+    @Override
+    public boolean matches(Tag tag) {
+        return this.keys.contains(tag.key);
     }
 }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/rule/NegativeMatcher.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/rule/NegativeMatcher.java
@@ -19,6 +19,7 @@ import org.mapsforge.core.model.Tag;
 import java.util.List;
 
 class NegativeMatcher implements AttributeMatcher {
+
     private final List<String> keyList;
     private final List<String> valueList;
 
@@ -33,20 +34,11 @@ class NegativeMatcher implements AttributeMatcher {
     }
 
     @Override
-    public boolean matches(List<Tag> tags) {
-        if (keyListDoesNotContainKeys(tags)) {
-            return true;
-        }
-
-        for (int i = 0, n = tags.size(); i < n; ++i) {
-            if (this.valueList.contains(tags.get(i).value)) {
-                return true;
-            }
-        }
-        return false;
+    public boolean matches(Tag tag) {
+        return this.valueList.contains(tag.value);
     }
 
-    private boolean keyListDoesNotContainKeys(List<Tag> tags) {
+    boolean keyListDoesNotContainKeys(List<Tag> tags) {
         for (int i = 0, n = tags.size(); i < n; ++i) {
             if (this.keyList.contains(tags.get(i).key)) {
                 return false;

--- a/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/rule/NegativeRule.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/rule/NegativeRule.java
@@ -16,12 +16,14 @@ package org.mapsforge.map.rendertheme.rule;
 
 import org.mapsforge.core.model.Tag;
 
+import java.util.ArrayList;
 import java.util.List;
 
 class NegativeRule extends Rule {
-    private final AttributeMatcher attributeMatcher;
 
-    NegativeRule(RuleBuilder ruleBuilder, AttributeMatcher attributeMatcher) {
+    private final NegativeMatcher attributeMatcher;
+
+    NegativeRule(RuleBuilder ruleBuilder, NegativeMatcher attributeMatcher) {
         super(ruleBuilder);
 
         this.attributeMatcher = attributeMatcher;
@@ -29,13 +31,32 @@ class NegativeRule extends Rule {
 
     @Override
     boolean matchesNode(List<Tag> tags, byte zoomLevel) {
-        return this.zoomMin <= zoomLevel && this.zoomMax >= zoomLevel && this.elementMatcher.matches(Element.NODE)
-                && this.attributeMatcher.matches(tags);
+        return this.zoomMin <= zoomLevel
+                && this.zoomMax >= zoomLevel
+                && this.elementMatcher.matches(Element.NODE)
+                && matchesTags(tags);
     }
 
     @Override
     boolean matchesWay(List<Tag> tags, byte zoomLevel, Closed closed) {
-        return this.zoomMin <= zoomLevel && this.zoomMax >= zoomLevel && this.elementMatcher.matches(Element.WAY)
-                && this.closedMatcher.matches(closed) && this.attributeMatcher.matches(tags);
+        return this.zoomMin <= zoomLevel
+                && this.zoomMax >= zoomLevel
+                && this.elementMatcher.matches(Element.WAY)
+                && this.closedMatcher.matches(closed)
+                && matchesTags(tags);
+    }
+
+    private boolean matchesTags(List<Tag> tags) {
+        if (attributeMatcher.keyListDoesNotContainKeys(tags)) {
+            return true;
+        }
+
+        // check tags
+        for (Tag tag : tags) {
+            if (attributeMatcher.matches(tag)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/rule/PositiveRule.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/rule/PositiveRule.java
@@ -19,6 +19,7 @@ import org.mapsforge.core.model.Tag;
 import java.util.List;
 
 class PositiveRule extends Rule {
+
     final AttributeMatcher keyMatcher;
     final AttributeMatcher valueMatcher;
 
@@ -31,14 +32,27 @@ class PositiveRule extends Rule {
 
     @Override
     boolean matchesNode(List<Tag> tags, byte zoomLevel) {
-        return this.zoomMin <= zoomLevel && this.zoomMax >= zoomLevel && this.elementMatcher.matches(Element.NODE)
-                && this.keyMatcher.matches(tags) && this.valueMatcher.matches(tags);
+        return this.zoomMin <= zoomLevel
+                && this.zoomMax >= zoomLevel
+                && this.elementMatcher.matches(Element.NODE)
+                && matchesAnyTag(tags);
     }
 
     @Override
     boolean matchesWay(List<Tag> tags, byte zoomLevel, Closed closed) {
-        return this.zoomMin <= zoomLevel && this.zoomMax >= zoomLevel && this.elementMatcher.matches(Element.WAY)
-                && this.closedMatcher.matches(closed) && this.keyMatcher.matches(tags)
-                && this.valueMatcher.matches(tags);
+        return this.zoomMin <= zoomLevel
+                && this.zoomMax >= zoomLevel
+                && this.elementMatcher.matches(Element.WAY)
+                && this.closedMatcher.matches(closed)
+                && matchesAnyTag(tags);
+    }
+
+    private boolean matchesAnyTag(List<Tag> tags) {
+        for (Tag tag : tags) {
+            if (keyMatcher.matches(tag) && valueMatcher.matches(tag)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/rule/RuleBuilder.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/rule/RuleBuilder.java
@@ -120,15 +120,15 @@ public class RuleBuilder {
      */
     public Rule build() {
         if (this.valueList.remove(STRING_NEGATION)) {
-            AttributeMatcher attributeMatcher = new NegativeMatcher(this.keyList, this.valueList);
+            NegativeMatcher attributeMatcher = new NegativeMatcher(this.keyList, this.valueList);
             return new NegativeRule(this, attributeMatcher);
         }
 
         AttributeMatcher keyMatcher = getKeyMatcher(this.keyList);
         AttributeMatcher valueMatcher = getValueMatcher(this.valueList);
 
-        keyMatcher = RuleOptimizer.optimize(keyMatcher, this.ruleStack);
-        valueMatcher = RuleOptimizer.optimize(valueMatcher, this.ruleStack);
+//        keyMatcher = RuleOptimizer.optimize(keyMatcher, this.ruleStack);
+//        valueMatcher = RuleOptimizer.optimize(valueMatcher, this.ruleStack);
 
         return new PositiveRule(this, keyMatcher, valueMatcher);
     }
@@ -165,8 +165,8 @@ public class RuleBuilder {
         this.elementMatcher = getElementMatcher(this.element);
         this.closedMatcher = getClosedMatcher(this.closed);
 
-        this.elementMatcher = RuleOptimizer.optimize(this.elementMatcher, this.ruleStack);
-        this.closedMatcher = RuleOptimizer.optimize(this.closedMatcher, this.ruleStack);
+//        this.elementMatcher = RuleOptimizer.optimize(this.elementMatcher, this.ruleStack);
+//        this.closedMatcher = RuleOptimizer.optimize(this.closedMatcher, this.ruleStack);
     }
 
     private void validate(String elementName) throws XmlPullParserException {

--- a/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/rule/ValueMatcher.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/rule/ValueMatcher.java
@@ -16,10 +16,10 @@ package org.mapsforge.map.rendertheme.rule;
 
 import org.mapsforge.core.model.Tag;
 
-import java.util.ArrayList;
 import java.util.List;
 
 class ValueMatcher implements AttributeMatcher {
+
     private final List<String> values;
 
     ValueMatcher(List<String> values) {
@@ -32,20 +32,16 @@ class ValueMatcher implements AttributeMatcher {
             return true;
         }
 
-        List<Tag> tags = new ArrayList<Tag>(this.values.size());
         for (int i = 0, n = this.values.size(); i < n; ++i) {
-            tags.add(new Tag(null, this.values.get(i)));
-        }
-        return attributeMatcher.matches(tags);
-    }
-
-    @Override
-    public boolean matches(List<Tag> tags) {
-        for (int i = 0, n = tags.size(); i < n; ++i) {
-            if (this.values.contains(tags.get(i).value)) {
+            if (attributeMatcher.matches(new Tag(null, this.values.get(i)))) {
                 return true;
             }
         }
         return false;
+    }
+
+    @Override
+    public boolean matches(Tag tag) {
+        return values.contains(tag.value);
     }
 }


### PR DESCRIPTION
## Specification of the problem

Imagine following line
```
<?xml version='1.0' encoding='UTF-8'?>
<osm version='0.6' generator='JOSM'>
  <node id='-101755' action='modify' timestamp='2022-06-28T11:25:07Z' visible='true' version='1' lat='50.01334453162' lon='15.75031220376' />
  <node id='-101756' action='modify' timestamp='2022-06-28T11:25:07Z' visible='true' version='1' lat='50.01342037049' lon='15.7506501621' />
  <node id='-101757' action='modify' timestamp='2022-06-28T11:25:07Z' visible='true' version='1' lat='50.01357549509' lon='15.75128316343' />
  <node id='-101761' action='modify' timestamp='2022-06-28T11:25:07Z' visible='true' version='1' lat='50.01385816529' lon='15.75433015287' />
  <node id='-101762' action='modify' timestamp='2022-06-28T11:25:07Z' visible='true' version='1' lat='50.0148957575' lon='15.75657247961' />
  <way id='-101802' action='modify' timestamp='2022-06-28T11:25:07Z' visible='true' version='1'>
    <nd ref='-101755' />
    <nd ref='-101756' />
    <nd ref='-101757' />
    <nd ref='-101761' />
    <nd ref='-101762' />
    <tag k='network' v='lwn' />
    <tag k='osm' v='yes' />
    <tag k='osmc_background' v='white' />
    <tag k='osmc_color' v='green' />
    <tag k='osmc_foreground' v='green_backslash' />
    <tag k='route' v='hiking' />
    <tag k='type' v='route' />
  </way>
</osm>
```

and a simple map theme
```
<?xml version="1.0" encoding="utf-8"?>
<rendertheme map-background="#ebeade" version="4" xmlns="http://mapsforge.org/renderTheme" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://mapsforge.org/renderTheme https://raw.githubusercontent.com/mapsforge/mapsforge/dev/resources/renderTheme.xsd">

	<rule e="any" k="*" v="*">
		<rule e="way" k="osmc_color" v="*" zoom-max="18" zoom-min="15">
			<rule e="way" k="osmc_color" v="green">
				<line dy="-0.9" stroke="#267f00" stroke-linecap="butt" stroke-width="0.6"/>				
			</rule>
			<rule e="way" k="osmc_color" v="white">
				<line dy="0.9" stroke="#EA3200" stroke-dasharray="8,6" stroke-linecap="butt" stroke-width="0.6"/>
			</rule>		
		</rule>
	</rule>
		
</rendertheme>
```

The result is following (incorrect)
![image](https://user-images.githubusercontent.com/1257075/203856174-65bc3232-afa7-477b-8653-60491e61301f.png)

### The reasons are two:

1. `PositiveRule` matches the` keys` and `values` of every tag separately (other rules as well of course)! Because the line contains `osmc_background = white` and `osmc_color = green`, this cases that both rules are applied. But there is no `osmc_color = white`!
2. Even after fixing problem 1, there remains an issue caused by the optimization. Optimization change third rule key from `osmc_color` to `AnyMatcher`and ... 

## Solution
The solution to this problem is in this PR.

1. All matches are made per `Tag` and not by all tags at once
2. Completely disabled optimization in the `RuleBuilder` class

The result is (correct)
![image](https://user-images.githubusercontent.com/1257075/203857562-a939676b-990e-4cb5-930f-b9142398e607.png)

## Benchmark
I use my own simple benchmark for testing of the tile rendering system.
Setup: OpenAndroMap, Elements theme, zoom level 12, 3000 tiles

Old solution: 106ms per tile
New solution: 105ms per tile

The test is simple and not perfectly precise, but at least it shows that removing of the optimization does not have a negative effect.