### PR TITLE
Fix: AWT sample app always requests zoom level zero (0) tiles at startup

### DIFF
--- a/mapsforge-samples-awt/src/main/java/org/mapsforge/samples/awt/Samples.java
+++ b/mapsforge-samples-awt/src/main/java/org/mapsforge/samples/awt/Samples.java
@@ -39,10 +39,10 @@ import org.mapsforge.map.layer.debug.TileGridLayer;
 import org.mapsforge.map.layer.download.TileDownloadLayer;
 import org.mapsforge.map.layer.download.tilesource.OpenStreetMapMapnik;
 import org.mapsforge.map.layer.download.tilesource.TileSource;
+import org.mapsforge.map.layer.hills.AdaptiveClasyHillShading;
 import org.mapsforge.map.layer.hills.DemFolderFS;
 import org.mapsforge.map.layer.hills.HillsRenderConfig;
 import org.mapsforge.map.layer.hills.MemoryCachingHgtReaderTileSource;
-import org.mapsforge.map.layer.hills.StandardClasyHillShading;
 import org.mapsforge.map.layer.renderer.TileRendererLayer;
 import org.mapsforge.map.model.IMapViewPosition;
 import org.mapsforge.map.model.Model;
@@ -84,7 +84,7 @@ public final class Samples {
         final HillsRenderConfig hillsCfg;
         File demFolder = getDemFolder(args);
         if (demFolder != null) {
-            MemoryCachingHgtReaderTileSource tileSource = new MemoryCachingHgtReaderTileSource(new DemFolderFS(demFolder), new StandardClasyHillShading(), AwtGraphicFactory.INSTANCE);
+            MemoryCachingHgtReaderTileSource tileSource = new MemoryCachingHgtReaderTileSource(new DemFolderFS(demFolder), new AdaptiveClasyHillShading(), AwtGraphicFactory.INSTANCE);
             hillsCfg = new HillsRenderConfig(tileSource);
             hillsCfg.indexOnThread();
             args = Arrays.copyOfRange(args, 1, args.length);
@@ -148,7 +148,7 @@ public final class Samples {
             mapView.getModel().displayModel.setFixedTileSize(tileSize);
             OpenStreetMapMapnik tileSource = OpenStreetMapMapnik.INSTANCE;
             tileSource.setUserAgent("mapsforge-samples-awt");
-            TileDownloadLayer tileDownloadLayer = createTileDownloadLayer(tileCache, mapView, mapView.getModel().mapViewPosition, tileSource);
+            TileDownloadLayer tileDownloadLayer = createTileDownloadLayer(tileCache, mapView.getModel().mapViewPosition, tileSource);
             layers.add(tileDownloadLayer);
             tileDownloadLayer.start();
             mapView.setZoomLevelMin(tileSource.getZoomLevelMin());
@@ -161,7 +161,7 @@ public final class Samples {
             for (File file : mapFiles) {
                 mapDataStore.addMapDataStore(new MapFile(file), false, false);
             }
-            TileRendererLayer tileRendererLayer = createTileRendererLayer(tileCache, mapDataStore, mapView, mapView.getModel().mapViewPosition, hillsRenderConfig);
+            TileRendererLayer tileRendererLayer = createTileRendererLayer(tileCache, mapDataStore, mapView.getModel().mapViewPosition, hillsRenderConfig);
             layers.add(tileRendererLayer);
             boundingBox = mapDataStore.boundingBox();
         }
@@ -186,22 +186,22 @@ public final class Samples {
     }
 
     @SuppressWarnings("unused")
-    private static TileDownloadLayer createTileDownloadLayer(TileCache tileCache, MapView mapView, IMapViewPosition mapViewPosition, TileSource tileSource) {
+    private static TileDownloadLayer createTileDownloadLayer(TileCache tileCache, IMapViewPosition mapViewPosition, TileSource tileSource) {
         return new TileDownloadLayer(tileCache, mapViewPosition, tileSource, GRAPHIC_FACTORY) {
             @Override
             public boolean onTap(LatLong tapLatLong, Point layerXY, Point tapXY) {
-                final byte currentZoomLevel = mapView.getModel().mapViewPosition.getZoomLevel();
+                final byte currentZoomLevel = mapViewPosition.getZoomLevel();
                 System.out.println("Tap on: " + tapLatLong + ", zoom level: " + currentZoomLevel);
                 return true;
             }
         };
     }
 
-    private static TileRendererLayer createTileRendererLayer(TileCache tileCache, MapDataStore mapDataStore, MapView mapView, IMapViewPosition mapViewPosition, HillsRenderConfig hillsRenderConfig) {
+    private static TileRendererLayer createTileRendererLayer(TileCache tileCache, MapDataStore mapDataStore, IMapViewPosition mapViewPosition, HillsRenderConfig hillsRenderConfig) {
         TileRendererLayer tileRendererLayer = new TileRendererLayer(tileCache, mapDataStore, mapViewPosition, false, true, false, GRAPHIC_FACTORY, hillsRenderConfig) {
             @Override
             public boolean onTap(LatLong tapLatLong, Point layerXY, Point tapXY) {
-                final byte currentZoomLevel = mapView.getModel().mapViewPosition.getZoomLevel();
+                final byte currentZoomLevel = mapViewPosition.getZoomLevel();
                 System.out.println("Tap on: " + tapLatLong + ", zoom level: " + currentZoomLevel);
                 return true;
             }

--- a/mapsforge-samples-awt/src/main/java/org/mapsforge/samples/awt/Samples.java
+++ b/mapsforge-samples-awt/src/main/java/org/mapsforge/samples/awt/Samples.java
@@ -4,6 +4,7 @@
  * Copyright 2014 Ludwig M Brinckmann
  * Copyright 2014-2022 devemux86
  * Copyright 2017-2022 usrusr
+ * Copyright 2024 Sublimis
  *
  * This program is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
@@ -38,10 +39,10 @@ import org.mapsforge.map.layer.debug.TileGridLayer;
 import org.mapsforge.map.layer.download.TileDownloadLayer;
 import org.mapsforge.map.layer.download.tilesource.OpenStreetMapMapnik;
 import org.mapsforge.map.layer.download.tilesource.TileSource;
-import org.mapsforge.map.layer.hills.StandardClasyHillShading;
 import org.mapsforge.map.layer.hills.DemFolderFS;
 import org.mapsforge.map.layer.hills.HillsRenderConfig;
 import org.mapsforge.map.layer.hills.MemoryCachingHgtReaderTileSource;
+import org.mapsforge.map.layer.hills.StandardClasyHillShading;
 import org.mapsforge.map.layer.renderer.TileRendererLayer;
 import org.mapsforge.map.model.IMapViewPosition;
 import org.mapsforge.map.model.Model;
@@ -49,7 +50,6 @@ import org.mapsforge.map.model.common.PreferencesFacade;
 import org.mapsforge.map.reader.MapFile;
 import org.mapsforge.map.rendertheme.internal.MapsforgeThemes;
 
-import javax.swing.*;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.io.File;
@@ -58,6 +58,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import java.util.prefs.Preferences;
+
+import javax.swing.JFrame;
+import javax.swing.JOptionPane;
+import javax.swing.WindowConstants;
 
 public final class Samples {
     private static final GraphicFactory GRAPHIC_FACTORY = AwtGraphicFactory.INSTANCE;
@@ -77,19 +81,19 @@ public final class Samples {
         // Square frame buffer
         Parameters.SQUARE_FRAME_BUFFER = false;
 
-        HillsRenderConfig hillsCfg = null;
+        final HillsRenderConfig hillsCfg;
         File demFolder = getDemFolder(args);
         if (demFolder != null) {
             MemoryCachingHgtReaderTileSource tileSource = new MemoryCachingHgtReaderTileSource(new DemFolderFS(demFolder), new StandardClasyHillShading(), AwtGraphicFactory.INSTANCE);
-            tileSource.setEnableInterpolationOverlap(true);
             hillsCfg = new HillsRenderConfig(tileSource);
             hillsCfg.indexOnThread();
             args = Arrays.copyOfRange(args, 1, args.length);
+        } else {
+            hillsCfg = null;
         }
 
         List<File> mapFiles = SHOW_RASTER_MAP ? null : getMapFiles(args);
         final MapView mapView = createMapView();
-        final BoundingBox boundingBox = addLayers(mapView, mapFiles, hillsCfg);
 
         final PreferencesFacade preferencesFacade = new JavaPreferences(Preferences.userNodeForPackage(Samples.class));
 
@@ -114,6 +118,7 @@ public final class Samples {
 
             @Override
             public void windowOpened(WindowEvent e) {
+                final BoundingBox boundingBox = addLayers(mapView, mapFiles, hillsCfg);
                 final Model model = mapView.getModel();
                 model.init(preferencesFacade);
                 if (model.mapViewPosition.getZoomLevel() == 0 || !boundingBox.contains(model.mapViewPosition.getCenter())) {
@@ -143,7 +148,7 @@ public final class Samples {
             mapView.getModel().displayModel.setFixedTileSize(tileSize);
             OpenStreetMapMapnik tileSource = OpenStreetMapMapnik.INSTANCE;
             tileSource.setUserAgent("mapsforge-samples-awt");
-            TileDownloadLayer tileDownloadLayer = createTileDownloadLayer(tileCache, mapView.getModel().mapViewPosition, tileSource);
+            TileDownloadLayer tileDownloadLayer = createTileDownloadLayer(tileCache, mapView, mapView.getModel().mapViewPosition, tileSource);
             layers.add(tileDownloadLayer);
             tileDownloadLayer.start();
             mapView.setZoomLevelMin(tileSource.getZoomLevelMin());
@@ -156,7 +161,7 @@ public final class Samples {
             for (File file : mapFiles) {
                 mapDataStore.addMapDataStore(new MapFile(file), false, false);
             }
-            TileRendererLayer tileRendererLayer = createTileRendererLayer(tileCache, mapDataStore, mapView.getModel().mapViewPosition, hillsRenderConfig);
+            TileRendererLayer tileRendererLayer = createTileRendererLayer(tileCache, mapDataStore, mapView, mapView.getModel().mapViewPosition, hillsRenderConfig);
             layers.add(tileRendererLayer);
             boundingBox = mapDataStore.boundingBox();
         }
@@ -181,21 +186,23 @@ public final class Samples {
     }
 
     @SuppressWarnings("unused")
-    private static TileDownloadLayer createTileDownloadLayer(TileCache tileCache, IMapViewPosition mapViewPosition, TileSource tileSource) {
+    private static TileDownloadLayer createTileDownloadLayer(TileCache tileCache, MapView mapView, IMapViewPosition mapViewPosition, TileSource tileSource) {
         return new TileDownloadLayer(tileCache, mapViewPosition, tileSource, GRAPHIC_FACTORY) {
             @Override
             public boolean onTap(LatLong tapLatLong, Point layerXY, Point tapXY) {
-                System.out.println("Tap on: " + tapLatLong);
+                final byte currentZoomLevel = mapView.getModel().mapViewPosition.getZoomLevel();
+                System.out.println("Tap on: " + tapLatLong + ", zoom level: " + currentZoomLevel);
                 return true;
             }
         };
     }
 
-    private static TileRendererLayer createTileRendererLayer(TileCache tileCache, MapDataStore mapDataStore, IMapViewPosition mapViewPosition, HillsRenderConfig hillsRenderConfig) {
+    private static TileRendererLayer createTileRendererLayer(TileCache tileCache, MapDataStore mapDataStore, MapView mapView, IMapViewPosition mapViewPosition, HillsRenderConfig hillsRenderConfig) {
         TileRendererLayer tileRendererLayer = new TileRendererLayer(tileCache, mapDataStore, mapViewPosition, false, true, false, GRAPHIC_FACTORY, hillsRenderConfig) {
             @Override
             public boolean onTap(LatLong tapLatLong, Point layerXY, Point tapXY) {
-                System.out.println("Tap on: " + tapLatLong);
+                final byte currentZoomLevel = mapView.getModel().mapViewPosition.getZoomLevel();
+                System.out.println("Tap on: " + tapLatLong + ", zoom level: " + currentZoomLevel);
                 return true;
             }
         };

--- a/mapsforge-samples-awt/src/main/java/org/mapsforge/samples/awt/Samples.java
+++ b/mapsforge-samples-awt/src/main/java/org/mapsforge/samples/awt/Samples.java
@@ -39,10 +39,10 @@ import org.mapsforge.map.layer.debug.TileGridLayer;
 import org.mapsforge.map.layer.download.TileDownloadLayer;
 import org.mapsforge.map.layer.download.tilesource.OpenStreetMapMapnik;
 import org.mapsforge.map.layer.download.tilesource.TileSource;
-import org.mapsforge.map.layer.hills.AdaptiveClasyHillShading;
 import org.mapsforge.map.layer.hills.DemFolderFS;
 import org.mapsforge.map.layer.hills.HillsRenderConfig;
 import org.mapsforge.map.layer.hills.MemoryCachingHgtReaderTileSource;
+import org.mapsforge.map.layer.hills.StandardClasyHillShading;
 import org.mapsforge.map.layer.renderer.TileRendererLayer;
 import org.mapsforge.map.model.IMapViewPosition;
 import org.mapsforge.map.model.Model;
@@ -84,7 +84,7 @@ public final class Samples {
         final HillsRenderConfig hillsCfg;
         File demFolder = getDemFolder(args);
         if (demFolder != null) {
-            MemoryCachingHgtReaderTileSource tileSource = new MemoryCachingHgtReaderTileSource(new DemFolderFS(demFolder), new AdaptiveClasyHillShading(), AwtGraphicFactory.INSTANCE);
+            MemoryCachingHgtReaderTileSource tileSource = new MemoryCachingHgtReaderTileSource(new DemFolderFS(demFolder), new StandardClasyHillShading(), AwtGraphicFactory.INSTANCE);
             hillsCfg = new HillsRenderConfig(tileSource);
             hillsCfg.indexOnThread();
             args = Arrays.copyOfRange(args, 1, args.length);


### PR DESCRIPTION
* Fix: AWT sample app always requests zoom level zero (0) tiles at startup, regardless of the actual initial zoom level
* Print zoom level on tap (in addition to lat/lon)