### PR TITLE
- add: new upright parameter

### DIFF
--- a/mapsforge-core/src/main/java/org/mapsforge/core/graphics/Upright.java
+++ b/mapsforge-core/src/main/java/org/mapsforge/core/graphics/Upright.java
@@ -1,0 +1,29 @@
+package org.mapsforge.core.graphics;
+
+public enum Upright {
+
+    /**
+     * Automatic map rotation.
+     */
+    AUTO,
+
+    /**
+     * Rotate the text up when the path segment (where the text is to be placed) is facing east. / right.
+     */
+    RIGHT,
+
+    /**
+     * Rotate text up when path segment the text goes to the west/left.
+     */
+    LEFT;
+
+    public static Upright fromString(String value) {
+        if (value.equals("right")) {
+            return RIGHT;
+        } else if (value.equals("left")) {
+            return LEFT;
+        } else {
+            return AUTO;
+        }
+    }
+}

--- a/mapsforge-core/src/main/java/org/mapsforge/core/mapelements/WayTextContainer.java
+++ b/mapsforge-core/src/main/java/org/mapsforge/core/mapelements/WayTextContainer.java
@@ -82,18 +82,16 @@ public class WayTextContainer extends MapElementContainer {
     private Path generatePath(Point origin) {
         // compute rotation so text isn't upside down
         LineSegment firstSegment = this.lineString.segments.get(0);
-        boolean isWest = firstSegment.end.x <= firstSegment.start.x;
-        boolean doInvert = false;
+        boolean doInvert;
         switch (upright) {
             case RIGHT:
-                //noinspection ConstantConditions
                 doInvert = false;
                 break;
             case LEFT:
                 doInvert = true;
                 break;
-            case AUTO:
-                doInvert = isWest;
+            default: // AUTO
+                doInvert = firstSegment.end.x <= firstSegment.start.x;
                 break;
         }
 

--- a/mapsforge-map-awt/src/test/java/org/mapsforge/map/rendertheme/rule/DummyRenderCallback.java
+++ b/mapsforge-map-awt/src/test/java/org/mapsforge/map/rendertheme/rule/DummyRenderCallback.java
@@ -19,6 +19,7 @@ import org.mapsforge.core.graphics.Curve;
 import org.mapsforge.core.graphics.Display;
 import org.mapsforge.core.graphics.Paint;
 import org.mapsforge.core.graphics.Position;
+import org.mapsforge.core.graphics.Upright;
 import org.mapsforge.core.model.Rectangle;
 import org.mapsforge.map.datastore.PointOfInterest;
 import org.mapsforge.map.layer.renderer.PolylineContainer;
@@ -62,13 +63,13 @@ class DummyRenderCallback implements RenderCallback {
     }
 
     @Override
-    public void renderWaySymbol(final RenderContext renderContext, Display display, int priority, Bitmap symbol, float dy, Rectangle boundary, boolean repeat, float repeatGap, float repeatStart, boolean rotate, PolylineContainer way) {
+    public void renderWaySymbol(final RenderContext renderContext, Display display, int priority, Bitmap symbol, float dy, Rectangle boundary, boolean repeat, float repeatGap, float repeatStart, Upright upright, PolylineContainer way) {
         // do nothing
     }
 
     @Override
     public void renderWayText(final RenderContext renderContext, Display display, int priority, String text, float dy, Paint fill, Paint stroke,
-                              boolean repeat, float repeatGap, float repeatStart, boolean rotate, PolylineContainer way) {
+                              boolean repeat, float repeatGap, float repeatStart, Upright upright, PolylineContainer way) {
         // do nothing
     }
 }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/StandardRenderer.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/StandardRenderer.java
@@ -154,19 +154,19 @@ public class StandardRenderer implements RenderCallback {
     }
 
     @Override
-    public void renderWaySymbol(final RenderContext renderContext, Display display, int priority, Bitmap symbol, float dy, Rectangle boundary, boolean repeat, float repeatGap, float repeatStart, boolean rotate, PolylineContainer way) {
+    public void renderWaySymbol(final RenderContext renderContext, Display display, int priority, Bitmap symbol, float dy, Rectangle boundary, boolean repeat, float repeatGap, float repeatStart, Upright upright, PolylineContainer way) {
         if (renderLabels) {
             WayDecorator.renderSymbol(symbol, display, priority, dy, boundary, repeat, repeatGap,
-                    repeatStart, rotate, way.getCoordinatesAbsolute(), renderContext.labels);
+                    repeatStart, upright, way.getCoordinatesAbsolute(), renderContext.labels);
         }
     }
 
     @Override
     public void renderWayText(final RenderContext renderContext, Display display, int priority, String textKey, float dy, Paint fill, Paint stroke,
-                              boolean repeat, float repeatGap, float repeatStart, boolean rotate, PolylineContainer way) {
+                              boolean repeat, float repeatGap, float repeatStart, Upright upright, PolylineContainer way) {
         if (renderLabels) {
             WayDecorator.renderText(graphicFactory, way.getUpperLeft(), way.getLowerRight(), textKey, display, priority, dy, fill, stroke,
-                    repeat, repeatGap, repeatStart, rotate, way.getCoordinatesAbsolute(), renderContext.labels);
+                    repeat, repeatGap, repeatStart, upright, way.getCoordinatesAbsolute(), renderContext.labels);
         }
     }
 

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/WayDecorator.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/WayDecorator.java
@@ -60,18 +60,16 @@ final class WayDecorator {
             double currentY = c[i].y;
 
             // compute rotation so text isn't upside down
-            boolean isWest = currentX <= previousX;
-            boolean doInvert = false;
+            boolean doInvert;
             switch (upright) {
                 case RIGHT:
-                    //noinspection ConstantConditions
                     doInvert = false;
                     break;
                 case LEFT:
                     doInvert = true;
                     break;
-                case AUTO:
-                    doInvert = isWest;
+                default: // AUTO
+                    doInvert = currentX <= previousX;
                     break;
             }
 

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/WayDecorator.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/WayDecorator.java
@@ -19,6 +19,7 @@ import org.mapsforge.core.graphics.Bitmap;
 import org.mapsforge.core.graphics.Display;
 import org.mapsforge.core.graphics.GraphicFactory;
 import org.mapsforge.core.graphics.Paint;
+import org.mapsforge.core.graphics.Upright;
 import org.mapsforge.core.mapelements.MapElementContainer;
 import org.mapsforge.core.mapelements.SymbolContainer;
 import org.mapsforge.core.mapelements.WayTextContainer;
@@ -32,7 +33,7 @@ final class WayDecorator {
 
     static void renderSymbol(Bitmap symbolBitmap, Display display, int priority, float dy, Rectangle boundary,
                              boolean repeatSymbol, float repeatGap, float repeatStart,
-                             boolean rotate, Point[][] coordinates,
+                             Upright upright, Point[][] coordinates,
                              List<MapElementContainer> currentItems) {
         int skipPixels = (int) repeatStart;
 
@@ -58,6 +59,22 @@ final class WayDecorator {
             double currentX = c[i].x;
             double currentY = c[i].y;
 
+            // compute rotation so text isn't upside down
+            boolean isWest = currentX <= previousX;
+            boolean doInvert = false;
+            switch (upright) {
+                case RIGHT:
+                    //noinspection ConstantConditions
+                    doInvert = false;
+                    break;
+                case LEFT:
+                    doInvert = true;
+                    break;
+                case AUTO:
+                    doInvert = isWest;
+                    break;
+            }
+
             // calculate the length of the current segment (Euclidian distance)
             double diffX = currentX - previousX;
             double diffY = currentY - previousY;
@@ -71,7 +88,7 @@ final class WayDecorator {
                 // move the previous point forward towards the current point
                 previousX += diffX * segmentSkipPercentage;
                 previousY += diffY * segmentSkipPercentage;
-                if (rotate) {
+                if (doInvert) {
                     // if we do not rotate theta will be 0, which is correct
                     theta = (float) Math.atan2(currentY - previousY, currentX - previousX);
                 }
@@ -123,7 +140,7 @@ final class WayDecorator {
      */
     static void renderText(GraphicFactory graphicFactory, Tile upperLeft, Tile lowerRight, String text, Display display, int priority, float dy,
                            Paint fill, Paint stroke,
-                           boolean repeat, float repeatGap, float repeatStart, boolean rotate, Point[][] coordinates,
+                           boolean repeat, float repeatGap, float repeatStart, Upright upright, Point[][] coordinates,
                            List<MapElementContainer> currentLabels) {
         if (coordinates.length == 0) {
             return;
@@ -165,7 +182,7 @@ final class WayDecorator {
             if (tooSharp)
                 continue;
 
-            currentLabels.add(new WayTextContainer(graphicFactory, linePart, display, priority, text, fill, stroke, textHeight, rotate));
+            currentLabels.add(new WayTextContainer(graphicFactory, linePart, display, priority, text, fill, stroke, textHeight, upright));
         }
     }
 

--- a/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/RenderCallback.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/RenderCallback.java
@@ -19,6 +19,7 @@ import org.mapsforge.core.graphics.Curve;
 import org.mapsforge.core.graphics.Display;
 import org.mapsforge.core.graphics.Paint;
 import org.mapsforge.core.graphics.Position;
+import org.mapsforge.core.graphics.Upright;
 import org.mapsforge.core.model.Rectangle;
 import org.mapsforge.map.datastore.PointOfInterest;
 import org.mapsforge.map.layer.renderer.PolylineContainer;
@@ -115,7 +116,7 @@ public interface RenderCallback {
      * @param repeatGap     distance between repetitions.
      * @param repeatStart
      */
-    void renderWaySymbol(final RenderContext renderContext, Display display, int priority, Bitmap symbol, float dy, Rectangle boundary, boolean repeat, float repeatGap, float repeatStart, boolean rotate, PolylineContainer way);
+    void renderWaySymbol(final RenderContext renderContext, Display display, int priority, Bitmap symbol, float dy, Rectangle boundary, boolean repeat, float repeatGap, float repeatStart, Upright upright, PolylineContainer way);
 
     /**
      * Renders a way with the given text along the way path.
@@ -128,5 +129,5 @@ public interface RenderCallback {
      */
     void renderWayText(final RenderContext renderContext, Display display, int priority, String text,
                        float dy, Paint fill, Paint stroke,
-                       boolean repeat, float repeatGap, float repeatStart, boolean rotate, PolylineContainer way);
+                       boolean repeat, float repeatGap, float repeatStart, Upright upright, PolylineContainer way);
 }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/LineSymbol.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/LineSymbol.java
@@ -112,6 +112,10 @@ public class LineSymbol extends RenderInstruction {
                 this.repeatGap = Float.parseFloat(value) * displayModel.getScaleFactor();
             } else if (REPEAT_START.equals(name)) {
                 this.repeatStart = Float.parseFloat(value) * displayModel.getScaleFactor();
+            } else if (ROTATE.equals(name)) {
+                if (!Boolean.parseBoolean(value)) {
+                    this.upright = Upright.RIGHT;
+                }
             } else if (SCALE.equals(name)) {
                 this.scale = scaleFromValue(value);
             } else if (SYMBOL_HEIGHT.equals(name)) {

--- a/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/LineSymbol.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/LineSymbol.java
@@ -21,6 +21,7 @@ import org.mapsforge.core.graphics.Bitmap;
 import org.mapsforge.core.graphics.Display;
 import org.mapsforge.core.graphics.GraphicFactory;
 import org.mapsforge.core.graphics.Position;
+import org.mapsforge.core.graphics.Upright;
 import org.mapsforge.core.model.Rectangle;
 import org.mapsforge.map.datastore.PointOfInterest;
 import org.mapsforge.map.layer.renderer.PolylineContainer;
@@ -55,21 +56,21 @@ public class LineSymbol extends RenderInstruction {
     private float repeatGap;
     private float repeatStart;
     private final XmlThemeResourceProvider resourceProvider;
-    private boolean rotate;
     private Scale scale = Scale.STROKE;
     private String src;
+    private Upright upright;
 
     public LineSymbol(GraphicFactory graphicFactory, DisplayModel displayModel, String elementName,
                       XmlPullParser pullParser, String relativePathPrefix, XmlThemeResourceProvider resourceProvider) throws IOException, XmlPullParserException {
         super(graphicFactory, displayModel);
 
         this.display = Display.IFSPACE;
-        this.rotate = true;
         this.relativePathPrefix = relativePathPrefix;
         this.resourceProvider = resourceProvider;
         this.dyScaled = new HashMap<>();
         // Probably not a good default, but backwards compatible
         this.position = Position.BELOW_RIGHT;
+        this.upright = Upright.AUTO;
 
         extractValues(elementName, pullParser);
     }
@@ -111,8 +112,6 @@ public class LineSymbol extends RenderInstruction {
                 this.repeatGap = Float.parseFloat(value) * displayModel.getScaleFactor();
             } else if (REPEAT_START.equals(name)) {
                 this.repeatStart = Float.parseFloat(value) * displayModel.getScaleFactor();
-            } else if (ROTATE.equals(name)) {
-                this.rotate = Boolean.parseBoolean(value);
             } else if (SCALE.equals(name)) {
                 this.scale = scaleFromValue(value);
             } else if (SYMBOL_HEIGHT.equals(name)) {
@@ -125,6 +124,8 @@ public class LineSymbol extends RenderInstruction {
                 this.width = XmlUtils.parseNonNegativeInteger(name, value) * displayModel.getScaleFactor();
             } else if (POSITION.equals(name)) {
                 this.position = Position.fromString(value);
+            } else if (UPRIGHT.equals(name)) {
+                this.upright = Upright.fromString(value);
             } else {
                 throw XmlUtils.createXmlPullParserException(elementName, name, value, i);
             }
@@ -158,7 +159,7 @@ public class LineSymbol extends RenderInstruction {
         if (this.bitmap != null) {
             Rectangle boundary = computeBoundary(this.bitmap.getWidth(), this.bitmap.getHeight(), this.position);
             renderCallback.renderWaySymbol(renderContext, this.display, this.priority, this.bitmap, dyScale, boundary,
-                    this.repeat, this.repeatGap, this.repeatStart, this.rotate, way);
+                    this.repeat, this.repeatGap, this.repeatStart, this.upright, way);
         }
     }
 

--- a/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/PathText.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/PathText.java
@@ -49,9 +49,9 @@ public class PathText extends RenderInstruction {
     private boolean repeat;
     private float repeatGap;
     private float repeatStart;
-    private boolean rotate;
     private TextKey textKey;
     private TextTransform textTransform;
+    private Upright upright;
 
     public PathText(GraphicFactory graphicFactory, DisplayModel displayModel, String elementName,
                     XmlPullParser pullParser) throws XmlPullParserException {
@@ -61,7 +61,6 @@ public class PathText extends RenderInstruction {
         this.fill.setStyle(Style.FILL);
         this.fill.setTextAlign(Align.CENTER);
         this.fills = new HashMap<>();
-        this.rotate = true;
         this.repeat = true;
 
         this.stroke = graphicFactory.createPaint();
@@ -72,6 +71,7 @@ public class PathText extends RenderInstruction {
         this.dyScaled = new HashMap<>();
         this.display = Display.IFSPACE;
         this.textTransform = TextTransform.NONE;
+        this.upright = Upright.AUTO;
 
         extractValues(graphicFactory, displayModel, elementName, pullParser);
     }
@@ -115,8 +115,6 @@ public class PathText extends RenderInstruction {
                 this.repeatGap = Float.parseFloat(value) * displayModel.getScaleFactor();
             } else if (REPEAT_START.equals(name)) {
                 this.repeatStart = Float.parseFloat(value) * displayModel.getScaleFactor();
-            } else if (ROTATE.equals(name)) {
-                this.rotate = Boolean.parseBoolean(value);
             } else if (PRIORITY.equals(name)) {
                 this.priority = Integer.parseInt(value);
             } else if (SCALE.equals(name)) {
@@ -127,6 +125,8 @@ public class PathText extends RenderInstruction {
                 this.stroke.setStrokeWidth(XmlUtils.parseNonNegativeFloat(name, value) * displayModel.getScaleFactor());
             } else if (TEXT_TRANSFORM.equals(name)) {
                 this.textTransform = TextTransform.fromString(value);
+            } else if (UPRIGHT.equals(name)) {
+                this.upright = Upright.fromString(value);
             } else {
                 throw XmlUtils.createXmlPullParserException(elementName, name, value, i);
             }
@@ -179,7 +179,7 @@ public class PathText extends RenderInstruction {
                 transformText(caption, textTransform), dyScale,
                 getFillPaint(renderContext.rendererJob.tile.zoomLevel),
                 getStrokePaint(renderContext.rendererJob.tile.zoomLevel),
-                this.repeat, this.repeatGap, this.repeatStart, this.rotate,
+                this.repeat, this.repeatGap, this.repeatStart, this.upright,
                 way);
     }
 

--- a/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/PathText.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/PathText.java
@@ -117,6 +117,10 @@ public class PathText extends RenderInstruction {
                 this.repeatStart = Float.parseFloat(value) * displayModel.getScaleFactor();
             } else if (PRIORITY.equals(name)) {
                 this.priority = Integer.parseInt(value);
+            } else if (ROTATE.equals(name)) {
+                if (!Boolean.parseBoolean(value)) {
+                    this.upright = Upright.RIGHT;
+                }
             } else if (SCALE.equals(name)) {
                 this.scale = scaleFromValue(value);
             } else if (STROKE.equals(name)) {

--- a/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/RenderInstruction.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/RenderInstruction.java
@@ -58,6 +58,9 @@ public abstract class RenderInstruction {
     static final String REPEAT = "repeat";
     static final String REPEAT_GAP = "repeat-gap";
     static final String REPEAT_START = "repeat-start";
+    // Use "upright" parameter instead.
+    @Deprecated
+    static final String ROTATE = "rotate";
     static final String SCALE = "scale";
     static final String SCALE_RADIUS = "scale-radius";
     static final String SRC = "src";

--- a/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/RenderInstruction.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/RenderInstruction.java
@@ -58,7 +58,6 @@ public abstract class RenderInstruction {
     static final String REPEAT = "repeat";
     static final String REPEAT_GAP = "repeat-gap";
     static final String REPEAT_START = "repeat-start";
-    static final String ROTATE = "rotate";
     static final String SCALE = "scale";
     static final String SCALE_RADIUS = "scale-radius";
     static final String SRC = "src";
@@ -74,6 +73,7 @@ public abstract class RenderInstruction {
     static final String SYMBOL_WIDTH = "symbol-width";
     static final String TEXT_TRANSFORM = "text-transform";
     static final String TEXT_WRAP_WIDTH = "text-wrap-width";
+    static final String UPRIGHT = "upright";
 
     enum Scale {
         ALL,

--- a/mapsforge-themes/src/main/resources/assets/mapsforge/default.xml
+++ b/mapsforge-themes/src/main/resources/assets/mapsforge/default.xml
@@ -834,13 +834,13 @@
         <line stroke="#202020" stroke-linecap="butt" stroke-width="0.4" />
         <line stroke="#202020" stroke-dasharray="2,200" stroke-linecap="butt" stroke-width="4.0" />
         <rule e="way" k="aerialway" v="cable_car" zoom-min="15">
-            <lineSymbol repeat="true" rotate="false" src="jar:symbols/cable_car.svg" />
+            <lineSymbol repeat="true" upright="right" src="jar:symbols/cable_car.svg" />
         </rule>
         <rule e="way" k="aerialway" v="chair_lift" zoom-min="15">
-            <lineSymbol repeat="true" rotate="false" src="jar:symbols/chair_lift.svg" />
+            <lineSymbol repeat="true" upright="right" src="jar:symbols/chair_lift.svg" />
         </rule>
         <rule e="way" k="aerialway" v="gondola" zoom-min="15">
-            <lineSymbol repeat="true" rotate="false" src="jar:symbols/gondola.svg" />
+            <lineSymbol repeat="true" upright="right" src="jar:symbols/gondola.svg" />
         </rule>
         <rule e="any" k="*" v="*" zoom-min="15">
             <pathText fill="#606060" font-size="10" font-style="bold" k="name" stroke="#FFFFFF"

--- a/mapsforge-themes/src/main/resources/assets/mapsforge/default.xml
+++ b/mapsforge-themes/src/main/resources/assets/mapsforge/default.xml
@@ -834,13 +834,13 @@
         <line stroke="#202020" stroke-linecap="butt" stroke-width="0.4" />
         <line stroke="#202020" stroke-dasharray="2,200" stroke-linecap="butt" stroke-width="4.0" />
         <rule e="way" k="aerialway" v="cable_car" zoom-min="15">
-            <lineSymbol repeat="true" upright="right" src="jar:symbols/cable_car.svg" />
+            <lineSymbol repeat="true" rotate="false" src="jar:symbols/cable_car.svg" />
         </rule>
         <rule e="way" k="aerialway" v="chair_lift" zoom-min="15">
-            <lineSymbol repeat="true" upright="right" src="jar:symbols/chair_lift.svg" />
+            <lineSymbol repeat="true" rotate="false" src="jar:symbols/chair_lift.svg" />
         </rule>
         <rule e="way" k="aerialway" v="gondola" zoom-min="15">
-            <lineSymbol repeat="true" upright="right" src="jar:symbols/gondola.svg" />
+            <lineSymbol repeat="true" rotate="false" src="jar:symbols/gondola.svg" />
         </rule>
         <rule e="any" k="*" v="*" zoom-min="15">
             <pathText fill="#606060" font-size="10" font-style="bold" k="name" stroke="#FFFFFF"

--- a/resources/renderTheme.xsd
+++ b/resources/renderTheme.xsd
@@ -232,6 +232,7 @@
         <xs:attribute name="repeat" default="false" type="xs:boolean" use="optional" />
         <xs:attribute name="repeat-gap" default="200" type="xs:float" use="optional" />
         <xs:attribute name="repeat-start" default="30" type="xs:float" use="optional" />
+        <xs:attribute name="rotate" default="true" type="xs:boolean" use="optional" />
         <xs:attribute name="upright" default="auto" type="tns:upright" use="optional" />
     </xs:complexType>
 
@@ -262,6 +263,7 @@
         <xs:attribute name="repeat" default="true" type="xs:boolean" use="optional" />
         <xs:attribute name="repeat-gap" default="100" type="xs:float" use="optional" />
         <xs:attribute name="repeat-start" default="10" type="xs:float" use="optional" />
+        <xs:attribute name="rotate" default="true" type="xs:boolean" use="optional" />
         <xs:attribute name="text-transform" default="none" type="tns:textTransform" use="optional" />
         <xs:attribute name="upright" default="auto" type="tns:upright" use="optional" />
     </xs:complexType>

--- a/resources/renderTheme.xsd
+++ b/resources/renderTheme.xsd
@@ -136,6 +136,14 @@
         </xs:restriction>
     </xs:simpleType>
 
+    <xs:simpleType name="upright">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="auto" />
+            <xs:enumeration value="right" />
+            <xs:enumeration value="left" />
+        </xs:restriction>
+    </xs:simpleType>
+
     <xs:complexType name="area">
         <xs:attribute name="cat" type="xs:string" use="optional" />
         <xs:attribute name="src" type="tns:src" use="optional" />
@@ -224,7 +232,7 @@
         <xs:attribute name="repeat" default="false" type="xs:boolean" use="optional" />
         <xs:attribute name="repeat-gap" default="200" type="xs:float" use="optional" />
         <xs:attribute name="repeat-start" default="30" type="xs:float" use="optional" />
-        <xs:attribute name="rotate" default="true" type="xs:boolean" use="optional" />
+        <xs:attribute name="upright" default="auto" type="tns:upright" use="optional" />
     </xs:complexType>
 
     <!-- style menu name element -->
@@ -254,8 +262,8 @@
         <xs:attribute name="repeat" default="true" type="xs:boolean" use="optional" />
         <xs:attribute name="repeat-gap" default="100" type="xs:float" use="optional" />
         <xs:attribute name="repeat-start" default="10" type="xs:float" use="optional" />
-        <xs:attribute name="rotate" default="true" type="xs:boolean" use="optional" />
         <xs:attribute name="text-transform" default="none" type="tns:textTransform" use="optional" />
+        <xs:attribute name="upright" default="auto" type="tns:upright" use="optional" />
     </xs:complexType>
 
     <xs:complexType name="symbol">


### PR DESCRIPTION
We added the attribute `rotate` to disable the rotation of `PathText` for contour lines. Unfortunately, this parameter doesn't cover all possible situations - especially different orientations of source lines. 

This PR creates a new parameter `upright` with possible values and removes the previous `rotate` parameter.

**auto** - original text rotation when text is always upright (use as a default value)
**right** - rotate the text up when the path segment (where the text is to be placed) is facing east. / right (it's basically the latest implementation of the rotate attribute in mode rotate=false )
**left** - rotate text up when the path segment the text goes to the west/left

Inspiration based on Mapnik upright attribute. https://github.com/mapnik/mapnik/wiki/TextSymbolizer

Left
![image](https://user-images.githubusercontent.com/1257075/218710804-ece87310-52e7-4ec2-938b-19c23b39b41f.png)

Right
![image](https://user-images.githubusercontent.com/1257075/218710887-f62bf4da-4c7b-417e-ba00-8e5ce0223f4a.png)

Auto (default)
![image](https://user-images.githubusercontent.com/1257075/218710923-e11fb776-5483-4c33-b370-081400e572f1.png)
