### PR TITLE
Improved 'text-wrap-width' parameter

### DIFF
--- a/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidPointTextContainer.java
+++ b/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidPointTextContainer.java
@@ -15,6 +15,8 @@
  */
 package org.mapsforge.map.android.graphics;
 
+import android.graphics.text.LineBreaker;
+import android.os.Build;
 import android.text.Layout;
 import android.text.StaticLayout;
 import android.text.TextPaint;
@@ -69,10 +71,10 @@ public class AndroidPointTextContainer extends PointTextContainer {
                 backTextPaint.setTextAlign(android.graphics.Paint.Align.LEFT);
             }
 
-            frontLayout = new StaticLayout(this.text, frontTextPaint, this.maxTextWidth, alignment, 1, 0, false);
+            frontLayout = createTextLayout(frontTextPaint, alignment);
             backLayout = null;
             if (this.paintBack != null) {
-                backLayout = new StaticLayout(this.text, backTextPaint, this.maxTextWidth, alignment, 1, 0, false);
+                backLayout = createTextLayout(backTextPaint, alignment);
             }
 
             boxWidth = frontLayout.getWidth();
@@ -112,6 +114,19 @@ public class AndroidPointTextContainer extends PointTextContainer {
                 break;
             default:
                 break;
+        }
+    }
+
+    private StaticLayout createTextLayout(TextPaint paint, Layout.Alignment alignment) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            // API29+, A10+
+            return StaticLayout.Builder
+                    .obtain(this.text, 0, this.text.length(), paint, this.maxTextWidth)
+                    .setBreakStrategy(LineBreaker.BREAK_STRATEGY_HIGH_QUALITY)
+                    .setIncludePad(false)
+                    .build();
+        } else {
+            return new StaticLayout(this.text, paint, this.maxTextWidth, alignment, 1, 0, false);
         }
     }
 

--- a/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/Caption.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/Caption.java
@@ -185,7 +185,7 @@ public class Caption extends RenderInstruction {
             } else if (TEXT_TRANSFORM.equals(name)) {
                 this.textTransform = TextTransform.fromString(value);
             } else if (TEXT_WRAP_WIDTH .equals(name)) {
-                int maxWidth = XmlUtils.parseNonNegativeInteger(name, value);
+                int maxWidth = (int) (XmlUtils.parseNonNegativeInteger(name, value) * displayModel.getScaleFactor());
                 if (maxWidth == 0) {
                     maxTextWidth = Integer.MAX_VALUE;
                 } else {


### PR DESCRIPTION
Current implementation has two minor issues:

1. 'text-wrap-width' parameter ignores device DPI and is used directly.

2. breaking to lines is not too clever and Android 29+ provide improved version of the `StaticLayout` class with [optional break strategy parameter](https://developer.android.com/reference/android/graphics/text/LineBreaker#BREAK_STRATEGY_HIGH_QUALITY). This allows to apply a more clever logic when separating text into multiple lines.

Example
full name: "Králove-Krnišov v Pardubicích". Max width set to 100*DPI

SIMPLE (default, current)
<img width="162" alt="image" src="https://user-images.githubusercontent.com/1257075/218770890-b7289152-f0a4-4dba-96ed-ce9dc308572c.png">

HIGH_QUALITY
<img width="139" alt="image" src="https://user-images.githubusercontent.com/1257075/218771083-f45198e4-90c6-483e-ad91-d9d51e8d58fa.png">
