### PR TITLE
Throw exception on missing envvar for Android-related builds

### DIFF
--- a/mapsforge-map-android/build.gradle
+++ b/mapsforge-map-android/build.gradle
@@ -20,3 +20,7 @@ if (project.hasProperty("SONATYPE_USERNAME")) {
         project.apply from: "${rootProject.projectDir}/deploy.gradle"
     }
 }
+
+if (System.getenv('ANDROID_HOME') == null) {
+    throw new GradleException("Environment variable ANDROID_HOME needs to be set to SDK folder")
+}

--- a/mapsforge-poi-android/build.gradle
+++ b/mapsforge-poi-android/build.gradle
@@ -20,3 +20,7 @@ if (project.hasProperty("SONATYPE_USERNAME")) {
         project.apply from: "${rootProject.projectDir}/deploy.gradle"
     }
 }
+
+if (System.getenv('ANDROID_HOME') == null) {
+    throw new GradleException("Environment variable ANDROID_HOME needs to be set to SDK folder")
+}

--- a/sqlite-android/build.gradle
+++ b/sqlite-android/build.gradle
@@ -28,3 +28,7 @@ if (project.hasProperty("SONATYPE_USERNAME")) {
         project.apply from: "${rootProject.projectDir}/deploy.gradle"
     }
 }
+
+if (System.getenv('ANDROID_HOME') == null) {
+    throw new GradleException("Environment variable ANDROID_HOME needs to be set to SDK folder")
+}


### PR DESCRIPTION
Throw a gradle exception during build, if the required environment variable "ANDROID_HOME" is undefined
(only applies to Android-related builds)