### PR TITLE
Correct pull of data from MultiMapDataStore

### DIFF
--- a/mapsforge-map-reader/src/main/java/org/mapsforge/map/reader/MapFile.java
+++ b/mapsforge-map-reader/src/main/java/org/mapsforge/map/reader/MapFile.java
@@ -1073,8 +1073,9 @@ public class MapFile extends MapDataStore {
     }
 
     @Override
-    public boolean supportsArea(BoundingBox boundingBox) {
-        return boundingBox.intersects(getMapFileInfo().boundingBox);
+    public boolean supportsArea(BoundingBox boundingBox, byte zoomLevel) {
+        return boundingBox.intersects(getMapFileInfo().boundingBox)
+                && (zoomLevel >= this.zoomLevelMin && zoomLevel <= this.zoomLevelMax);
     }
 
     /**

--- a/mapsforge-map-reader/src/main/java/org/mapsforge/map/reader/MapFile.java
+++ b/mapsforge-map-reader/src/main/java/org/mapsforge/map/reader/MapFile.java
@@ -1072,6 +1072,11 @@ public class MapFile extends MapDataStore {
                 && (tile.zoomLevel >= this.zoomLevelMin && tile.zoomLevel <= this.zoomLevelMax);
     }
 
+    @Override
+    public boolean supportsArea(BoundingBox boundingBox) {
+        return boundingBox.intersects(getMapFileInfo().boundingBox);
+    }
+
     /**
      * The Selector enum is used to specify which data subset is to be retrieved from a MapFile:
      * ALL: all data (as in version 0.6.0)

--- a/mapsforge-map/src/main/java/org/mapsforge/map/datastore/MapDataStore.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/datastore/MapDataStore.java
@@ -253,12 +253,13 @@ public abstract class MapDataStore {
     public abstract boolean supportsTile(Tile tile);
 
     /**
-     * Returns true if MapDatabase covers (even partially) certain area.
+     * Returns true if MapDatabase covers (even partially) certain area in required zoom level.
      *
      * @param boundingBox area we test
+     * @param zoomLevel zoom level we test
      * @return true if area is part of the database.
      */
-    public abstract boolean supportsArea(BoundingBox boundingBox);
+    public abstract boolean supportsArea(BoundingBox boundingBox, byte zoomLevel);
 
     /**
      * Returns true if a way should be included in the result set for readLabels()

--- a/mapsforge-map/src/main/java/org/mapsforge/map/datastore/MapDataStore.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/datastore/MapDataStore.java
@@ -253,6 +253,14 @@ public abstract class MapDataStore {
     public abstract boolean supportsTile(Tile tile);
 
     /**
+     * Returns true if MapDatabase covers (even partially) certain area.
+     *
+     * @param boundingBox area we test
+     * @return true if area is part of the database.
+     */
+    public abstract boolean supportsArea(BoundingBox boundingBox);
+
+    /**
      * Returns true if a way should be included in the result set for readLabels()
      * By default only ways with names, house numbers or a ref are included in the result set
      * of readLabels(). This is to reduce the set of ways as much as possible to save memory.

--- a/mapsforge-map/src/main/java/org/mapsforge/map/datastore/MultiMapDataStore.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/datastore/MultiMapDataStore.java
@@ -162,7 +162,7 @@ public class MultiMapDataStore extends MapDataStore {
         switch (this.dataPolicy) {
             case RETURN_FIRST:
                 for (MapDataStore mdb : mapDatabases) {
-                    if (mdb.supportsTile(upperLeft)) {
+                    if (mdb.supportsArea(upperLeft.getBoundingBox().extendBoundingBox(lowerRight.getBoundingBox()))) {
                         return mdb.readLabels(upperLeft, lowerRight);
                     }
                 }
@@ -179,7 +179,7 @@ public class MultiMapDataStore extends MapDataStore {
     private MapReadResult readLabels(Tile upperLeft, Tile lowerRight, boolean deduplicate) {
         MapReadResult mapReadResult = new MapReadResult();
         for (MapDataStore mdb : mapDatabases) {
-            if (mdb.supportsTile(upperLeft)) {
+            if (mdb.supportsArea(upperLeft.getBoundingBox().extendBoundingBox(lowerRight.getBoundingBox()))) {
                 MapReadResult result = mdb.readLabels(upperLeft, lowerRight);
                 if (result == null) {
                     continue;
@@ -231,7 +231,7 @@ public class MultiMapDataStore extends MapDataStore {
         switch (this.dataPolicy) {
             case RETURN_FIRST:
                 for (MapDataStore mdb : mapDatabases) {
-                    if (mdb.supportsTile(upperLeft)) {
+                    if (mdb.supportsArea(upperLeft.getBoundingBox().extendBoundingBox(lowerRight.getBoundingBox()))) {
                         return mdb.readMapData(upperLeft, lowerRight);
                     }
                 }
@@ -247,7 +247,7 @@ public class MultiMapDataStore extends MapDataStore {
     private MapReadResult readMapData(Tile upperLeft, Tile lowerRight, boolean deduplicate) {
         MapReadResult mapReadResult = new MapReadResult();
         for (MapDataStore mdb : mapDatabases) {
-            if (mdb.supportsTile(upperLeft)) {
+            if (mdb.supportsArea(upperLeft.getBoundingBox().extendBoundingBox(lowerRight.getBoundingBox()))) {
                 MapReadResult result = mdb.readMapData(upperLeft, lowerRight);
                 if (result == null) {
                     continue;
@@ -300,7 +300,7 @@ public class MultiMapDataStore extends MapDataStore {
         switch (this.dataPolicy) {
             case RETURN_FIRST:
                 for (MapDataStore mdb : mapDatabases) {
-                    if (mdb.supportsTile(upperLeft)) {
+                    if (mdb.supportsArea(upperLeft.getBoundingBox().extendBoundingBox(lowerRight.getBoundingBox()))) {
                         return mdb.readPoiData(upperLeft, lowerRight);
                     }
                 }
@@ -317,7 +317,7 @@ public class MultiMapDataStore extends MapDataStore {
     private MapReadResult readPoiData(Tile upperLeft, Tile lowerRight, boolean deduplicate) {
         MapReadResult mapReadResult = new MapReadResult();
         for (MapDataStore mdb : mapDatabases) {
-            if (mdb.supportsTile(upperLeft)) {
+            if (mdb.supportsArea(upperLeft.getBoundingBox().extendBoundingBox(lowerRight.getBoundingBox()))) {
                 MapReadResult result = mdb.readPoiData(upperLeft, lowerRight);
                 if (result == null) {
                     continue;
@@ -358,6 +358,16 @@ public class MultiMapDataStore extends MapDataStore {
     public boolean supportsTile(Tile tile) {
         for (MapDataStore mdb : mapDatabases) {
             if (mdb.supportsTile(tile)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean supportsArea(BoundingBox boundingBox) {
+        for (MapDataStore mdb : mapDatabases) {
+            if (mdb.supportsArea(boundingBox)) {
                 return true;
             }
         }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/datastore/MultiMapDataStore.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/datastore/MultiMapDataStore.java
@@ -162,7 +162,10 @@ public class MultiMapDataStore extends MapDataStore {
         switch (this.dataPolicy) {
             case RETURN_FIRST:
                 for (MapDataStore mdb : mapDatabases) {
-                    if (mdb.supportsArea(upperLeft.getBoundingBox().extendBoundingBox(lowerRight.getBoundingBox()))) {
+                    if (mdb.supportsArea(
+                            upperLeft.getBoundingBox().extendBoundingBox(lowerRight.getBoundingBox()),
+                            upperLeft.zoomLevel
+                    )) {
                         return mdb.readLabels(upperLeft, lowerRight);
                     }
                 }
@@ -179,7 +182,10 @@ public class MultiMapDataStore extends MapDataStore {
     private MapReadResult readLabels(Tile upperLeft, Tile lowerRight, boolean deduplicate) {
         MapReadResult mapReadResult = new MapReadResult();
         for (MapDataStore mdb : mapDatabases) {
-            if (mdb.supportsArea(upperLeft.getBoundingBox().extendBoundingBox(lowerRight.getBoundingBox()))) {
+            if (mdb.supportsArea(
+                    upperLeft.getBoundingBox().extendBoundingBox(lowerRight.getBoundingBox()),
+                    upperLeft.zoomLevel
+            )) {
                 MapReadResult result = mdb.readLabels(upperLeft, lowerRight);
                 if (result == null) {
                     continue;
@@ -231,7 +237,10 @@ public class MultiMapDataStore extends MapDataStore {
         switch (this.dataPolicy) {
             case RETURN_FIRST:
                 for (MapDataStore mdb : mapDatabases) {
-                    if (mdb.supportsArea(upperLeft.getBoundingBox().extendBoundingBox(lowerRight.getBoundingBox()))) {
+                    if (mdb.supportsArea(
+                            upperLeft.getBoundingBox().extendBoundingBox(lowerRight.getBoundingBox()),
+                            upperLeft.zoomLevel
+                    )) {
                         return mdb.readMapData(upperLeft, lowerRight);
                     }
                 }
@@ -247,7 +256,10 @@ public class MultiMapDataStore extends MapDataStore {
     private MapReadResult readMapData(Tile upperLeft, Tile lowerRight, boolean deduplicate) {
         MapReadResult mapReadResult = new MapReadResult();
         for (MapDataStore mdb : mapDatabases) {
-            if (mdb.supportsArea(upperLeft.getBoundingBox().extendBoundingBox(lowerRight.getBoundingBox()))) {
+            if (mdb.supportsArea(
+                    upperLeft.getBoundingBox().extendBoundingBox(lowerRight.getBoundingBox()),
+                    upperLeft.zoomLevel)
+            ) {
                 MapReadResult result = mdb.readMapData(upperLeft, lowerRight);
                 if (result == null) {
                     continue;
@@ -300,7 +312,10 @@ public class MultiMapDataStore extends MapDataStore {
         switch (this.dataPolicy) {
             case RETURN_FIRST:
                 for (MapDataStore mdb : mapDatabases) {
-                    if (mdb.supportsArea(upperLeft.getBoundingBox().extendBoundingBox(lowerRight.getBoundingBox()))) {
+                    if (mdb.supportsArea(
+                            upperLeft.getBoundingBox().extendBoundingBox(lowerRight.getBoundingBox()),
+                            upperLeft.zoomLevel)
+                    ) {
                         return mdb.readPoiData(upperLeft, lowerRight);
                     }
                 }
@@ -317,7 +332,10 @@ public class MultiMapDataStore extends MapDataStore {
     private MapReadResult readPoiData(Tile upperLeft, Tile lowerRight, boolean deduplicate) {
         MapReadResult mapReadResult = new MapReadResult();
         for (MapDataStore mdb : mapDatabases) {
-            if (mdb.supportsArea(upperLeft.getBoundingBox().extendBoundingBox(lowerRight.getBoundingBox()))) {
+            if (mdb.supportsArea(
+                    upperLeft.getBoundingBox().extendBoundingBox(lowerRight.getBoundingBox()),
+                    upperLeft.zoomLevel)
+            ) {
                 MapReadResult result = mdb.readPoiData(upperLeft, lowerRight);
                 if (result == null) {
                     continue;
@@ -365,9 +383,9 @@ public class MultiMapDataStore extends MapDataStore {
     }
 
     @Override
-    public boolean supportsArea(BoundingBox boundingBox) {
+    public boolean supportsArea(BoundingBox boundingBox, byte zoomLevel) {
         for (MapDataStore mdb : mapDatabases) {
-            if (mdb.supportsArea(boundingBox)) {
+            if (mdb.supportsArea(boundingBox, zoomLevel)) {
                 return true;
             }
         }


### PR DESCRIPTION
Recent implementations of the `read` operations in the `MultiMapDataStore` are based on the checking of the upper-left tile only. 

This results in missing data in case of for example low zoom level and multiple maps covered by area defined by "upperLeft" and "lowerRight" tiles.

On the attached screen is an example of "readLabels" results, which should cover the whole screen, but the results are only data from the first DE map.

<img width="244" alt="image" src="https://github.com/user-attachments/assets/30b9d832-deac-4438-9981-81c5008f5c18">
