### PR TITLE
- add: support for 'text-wrap-width' attribute

### DIFF
--- a/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/Caption.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/Caption.java
@@ -48,7 +48,7 @@ public class Caption extends RenderInstruction {
     private final Map<Byte, Paint> fills;
     private float fontSize;
     private final float gap;
-    private final int maxTextWidth;
+    private int maxTextWidth;
     private Position position;
     private int priority;
     private final Paint stroke;
@@ -75,6 +75,7 @@ public class Caption extends RenderInstruction {
 
         this.gap = DEFAULT_GAP * displayModel.getScaleFactor();
         this.textTransform = TextTransform.NONE;
+        this.maxTextWidth = displayModel.getMaxTextWidth();
 
         extractValues(graphicFactory, displayModel, elementName, pullParser);
 
@@ -115,8 +116,6 @@ public class Caption extends RenderInstruction {
             default:
                 throw new IllegalArgumentException("Position invalid");
         }
-
-        this.maxTextWidth = displayModel.getMaxTextWidth();
     }
 
     private float computeHorizontalOffset() {
@@ -185,6 +184,13 @@ public class Caption extends RenderInstruction {
                 this.symbolId = value;
             } else if (TEXT_TRANSFORM.equals(name)) {
                 this.textTransform = TextTransform.fromString(value);
+            } else if (TEXT_WRAP_WIDTH .equals(name)) {
+                int maxWidth = XmlUtils.parseNonNegativeInteger(name, value);
+                if (maxWidth == 0) {
+                    maxTextWidth = Integer.MAX_VALUE;
+                } else {
+                    maxTextWidth = maxWidth;
+                }
             } else {
                 throw XmlUtils.createXmlPullParserException(elementName, name, value, i);
             }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/RenderInstruction.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/RenderInstruction.java
@@ -73,6 +73,7 @@ public abstract class RenderInstruction {
     static final String SYMBOL_SCALING = "symbol-scaling";
     static final String SYMBOL_WIDTH = "symbol-width";
     static final String TEXT_TRANSFORM = "text-transform";
+    static final String TEXT_WRAP_WIDTH = "text-wrap-width";
 
     enum Scale {
         ALL,

--- a/resources/renderTheme.xsd
+++ b/resources/renderTheme.xsd
@@ -164,6 +164,7 @@
         <xs:attribute name="position" default="auto" type="tns:position" use="optional" />
         <xs:attribute name="symbol-id" type="xs:string" use="optional" />
         <xs:attribute name="text-transform" default="none" type="tns:textTransform" use="optional" />
+        <xs:attribute name="text-wrap-width" default="none" type="xs:integer" use="optional" />
     </xs:complexType>
 
     <!-- style menu cat element -->


### PR DESCRIPTION
Currently, the text is wrapped based on hardcoded parameter 256 (tilesize) * 0.7.

![image](https://user-images.githubusercontent.com/1257075/210270615-6d234e38-a8c4-4773-b4b2-2341ca6d3067.png)

The new parameter 'text-wrap-width' for the 'Caption', allows setting maximum width (in pixels) as

Value: 0 ... no wrap 

![image](https://user-images.githubusercontent.com/1257075/210270778-3a6c1f82-5332-4425-8c78-78e7eb6987c2.png)

Value > 0 ... wrap 
Example: `text-wrap-width="100"`

![image](https://user-images.githubusercontent.com/1257075/210270751-5cb2783a-4a8f-48cd-b6d5-35759973da80.png)

