### PR TITLE
Render themes: exclusive / except negation

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -7,8 +7,9 @@
 - Fractional zoom [#75](https://github.com/mapsforge/mapsforge/issues/75)
     - `Parameters.FRACTIONAL_ZOOM`
 - Pre-cache map tiles (+-zoom, margin) [#1507](https://github.com/mapsforge/mapsforge/issues/1507)
+- Render themes: exclusive / except negation [#1524](https://github.com/mapsforge/mapsforge/pull/1524)
 - Motorider map theme [#1483](https://github.com/mapsforge/mapsforge/issues/1483)
-- Hillshading new algorithm [#1521](https://github.com/mapsforge/mapsforge/pull/1521)
+- Hillshading `ClearAsymmetryShadingAlgorithm` algorithm [#1521](https://github.com/mapsforge/mapsforge/pull/1521)
 - Fix hillshading at 0 lat / lon [#1497](https://github.com/mapsforge/mapsforge/issues/1497)
 - `mapsforge-themes` change package [#1135](https://github.com/mapsforge/mapsforge/issues/1135)
   - Rename `InternalRenderTheme` to `MapsforgeThemes`

--- a/docs/Rendertheme.md
+++ b/docs/Rendertheme.md
@@ -40,8 +40,8 @@ A rule element has several attributes to specify which map elements the rule mat
 |**Attribute**|**Valid values**|**Description**|**Required**|
 |-------------|----------------|---------------|------------|
 |e|<ul><li>node</li><li>way</li><li>any</li></ul>|Defines which map element type will be matched.|yes|
-|k|[string](http://www.w3.org/TR/xmlschema-2/#string)|The key of the tile source tag. <ul><li>A vertical bar "\|" can be used to specify multiple keys.</li><li>An asterisk "`*`" serves as wildcard character.</li>|yes|
-|v|[string](http://www.w3.org/TR/xmlschema-2/#string)|The value of the tile source tag. <ul><li>A vertical bar "\|" can be used to specify multiple values.</li><li>An asterisk "`*`" serves as wildcard character.</li><li>A tilde "~" matches if the map element does not have a tag with the specified key.</li>|yes|
+|k|[string](http://www.w3.org/TR/xmlschema-2/#string)|The key of the tile source tag. <ul><li>A vertical bar "`\|`" can be used to specify multiple keys.</li><li>An asterisk "`*`" serves as wildcard character.</li>|yes|
+|v|[string](http://www.w3.org/TR/xmlschema-2/#string)|The value of the tile source tag. <ul><li>A vertical bar "`\|`" can be used to specify multiple values.</li><li>An asterisk "`*`" serves as wildcard character.</li><li>A minus sign "`-`" excludes the other values after "`\|`". It never works alone.</li><li>A tilde "`~`" matches if the map element does not have a tag with the specified key.</li>|yes|
 |closed|<ul><li>yes</li><li>no</li><li>any</li></ul>|Defines which ways will be matched. A way is considered as closed if its first node and its last node are equal.|no (default is *any*)|
 |zoom-min|[unsignedByte](http://www.w3.org/TR/xmlschema-2/#unsignedByte)|The minimum zoom level on which the rule will be matched.|no (default is 0)|
 |zoom-max|[unsignedByte](http://www.w3.org/TR/xmlschema-2/#unsignedByte)|The maximum zoom level on which the rule will be matched.|no (default is 127)|

--- a/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/rule/NegativeRule.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/rule/NegativeRule.java
@@ -22,10 +22,23 @@ class NegativeRule extends Rule {
 
     final NegativeMatcher attributeMatcher;
 
-    NegativeRule(RuleBuilder ruleBuilder, NegativeMatcher attributeMatcher) {
+    /* (-) 'exclusive negation' matches when either KEY is not present
+     * or KEY is present and any VALUE is NOT present
+     *
+     * (\) 'except negation' matches when KEY is present
+     * none items of VALUE is present (TODO).
+     * (can be emulated by <m k="a"><m k=a v="-|b|c">...</m></m>)
+     *
+     * (~) 'non-exclusive negation' matches when either KEY is not present
+     * or KEY is present and any VALUE is present */
+
+    final boolean exclusive;
+
+    NegativeRule(RuleBuilder ruleBuilder, NegativeMatcher attributeMatcher, boolean exclusive) {
         super(ruleBuilder);
 
         this.attributeMatcher = attributeMatcher;
+        this.exclusive = exclusive;
     }
 
     @Override
@@ -53,9 +66,9 @@ class NegativeRule extends Rule {
         // check tags
         for (int i = 0, n = tags.size(); i < n; i++) {
             if (attributeMatcher.matches(tags.get(i))) {
-                return true;
+                return !exclusive;
             }
         }
-        return false;
+        return exclusive;
     }
 }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/rule/RuleBuilder.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/rule/RuleBuilder.java
@@ -35,6 +35,7 @@ public class RuleBuilder {
     private static final String K = "k";
     private static final Pattern SPLIT_PATTERN = Pattern.compile("\\|");
     private static final String STRING_NEGATION = "~";
+    private static final String STRING_EXCLUSIVE = "-";
     private static final String STRING_WILDCARD = "*";
     private static final String V = "v";
     private static final String ZOOM_MAX = "zoom-max";
@@ -121,7 +122,12 @@ public class RuleBuilder {
     public Rule build() {
         if (this.valueList.remove(STRING_NEGATION)) {
             NegativeMatcher attributeMatcher = new NegativeMatcher(this.keyList, this.valueList);
-            return new NegativeRule(this, attributeMatcher);
+            return new NegativeRule(this, attributeMatcher, false);
+        }
+
+        if (this.valueList.remove(STRING_EXCLUSIVE)) {
+            NegativeMatcher attributeMatcher = new NegativeMatcher(this.keyList, this.valueList);
+            return new NegativeRule(this, attributeMatcher, true);
         }
 
         AttributeMatcher keyMatcher = getKeyMatcher(this.keyList);


### PR DESCRIPTION
A minus sign "`-`" excludes the other values after "`|`". It never works alone.

For example:
```xml
<!-- match tunnel-tag that are not 'no' or 'false' -->
<rule k="tunnel" v="-|no|false">
```