### PR TITLE
Fix: DEM ZipFile-s not being closed

### DIFF
--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/DemFileZipEntryFS.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/DemFileZipEntryFS.java
@@ -15,6 +15,7 @@
 package org.mapsforge.map.layer.hills;
 
 import java.io.BufferedInputStream;
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -23,31 +24,36 @@ import java.util.zip.ZipFile;
 
 public class DemFileZipEntryFS implements DemFile {
 
-    protected final ZipFile zipFile;
-    protected final ZipEntry zipEntry;
+    protected final File mFile;
+    protected final String mZipEntryName;
+    protected final long mZipEntrySize;
 
-    public DemFileZipEntryFS(ZipFile zipFile, ZipEntry zipEntry) {
-        this.zipFile = zipFile;
-        this.zipEntry = zipEntry;
+    public DemFileZipEntryFS(File zipFile, String zipEntry, long zipEntrySize) {
+        mFile = zipFile;
+        mZipEntryName = zipEntry;
+        mZipEntrySize = zipEntrySize;
     }
 
     @Override
     public String getName() {
-        return zipEntry.getName();
+        return mZipEntryName;
     }
 
     @Override
     public long getSize() {
-        return zipEntry.getSize();
+        return mZipEntrySize;
     }
 
     @Override
     public InputStream openInputStream() throws FileNotFoundException {
         try {
+            final ZipFile zipFile = new ZipFile(mFile);
+            final ZipEntry zipEntry = zipFile.getEntry(mZipEntryName);
+
             // Buffer size is relatively small to reduce wasteful read-ahead (buffer fill) during multi-threaded processing
-            return new BufferedInputStream(zipFile.getInputStream(zipEntry), 512);
+            return new BufferedInputStream(new DemZipInputStream(zipFile, zipEntry), 512);
         } catch (IOException e) {
-            throw new FileNotFoundException(zipFile.getName() + " (" + zipEntry.getName() + ")");
+            throw new FileNotFoundException(mFile + " (" + mZipEntryName + ")");
         }
     }
 

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/DemFileZipEntryFS.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/DemFileZipEntryFS.java
@@ -24,36 +24,36 @@ import java.util.zip.ZipFile;
 
 public class DemFileZipEntryFS implements DemFile {
 
-    protected final File mFile;
-    protected final String mZipEntryName;
-    protected final long mZipEntrySize;
+    protected final File zipFile;
+    protected final String zipEntryName;
+    protected final long zipEntrySize;
 
     public DemFileZipEntryFS(File zipFile, String zipEntry, long zipEntrySize) {
-        mFile = zipFile;
-        mZipEntryName = zipEntry;
-        mZipEntrySize = zipEntrySize;
+        this.zipFile = zipFile;
+        this.zipEntryName = zipEntry;
+        this.zipEntrySize = zipEntrySize;
     }
 
     @Override
     public String getName() {
-        return mZipEntryName;
+        return zipEntryName;
     }
 
     @Override
     public long getSize() {
-        return mZipEntrySize;
+        return zipEntrySize;
     }
 
     @Override
     public InputStream openInputStream() throws FileNotFoundException {
         try {
-            final ZipFile zipFile = new ZipFile(mFile);
-            final ZipEntry zipEntry = zipFile.getEntry(mZipEntryName);
+            final ZipFile zipFile = new ZipFile(this.zipFile);
+            final ZipEntry zipEntry = zipFile.getEntry(zipEntryName);
 
             // Buffer size is relatively small to reduce wasteful read-ahead (buffer fill) during multi-threaded processing
             return new BufferedInputStream(new DemZipInputStream(zipFile, zipEntry), 512);
         } catch (IOException e) {
-            throw new FileNotFoundException(mFile + " (" + mZipEntryName + ")");
+            throw new FileNotFoundException(zipFile + " (" + zipEntryName + ")");
         }
     }
 

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/DemFileZipEntryFS.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/DemFileZipEntryFS.java
@@ -28,9 +28,9 @@ public class DemFileZipEntryFS implements DemFile {
     protected final String zipEntryName;
     protected final long zipEntrySize;
 
-    public DemFileZipEntryFS(File zipFile, String zipEntry, long zipEntrySize) {
+    public DemFileZipEntryFS(File zipFile, String zipEntryName, long zipEntrySize) {
         this.zipFile = zipFile;
-        this.zipEntryName = zipEntry;
+        this.zipEntryName = zipEntryName;
         this.zipEntrySize = zipEntrySize;
     }
 

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/DemFolderFS.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/DemFolderFS.java
@@ -21,9 +21,9 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.logging.Level;
-import java.util.zip.ZipFile;
 
 public class DemFolderFS implements DemFolder {
+
     public final File file;
 
     public DemFolderFS(File file) {
@@ -56,7 +56,7 @@ public class DemFolderFS implements DemFolder {
                         DemFolder ret = null;
                         if (HgtCache.isFileZip(nextFile)) {
                             try {
-                                ret = new DemFolderZipFS(new ZipFile(nextFile));
+                                ret = new DemFolderZipFS(nextFile);
                             } catch (IOException e) {
                                 LOGGER.log(Level.WARNING, e.toString());
                             }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/DemFolderZipFS.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/DemFolderZipFS.java
@@ -14,18 +14,22 @@
  */
 package org.mapsforge.map.layer.hills;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.logging.Level;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
 public class DemFolderZipFS implements DemFolder {
-    protected final ZipFile zipFile;
 
-    public DemFolderZipFS(ZipFile zipFile) {
-        this.zipFile = zipFile;
+    protected final File mZipFile;
+
+    public DemFolderZipFS(File zipFile) throws IOException {
+        mZipFile = zipFile;
     }
 
     @Override
@@ -35,16 +39,20 @@ public class DemFolderZipFS implements DemFolder {
 
     @Override
     public Iterable<DemFile> files() {
-        final Enumeration<? extends ZipEntry> entries = zipFile.entries();
-
         final List<DemFile> items = new ArrayList<>();
 
-        ZipEntry zipEntry;
+        try (ZipFile zipFile = new ZipFile(mZipFile)) {
+            final Enumeration<? extends ZipEntry> entries = zipFile.entries();
 
-        while (entries.hasMoreElements() && (zipEntry = entries.nextElement()) != null) {
-            if (false == zipEntry.isDirectory()) {
-                items.add(new DemFileZipEntryFS(zipFile, zipEntry));
+            ZipEntry zipEntry;
+
+            while (entries.hasMoreElements() && (zipEntry = entries.nextElement()) != null) {
+                if (false == zipEntry.isDirectory()) {
+                    items.add(new DemFileZipEntryFS(mZipFile, zipEntry.getName(), zipEntry.getSize()));
+                }
             }
+        } catch (IOException e) {
+            LOGGER.log(Level.WARNING, e.toString());
         }
 
         return items;
@@ -56,6 +64,6 @@ public class DemFolderZipFS implements DemFolder {
         if (!(obj instanceof DemFolderZipFS)) {
             return false;
         }
-        return zipFile.equals(((DemFolderZipFS) obj).zipFile);
+        return mZipFile.equals(((DemFolderZipFS) obj).mZipFile);
     }
 }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/DemFolderZipFS.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/DemFolderZipFS.java
@@ -26,10 +26,10 @@ import java.util.zip.ZipFile;
 
 public class DemFolderZipFS implements DemFolder {
 
-    protected final File mZipFile;
+    protected final File zipFile;
 
     public DemFolderZipFS(File zipFile) throws IOException {
-        mZipFile = zipFile;
+        this.zipFile = zipFile;
     }
 
     @Override
@@ -41,14 +41,14 @@ public class DemFolderZipFS implements DemFolder {
     public Iterable<DemFile> files() {
         final List<DemFile> items = new ArrayList<>();
 
-        try (ZipFile zipFile = new ZipFile(mZipFile)) {
+        try (ZipFile zipFile = new ZipFile(this.zipFile)) {
             final Enumeration<? extends ZipEntry> entries = zipFile.entries();
 
             ZipEntry zipEntry;
 
             while (entries.hasMoreElements() && (zipEntry = entries.nextElement()) != null) {
                 if (false == zipEntry.isDirectory()) {
-                    items.add(new DemFileZipEntryFS(mZipFile, zipEntry.getName(), zipEntry.getSize()));
+                    items.add(new DemFileZipEntryFS(this.zipFile, zipEntry.getName(), zipEntry.getSize()));
                 }
             }
         } catch (IOException e) {
@@ -64,6 +64,6 @@ public class DemFolderZipFS implements DemFolder {
         if (!(obj instanceof DemFolderZipFS)) {
             return false;
         }
-        return mZipFile.equals(((DemFolderZipFS) obj).mZipFile);
+        return zipFile.equals(((DemFolderZipFS) obj).zipFile);
     }
 }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/DemZipInputStream.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/DemZipInputStream.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2024 Sublimis
+ *
+ * This program is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.mapsforge.map.layer.hills;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+public class DemZipInputStream extends InputStream {
+
+    protected final ZipFile mZipFile;
+    protected final InputStream mZipInputStream;
+
+    public DemZipInputStream(ZipFile zipFile, ZipEntry zipEntry) throws IOException {
+        mZipFile = zipFile;
+        mZipInputStream = zipFile.getInputStream(zipEntry);
+    }
+
+    public void close() throws IOException {
+        mZipInputStream.close();
+        mZipFile.close();
+    }
+
+    public int read() throws IOException {
+        return mZipInputStream.read();
+    }
+
+    public int read(byte[] bytes) throws IOException {
+        return mZipInputStream.read(bytes);
+    }
+
+    public int read(byte[] bytes, int i, int i1) throws IOException {
+        return mZipInputStream.read(bytes, i, i1);
+    }
+
+    public long skip(long l) throws IOException {
+        return mZipInputStream.skip(l);
+    }
+
+    public int available() throws IOException {
+        return mZipInputStream.available();
+    }
+
+    public void mark(int i) {
+        mZipInputStream.mark(i);
+    }
+
+    public void reset() throws IOException {
+        mZipInputStream.reset();
+    }
+
+    public boolean markSupported() {
+        return mZipInputStream.markSupported();
+    }
+
+    // TODO (2024-11): Methods below must wait for Java 9/12
+//    public byte[] readAllBytes() throws IOException {
+//        return mZipInputStream.readAllBytes();
+//    }
+//
+//    public byte[] readNBytes(int i) throws IOException {
+//        return mZipInputStream.readNBytes(i);
+//    }
+//
+//    public int readNBytes(byte[] bytes, int i, int i1) throws IOException {
+//        return mZipInputStream.readNBytes(bytes, i, i1);
+//    }
+//
+//    public void skipNBytes(long l) throws IOException {
+//        mZipInputStream.skipNBytes(l);
+//    }
+//
+//    public long transferTo(OutputStream outputStream) throws IOException {
+//        return mZipInputStream.transferTo(outputStream);
+//    }
+}

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/DemZipInputStream.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/DemZipInputStream.java
@@ -21,69 +21,69 @@ import java.util.zip.ZipFile;
 
 public class DemZipInputStream extends InputStream {
 
-    protected final ZipFile mZipFile;
-    protected final InputStream mZipInputStream;
+    protected final ZipFile zipFile;
+    protected final InputStream zipInputStream;
 
     public DemZipInputStream(ZipFile zipFile, ZipEntry zipEntry) throws IOException {
-        mZipFile = zipFile;
-        mZipInputStream = zipFile.getInputStream(zipEntry);
+        this.zipFile = zipFile;
+        this.zipInputStream = zipFile.getInputStream(zipEntry);
     }
 
     public void close() throws IOException {
-        mZipInputStream.close();
-        mZipFile.close();
+        zipInputStream.close();
+        zipFile.close();
     }
 
     public int read() throws IOException {
-        return mZipInputStream.read();
+        return zipInputStream.read();
     }
 
     public int read(byte[] bytes) throws IOException {
-        return mZipInputStream.read(bytes);
+        return zipInputStream.read(bytes);
     }
 
     public int read(byte[] bytes, int i, int i1) throws IOException {
-        return mZipInputStream.read(bytes, i, i1);
+        return zipInputStream.read(bytes, i, i1);
     }
 
     public long skip(long l) throws IOException {
-        return mZipInputStream.skip(l);
+        return zipInputStream.skip(l);
     }
 
     public int available() throws IOException {
-        return mZipInputStream.available();
+        return zipInputStream.available();
     }
 
     public void mark(int i) {
-        mZipInputStream.mark(i);
+        zipInputStream.mark(i);
     }
 
     public void reset() throws IOException {
-        mZipInputStream.reset();
+        zipInputStream.reset();
     }
 
     public boolean markSupported() {
-        return mZipInputStream.markSupported();
+        return zipInputStream.markSupported();
     }
 
     // TODO (2024-11): Methods below must wait for Java 9/12
 //    public byte[] readAllBytes() throws IOException {
-//        return mZipInputStream.readAllBytes();
+//        return zipInputStream.readAllBytes();
 //    }
 //
 //    public byte[] readNBytes(int i) throws IOException {
-//        return mZipInputStream.readNBytes(i);
+//        return zipInputStream.readNBytes(i);
 //    }
 //
 //    public int readNBytes(byte[] bytes, int i, int i1) throws IOException {
-//        return mZipInputStream.readNBytes(bytes, i, i1);
+//        return zipInputStream.readNBytes(bytes, i, i1);
 //    }
 //
 //    public void skipNBytes(long l) throws IOException {
-//        mZipInputStream.skipNBytes(l);
+//        zipInputStream.skipNBytes(l);
 //    }
 //
 //    public long transferTo(OutputStream outputStream) throws IOException {
-//        return mZipInputStream.transferTo(outputStream);
+//        return zipInputStream.transferTo(outputStream);
 //    }
 }


### PR DESCRIPTION
This caused a memory leak observed on desktop (wasn't tested on Android). The leak becomes apparent when many HGT files are used for hill shading.