### PR TITLE
Option to transform text before rendering

### DIFF
--- a/mapsforge-core/src/main/java/org/mapsforge/core/graphics/TextTransform.java
+++ b/mapsforge-core/src/main/java/org/mapsforge/core/graphics/TextTransform.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2010, 2011, 2012, 2013 mapsforge.org
+ *
+ * This program is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.mapsforge.core.graphics;
+
+public enum TextTransform {
+
+    NONE,
+    UPPERCASE,
+    LOWERCASE,
+    CAPITALIZE;
+
+    public static TextTransform fromString(String value) {
+        if ("uppercase".equals(value)) {
+            return UPPERCASE;
+        } else if ("lowercase".equals(value)) {
+            return LOWERCASE;
+        } else if ("capitalize".equals(value)) {
+            return CAPITALIZE;
+        } else {
+            return NONE;
+        }
+    }
+}

--- a/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/Caption.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/Caption.java
@@ -55,6 +55,7 @@ public class Caption extends RenderInstruction {
     private final Map<Byte, Paint> strokes;
     private String symbolId;
     private TextKey textKey;
+    private TextTransform textTransform;
 
     public Caption(GraphicFactory graphicFactory, DisplayModel displayModel, String elementName,
                    XmlPullParser pullParser, Map<String, Symbol> symbols) throws XmlPullParserException {
@@ -70,10 +71,10 @@ public class Caption extends RenderInstruction {
         this.strokes = new HashMap<>();
         this.dyScaled = new HashMap<>();
 
-
         this.display = Display.IFSPACE;
 
         this.gap = DEFAULT_GAP * displayModel.getScaleFactor();
+        this.textTransform = TextTransform.CAPITALIZE;
 
         extractValues(graphicFactory, displayModel, elementName, pullParser);
 
@@ -115,9 +116,7 @@ public class Caption extends RenderInstruction {
                 throw new IllegalArgumentException("Position invalid");
         }
 
-
         this.maxTextWidth = displayModel.getMaxTextWidth();
-
     }
 
     private float computeHorizontalOffset() {
@@ -184,6 +183,8 @@ public class Caption extends RenderInstruction {
                 this.stroke.setStrokeWidth(XmlUtils.parseNonNegativeFloat(name, value) * displayModel.getScaleFactor());
             } else if (SYMBOL_ID.equals(name)) {
                 this.symbolId = value;
+            } else if (TEXT_TRANSFORM.equals(name)) {
+                this.textTransform = TextTransform.fromString(value);
             } else {
                 throw XmlUtils.createXmlPullParserException(elementName, name, value, i);
             }
@@ -234,7 +235,8 @@ public class Caption extends RenderInstruction {
             verticalOffset = computeVerticalOffset(renderContext.rendererJob.tile.zoomLevel);
         }
 
-        renderCallback.renderPointOfInterestCaption(renderContext, this.display, this.priority, caption, horizontalOffset, verticalOffset,
+        renderCallback.renderPointOfInterestCaption(renderContext, this.display, this.priority,
+                transformText(caption, textTransform), horizontalOffset, verticalOffset,
                 getFillPaint(renderContext.rendererJob.tile.zoomLevel), getStrokePaint(renderContext.rendererJob.tile.zoomLevel), this.position, this.maxTextWidth, poi);
     }
 
@@ -260,7 +262,8 @@ public class Caption extends RenderInstruction {
             verticalOffset = computeVerticalOffset(renderContext.rendererJob.tile.zoomLevel);
         }
 
-        renderCallback.renderAreaCaption(renderContext, this.display, this.priority, caption, horizontalOffset, verticalOffset,
+        renderCallback.renderAreaCaption(renderContext, this.display, this.priority,
+                transformText(caption, textTransform), horizontalOffset, verticalOffset,
                 getFillPaint(renderContext.rendererJob.tile.zoomLevel), getStrokePaint(renderContext.rendererJob.tile.zoomLevel), this.position, this.maxTextWidth, way);
     }
 

--- a/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/Caption.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/Caption.java
@@ -74,7 +74,7 @@ public class Caption extends RenderInstruction {
         this.display = Display.IFSPACE;
 
         this.gap = DEFAULT_GAP * displayModel.getScaleFactor();
-        this.textTransform = TextTransform.CAPITALIZE;
+        this.textTransform = TextTransform.NONE;
 
         extractValues(graphicFactory, displayModel, elementName, pullParser);
 

--- a/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/PathText.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/PathText.java
@@ -71,7 +71,7 @@ public class PathText extends RenderInstruction {
         this.strokes = new HashMap<>();
         this.dyScaled = new HashMap<>();
         this.display = Display.IFSPACE;
-        this.textTransform = TextTransform.CAPITALIZE;
+        this.textTransform = TextTransform.NONE;
 
         extractValues(graphicFactory, displayModel, elementName, pullParser);
     }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/PathText.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/PathText.java
@@ -51,6 +51,7 @@ public class PathText extends RenderInstruction {
     private float repeatStart;
     private boolean rotate;
     private TextKey textKey;
+    private TextTransform textTransform;
 
     public PathText(GraphicFactory graphicFactory, DisplayModel displayModel, String elementName,
                     XmlPullParser pullParser) throws XmlPullParserException {
@@ -70,6 +71,7 @@ public class PathText extends RenderInstruction {
         this.strokes = new HashMap<>();
         this.dyScaled = new HashMap<>();
         this.display = Display.IFSPACE;
+        this.textTransform = TextTransform.CAPITALIZE;
 
         extractValues(graphicFactory, displayModel, elementName, pullParser);
     }
@@ -123,6 +125,8 @@ public class PathText extends RenderInstruction {
                 this.stroke.setColor(XmlUtils.getColor(graphicFactory, value, displayModel.getThemeCallback(), this));
             } else if (STROKE_WIDTH.equals(name)) {
                 this.stroke.setStrokeWidth(XmlUtils.parseNonNegativeFloat(name, value) * displayModel.getScaleFactor());
+            } else if (TEXT_TRANSFORM.equals(name)) {
+                this.textTransform = TextTransform.fromString(value);
             } else {
                 throw XmlUtils.createXmlPullParserException(elementName, name, value, i);
             }
@@ -171,7 +175,8 @@ public class PathText extends RenderInstruction {
             dyScale = this.dy;
         }
 
-        renderCallback.renderWayText(renderContext, this.display, this.priority, caption, dyScale,
+        renderCallback.renderWayText(renderContext, this.display, this.priority,
+                transformText(caption, textTransform), dyScale,
                 getFillPaint(renderContext.rendererJob.tile.zoomLevel),
                 getStrokePaint(renderContext.rendererJob.tile.zoomLevel),
                 this.repeat, this.repeatGap, this.repeatStart, this.rotate,

--- a/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/RenderInstruction.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/RenderInstruction.java
@@ -20,6 +20,7 @@ package org.mapsforge.map.rendertheme.renderinstruction;
 import org.mapsforge.core.graphics.Bitmap;
 import org.mapsforge.core.graphics.GraphicFactory;
 import org.mapsforge.core.graphics.Position;
+import org.mapsforge.core.graphics.TextTransform;
 import org.mapsforge.core.model.Rectangle;
 import org.mapsforge.core.util.Parameters;
 import org.mapsforge.map.datastore.PointOfInterest;
@@ -70,6 +71,7 @@ public abstract class RenderInstruction {
     static final String SYMBOL_PERCENT = "symbol-percent";
     static final String SYMBOL_SCALING = "symbol-scaling";
     static final String SYMBOL_WIDTH = "symbol-width";
+    static final String TEXT_TRANSFORM = "text-transform";
 
     enum Scale {
         ALL,
@@ -173,4 +175,22 @@ public abstract class RenderInstruction {
      * @param scaleFactor the factor by which the text size should be scaled.
      */
     public abstract void scaleTextSize(float scaleFactor, byte zoomLevel);
+
+    /**
+     * Transform text before render based on the selected text transformation.
+     */
+    protected String transformText(String text, TextTransform transformation) {
+        if (text.length() == 0) {
+            return text;
+        }
+        if (transformation == TextTransform.UPPERCASE) {
+            return text.toUpperCase();
+        } else if (transformation == TextTransform.LOWERCASE) {
+            return text.toLowerCase();
+        } else if (transformation == TextTransform.CAPITALIZE) {
+            return text.substring(0, 1).toUpperCase() + text.substring(1);
+        } else {
+            return text;
+        }
+    }
 }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/RenderInstruction.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/RenderInstruction.java
@@ -32,6 +32,7 @@ import org.mapsforge.map.rendertheme.XmlThemeResourceProvider;
 import org.mapsforge.map.rendertheme.XmlUtils;
 
 import java.io.IOException;
+import java.util.Locale;
 
 /**
  * A RenderInstruction is a basic graphical primitive to draw a map.
@@ -184,11 +185,11 @@ public abstract class RenderInstruction {
             return text;
         }
         if (transformation == TextTransform.UPPERCASE) {
-            return text.toUpperCase();
+            return text.toUpperCase(Locale.ROOT);
         } else if (transformation == TextTransform.LOWERCASE) {
-            return text.toLowerCase();
+            return text.toLowerCase(Locale.ROOT);
         } else if (transformation == TextTransform.CAPITALIZE) {
-            return text.substring(0, 1).toUpperCase() + text.substring(1);
+            return text.substring(0, 1).toUpperCase(Locale.ROOT) + text.substring(1);
         } else {
             return text;
         }

--- a/resources/renderTheme.xsd
+++ b/resources/renderTheme.xsd
@@ -127,6 +127,15 @@
         </xs:restriction>
     </xs:simpleType>
 
+    <xs:simpleType name="textTransform">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="none" />
+            <xs:enumeration value="uppercase" />
+            <xs:enumeration value="lowercase" />
+            <xs:enumeration value="capitalize" />
+        </xs:restriction>
+    </xs:simpleType>
+
     <xs:complexType name="area">
         <xs:attribute name="cat" type="xs:string" use="optional" />
         <xs:attribute name="src" type="tns:src" use="optional" />
@@ -137,6 +146,7 @@
         <xs:attribute name="scale" default="stroke" type="tns:scale" use="optional" />
         <xs:attribute name="stroke" default="#00000000" type="tns:color" use="optional" />
         <xs:attribute name="stroke-width" default="0" type="tns:nonNegativeFloat" use="optional" />
+        <xs:attribute name="text-transform" default="none" type="tns:textTransform" use="optional" />
     </xs:complexType>
 
     <xs:complexType name="caption">
@@ -153,6 +163,7 @@
         <xs:attribute name="stroke-width" default="0" type="tns:nonNegativeFloat" use="optional" />
         <xs:attribute name="position" default="auto" type="tns:position" use="optional" />
         <xs:attribute name="symbol-id" type="xs:string" use="optional" />
+        <xs:attribute name="text-transform" default="none" type="tns:textTransform" use="optional" />
     </xs:complexType>
 
     <!-- style menu cat element -->
@@ -195,7 +206,7 @@
         <xs:attribute name="stroke-dasharray" type="tns:strokeDasharray" use="optional" />
         <xs:attribute name="stroke-linecap" default="round" type="tns:cap" use="optional" />
         <xs:attribute name="stroke-linejoin" default="round" type="tns:linejoin" use="optional" />
-        <xs:attribute name="curve" default="no" type="xs:string" use="optional" />
+        <xs:attribute name="curve" default="no" type="tns:curve" use="optional" />
     </xs:complexType>
 
     <xs:complexType name="lineSymbol">
@@ -243,6 +254,7 @@
         <xs:attribute name="repeat-gap" default="100" type="xs:float" use="optional" />
         <xs:attribute name="repeat-start" default="10" type="xs:float" use="optional" />
         <xs:attribute name="rotate" default="true" type="xs:boolean" use="optional" />
+        <xs:attribute name="text-transform" default="none" type="tns:textTransform" use="optional" />
     </xs:complexType>
 
     <xs:complexType name="symbol">


### PR DESCRIPTION
New tag that allows to transform text before rendering.

**Tag**: "text-transform"

**Options**:
- "none" > default, no change
- "uppercase" > all letters uppercase
- "lowercase" > all letters lowercase
- "capitalize" > first letter capitalized

**Usable for**:
- area caption
- POI caption
- way text