### PR TITLE
Fix of "position" parameter on Android API29+

### DIFF
--- a/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidPointTextContainer.java
+++ b/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidPointTextContainer.java
@@ -15,6 +15,7 @@
  */
 package org.mapsforge.map.android.graphics;
 
+import android.graphics.RectF;
 import android.graphics.text.LineBreaker;
 import android.os.Build;
 import android.text.Layout;
@@ -123,6 +124,7 @@ public class AndroidPointTextContainer extends PointTextContainer {
             return StaticLayout.Builder
                     .obtain(this.text, 0, this.text.length(), paint, this.maxTextWidth)
                     .setBreakStrategy(LineBreaker.BREAK_STRATEGY_HIGH_QUALITY)
+                    .setAlignment(alignment)
                     .setIncludePad(false)
                     .build();
         } else {


### PR DESCRIPTION
On modern Android where is used new StaticLayout.Builder to wrap a texts, is not used correctly prepared `Layout.Alignment` parameter. 

This solves this small fix.

### Confirmation

ABOVE_LEFT
<img width="150" alt="image" src="https://user-images.githubusercontent.com/1257075/224988669-040cb438-fec1-4fe1-ac5c-63dd8d9a95b0.png">

ABOVE
<img width="150" alt="image" src="https://user-images.githubusercontent.com/1257075/224988771-0514e2ce-063e-40f0-874f-8897ac59a040.png">

ABOVE_RIGHT
<img width="150" alt="image" src="https://user-images.githubusercontent.com/1257075/224989330-94268c10-5c1e-483c-acf7-9d95a0ad0d7c.png">

LEFT
<img width="150" alt="image" src="https://user-images.githubusercontent.com/1257075/224988935-f6f8e44a-ba53-4940-b160-7ac120b0ed37.png">

CENTER
<img width="150" alt="image" src="https://user-images.githubusercontent.com/1257075/224988546-95ca49c7-3f5f-4b50-b9f4-a687d982cf39.png">

RIGHT
<img width="150" alt="image" src="https://user-images.githubusercontent.com/1257075/224988988-9921b158-14e3-47e5-a8bf-e1c486b86c6f.png">

BELOW_LEFT
<img width="150" alt="image" src="https://user-images.githubusercontent.com/1257075/224989056-47720b26-c429-44d1-a65b-1a4ce7e08a72.png">

BELOW
<img width="150" alt="image" src="https://user-images.githubusercontent.com/1257075/224989138-97e3dedc-619c-49d4-8122-cfb82eabb8c2.png">

BELOW_RIGHT
<img width="150" alt="image" src="https://user-images.githubusercontent.com/1257075/224989188-f15c0f65-5a2d-4d62-9cd2-ff07399cb21f.png">
