### PR TITLE
Fix: Labels & co.

### DIFF
--- a/mapsforge-core/src/main/java/org/mapsforge/core/graphics/Paint.java
+++ b/mapsforge-core/src/main/java/org/mapsforge/core/graphics/Paint.java
@@ -2,6 +2,7 @@
  * Copyright 2010, 2011, 2012, 2013 mapsforge.org
  * Copyright 2014 Ludwig M Brinckmann
  * Copyright 2016-2017 devemux86
+ * Copyright 2024 Sublimis
  *
  * This program is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
@@ -25,7 +26,39 @@ public interface Paint {
 
     int getTextHeight(String text);
 
+    default int getTextHeight(final String text, boolean includePadding) {
+        int retVal = 0;
+
+        retVal = getTextHeight(text);
+
+        if (includePadding && retVal > 0) {
+            retVal += getFontPadding();
+        }
+
+        return retVal;
+    }
+
     int getTextWidth(String text);
+
+    default int getTextWidth(String text, boolean includePadding) {
+        int retVal = 0;
+
+        retVal = getTextWidth(text);
+
+        if (includePadding && retVal > 0) {
+            retVal += getFontPadding();
+        }
+
+        return retVal;
+    }
+
+    default int getTextWidth(final String text, final int widthMax, boolean includePadding) {
+        return getTextWidth(text);
+    }
+
+    default int getFontPadding() {
+        return 0;
+    }
 
     boolean isTransparent();
 

--- a/mapsforge-core/src/main/java/org/mapsforge/core/mapelements/MapElementContainer.java
+++ b/mapsforge-core/src/main/java/org/mapsforge/core/mapelements/MapElementContainer.java
@@ -1,6 +1,7 @@
 /*
  * Copyright 2014 Ludwig M Brinckmann
  * Copyright 2016 devemux86
+ * Copyright 2024 Sublimis
  *
  * This program is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
@@ -36,7 +37,6 @@ import org.mapsforge.core.model.Rotation;
  * drawn.
  */
 public abstract class MapElementContainer implements Comparable<MapElementContainer> {
-    protected Rectangle boundary;
     protected Rectangle boundaryAbsolute;
     protected Display display;
     protected final int priority;
@@ -47,6 +47,8 @@ public abstract class MapElementContainer implements Comparable<MapElementContai
         this.display = display;
         this.priority = priority;
     }
+
+    protected abstract Rectangle getBoundary();
 
     /**
      * Compares elements according to their priority.
@@ -94,7 +96,7 @@ public abstract class MapElementContainer implements Comparable<MapElementContai
      */
     protected Rectangle getBoundaryAbsolute() {
         if (boundaryAbsolute == null) {
-            boundaryAbsolute = this.boundary.shift(xy);
+            boundaryAbsolute = this.getBoundary().shift(xy);
         }
         return boundaryAbsolute;
     }

--- a/mapsforge-core/src/main/java/org/mapsforge/core/mapelements/PointTextContainer.java
+++ b/mapsforge-core/src/main/java/org/mapsforge/core/mapelements/PointTextContainer.java
@@ -25,6 +25,8 @@ import org.mapsforge.core.model.Rotation;
 
 public abstract class PointTextContainer extends MapElementContainer {
 
+    protected static final boolean DEBUG_CLASH_BOUNDS = false;
+
     public final double horizontalOffset;
     public final boolean isVisible;
     public final int maxTextWidth;
@@ -33,9 +35,9 @@ public abstract class PointTextContainer extends MapElementContainer {
     public final Position position;
     public final SymbolContainer symbolContainer;
     public final String text;
-    public final int textHeight;
-    public final int textWidth;
     public final double verticalOffset;
+    public volatile double clashRotationDegrees;
+    public volatile Rectangle clashRect;
 
     /**
      * Create a new point container, that holds the x-y coordinates of a point, a text variable, two paint objects, and
@@ -52,13 +54,6 @@ public abstract class PointTextContainer extends MapElementContainer {
         this.paintFront = paintFront;
         this.paintBack = paintBack;
         this.position = position;
-        if (paintBack != null) {
-            this.textWidth = paintBack.getTextWidth(text);
-            this.textHeight = paintBack.getTextHeight(text);
-        } else {
-            this.textWidth = paintFront.getTextWidth(text);
-            this.textHeight = paintFront.getTextHeight(text);
-        }
         this.horizontalOffset = horizontalOffset;
         this.verticalOffset = verticalOffset;
         this.isVisible = !this.paintFront.isTransparent() || (this.paintBack != null && !this.paintBack.isTransparent());
@@ -72,18 +67,21 @@ public abstract class PointTextContainer extends MapElementContainer {
         if (!(other instanceof PointTextContainer)) {
             return false;
         }
+
         PointTextContainer ptc = (PointTextContainer) other;
-        if (!Rotation.noRotation(rotation)) {
-            Rotation mapRotation = new Rotation(rotation.degrees, (float) this.xy.x, (float) this.xy.y);
-            Rectangle rotated = mapRotation.rotate(this.boundary.shift(xy));
-            Rotation otherRotation = new Rotation(rotation.degrees, (float) ptc.xy.x, (float) ptc.xy.y);
-            Rectangle otherRotated = otherRotation.rotate(ptc.boundary.shift(ptc.xy));
-            if (rotated.intersects(otherRotated))
+
+        if (!Rotation.noRotation(rotation) || DEBUG_CLASH_BOUNDS) {
+            Rectangle rect1 = getClashRect(this, rotation);
+            Rectangle rect2 = getClashRect(ptc, rotation);
+
+            if (rect1 != null && rect2 != null && rect1.intersects(rect2)) {
                 return true;
+            }
         }
         if (this.text.equals(ptc.text) && this.xy.distance(ptc.xy) < 200) {
             return true;
         }
+
         return false;
     }
 
@@ -127,5 +125,157 @@ public abstract class PointTextContainer extends MapElementContainer {
         stringBuilder.append(", text=");
         stringBuilder.append(this.text);
         return stringBuilder.toString();
+    }
+
+    /**
+     * @return New rotated x,y position of the container relative to the origin point
+     */
+    protected Point getRotRelPosition(double originX, double originY, Rotation rotation) {
+        return getRotRelPosition(this, originX, originY, rotation);
+    }
+
+    /**
+     * @return New rotated x,y position of the container relative to the origin point
+     */
+    public static Point getRotRelPosition(PointTextContainer pointTextContainer, double originX, double originY, Rotation rotation) {
+        double x = pointTextContainer.xy.x - originX;
+        double y = pointTextContainer.xy.y - originY;
+
+        if (!Rotation.noRotation(rotation)) {
+            Point rotated = rotation.rotate(x, y, true);
+            x = rotated.x;
+            y = rotated.y;
+        }
+
+        // The offsets can only be applied after rotation
+        x += pointTextContainer.horizontalOffset + pointTextContainer.getBoundary().left;
+        y += pointTextContainer.verticalOffset + pointTextContainer.getBoundary().top;
+
+        return new Point(x, y);
+    }
+
+    /**
+     * See org.mapsforge.map.rendertheme.renderinstruction.Caption#Caption,
+     * org.mapsforge.map.android.graphics.AndroidPointTextContainer#AndroidPointTextContainer,
+     * or org.mapsforge.map.awt.graphics.AwtPointTextContainer#AwtPointTextContainer.
+     *
+     * @return Clash rectangle in absolute coordinate space
+     */
+    public static Rectangle getClashRect(PointTextContainer pointTextContainer, Rotation rotation) {
+        if (!pointTextContainer.isVisible) {
+            return null;
+        }
+
+        // All other fields used are final (read only)
+        if (rotation.degrees == pointTextContainer.clashRotationDegrees && pointTextContainer.clashRect != null) {
+            return pointTextContainer.clashRect;
+        }
+
+        final Rotation newRotation = new Rotation(rotation.degrees, 0, 0);
+
+        // We work in the absolute coordinate space of the map (intentionally)
+        double x = pointTextContainer.xy.x;
+        double y = pointTextContainer.xy.y;
+
+        if (!Rotation.noRotation(newRotation)) {
+            Point rotated = newRotation.rotate(x, y, true);
+            x = rotated.x;
+            y = rotated.y;
+        }
+
+        // The offsets can only be applied after rotation
+        x += pointTextContainer.horizontalOffset;
+        y += pointTextContainer.verticalOffset;
+
+        double textOffsetX, textOffsetY;
+
+        // Implementation of the constructors mentioned above allows such use of boundary dimensions
+        textOffsetX = pointTextContainer.getBoundary().getWidth();
+        textOffsetY = pointTextContainer.getBoundary().getHeight();
+
+        final Rectangle output;
+
+        switch (pointTextContainer.position) {
+            case CENTER:
+            default:
+                // Text is positioned centered on x,y
+                textOffsetX /= 2;
+                textOffsetY /= 2;
+                output = new Rectangle(x - textOffsetX, y - textOffsetY, x + textOffsetX, y + textOffsetY);
+                break;
+            case BELOW:
+                // Text is positioned centered-below x,y
+                textOffsetX /= 2;
+                output = new Rectangle(x - textOffsetX, y, x + textOffsetX, y + textOffsetY);
+                break;
+            case ABOVE:
+                // Text is positioned centered-above x,y
+                textOffsetX /= 2;
+                output = new Rectangle(x - textOffsetX, y - textOffsetY, x + textOffsetX, y);
+                break;
+            case BELOW_LEFT:
+                // Text is positioned below-left of x,y
+                output = new Rectangle(x - textOffsetX, y, x, y + textOffsetY);
+                break;
+            case ABOVE_LEFT:
+                // Text is positioned above-left of x,y
+                output = new Rectangle(x - textOffsetX, y - textOffsetY, x, y);
+                break;
+            case LEFT:
+                // Text is positioned centered-left of x,y
+                textOffsetY /= 2;
+                output = new Rectangle(x - textOffsetX, y - textOffsetY, x, y + textOffsetY);
+                break;
+            case BELOW_RIGHT:
+                // Text is positioned below-right of x,y
+                output = new Rectangle(x, y, x + textOffsetX, y + textOffsetY);
+                break;
+            case ABOVE_RIGHT:
+                // Text is positioned above-right of x,y
+                output = new Rectangle(x, y - textOffsetY, x + textOffsetX, y);
+                break;
+            case RIGHT:
+                // Text is positioned centered-right of x,y
+                textOffsetY /= 2;
+                output = new Rectangle(x, y - textOffsetY, x + textOffsetX, y + textOffsetY);
+                break;
+        }
+
+        pointTextContainer.clashRect = output;
+        pointTextContainer.clashRotationDegrees = newRotation.degrees;
+
+        return output;
+    }
+
+    /**
+     * Mainly used for debugging purposes.
+     *
+     * @return Clash rectangle transformed back to label space
+     */
+    public static Rectangle getClashRectTransformed(PointTextContainer pointTextContainer, double originX, double originY, Rotation rotation) {
+        Rectangle output = null;
+
+        final Rectangle clashBounds = pointTextContainer.clashRect;
+
+        if (clashBounds != null) {
+            final Rotation myRotation = new Rotation(rotation.degrees, 0, 0);
+
+            // "Undo" clash rectangle offset
+            Rectangle rect1 = clashBounds.shift(new Point(-pointTextContainer.horizontalOffset, -pointTextContainer.verticalOffset));
+
+            // "Undo" clash rectangle rotation
+            Point lt = myRotation.rotate(rect1.left, rect1.top, false);
+            Point rb = myRotation.rotate(rect1.right, rect1.bottom, false);
+
+            // Imitate drawing clash rectangle as a label
+            Point lt2 = lt.offset(-originX, -originY);
+            Point rb2 = rb.offset(-originX, -originY);
+            Point lt3 = rotation.rotate(lt2, true);
+            Point rb3 = rotation.rotate(rb2, true);
+            Rectangle rect2 = new Rectangle(lt3.x, lt3.y, rb3.x, rb3.y);
+            output = rect2.shift(new Point(pointTextContainer.horizontalOffset, pointTextContainer.verticalOffset));
+        }
+
+        return output;
     }
 }

--- a/mapsforge-core/src/main/java/org/mapsforge/core/mapelements/SymbolContainer.java
+++ b/mapsforge-core/src/main/java/org/mapsforge/core/mapelements/SymbolContainer.java
@@ -3,6 +3,7 @@
  * Copyright 2014 Ludwig M Brinckmann
  * Copyright 2015-2016 devemux86
  * Copyright 2020 Adrian Batzill
+ * Copyright 2024 Sublimis
  *
  * This program is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
@@ -26,6 +27,7 @@ import org.mapsforge.core.model.Rectangle;
 import org.mapsforge.core.model.Rotation;
 
 public class SymbolContainer extends MapElementContainer {
+    protected final Rectangle boundary;
     public final boolean alignCanvas; // if it has a fixed angle to canvas.
     public Bitmap symbol;
     public final float theta;
@@ -39,14 +41,20 @@ public class SymbolContainer extends MapElementContainer {
         this.symbol = symbol;
         this.theta = theta;
         this.alignCanvas = alignCanvas;
-        this.boundary = boundary;
-        if (this.boundary == null) {
+        if (boundary != null) {
+            this.boundary = boundary;
+        } else {
             double halfWidth = this.symbol.getWidth() / 2d;
             double halfHeight = this.symbol.getHeight() / 2d;
             this.boundary = new Rectangle(-halfWidth, -halfHeight, halfWidth, halfHeight);
         }
 
         this.symbol.incrementRefCount();
+    }
+
+    @Override
+    protected Rectangle getBoundary() {
+        return boundary;
     }
 
     @Override

--- a/mapsforge-core/src/main/java/org/mapsforge/core/mapelements/WayTextContainer.java
+++ b/mapsforge-core/src/main/java/org/mapsforge/core/mapelements/WayTextContainer.java
@@ -3,6 +3,7 @@
  * Copyright 2014 Ludwig M Brinckmann
  * Copyright 2016 devemux86
  * Copyright 2019 Adrian Batzill
+ * Copyright 2024 Sublimis
  *
  * This program is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
@@ -21,10 +22,12 @@ import org.mapsforge.core.graphics.*;
 import org.mapsforge.core.model.LineSegment;
 import org.mapsforge.core.model.LineString;
 import org.mapsforge.core.model.Point;
+import org.mapsforge.core.model.Rectangle;
 import org.mapsforge.core.model.Rotation;
 
 public class WayTextContainer extends MapElementContainer {
     private final GraphicFactory graphicFactory;
+    protected final Rectangle boundary;
     private final LineString lineString;
     private final Paint paintFront;
     private final Paint paintBack;
@@ -46,6 +49,11 @@ public class WayTextContainer extends MapElementContainer {
         // not correctly reflect the size of the text on screen
         this.boundaryAbsolute = lineString.getBounds().enlarge(textHeight / 2d, textHeight / 2d, textHeight / 2d, textHeight / 2d);
         this.textOrientation = textOrientation;
+    }
+
+    @Override
+    protected Rectangle getBoundary() {
+        return boundary;
     }
 
     @Override

--- a/mapsforge-map-android/build.gradle
+++ b/mapsforge-map-android/build.gradle
@@ -1,7 +1,9 @@
-apply plugin: 'java-library'
+apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'
 
 dependencies {
+    testImplementation "junit:junit:4.13.2"
+    testImplementation 'org.robolectric:robolectric:4.14.1'
     compileOnly files("${System.env.ANDROID_HOME}/platforms/android-${androidCompileSdk()}/android.jar")
     api project(":mapsforge-map-reader")
     api 'com.caverock:androidsvg:1.4'
@@ -9,8 +11,14 @@ dependencies {
 
 publishing {
     publications {
-        maven(MavenPublication) {
-            from components.java
+        release(MavenPublication) {
+            groupId = group()
+            artifactId = 'mapsforge-map-android'
+            version = getVersion()
+
+            afterEvaluate {
+                from components.release
+            }
         }
     }
 }
@@ -23,4 +31,15 @@ if (project.hasProperty("SONATYPE_USERNAME")) {
 
 if (System.getenv('ANDROID_HOME') == null) {
     throw new GradleException("Environment variable ANDROID_HOME needs to be set to SDK folder")
+}
+
+android {
+    namespace 'org.mapsforge.map.android'
+    compileSdk androidCompileSdk()
+
+    publishing {
+        singleVariant('release') {
+            withSourcesJar()
+        }
+    }
 }

--- a/mapsforge-map-android/src/test/java/org/mapsforge/map/android/graphics/AndroidPointTextContainerTest.java
+++ b/mapsforge-map-android/src/test/java/org/mapsforge/map/android/graphics/AndroidPointTextContainerTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2024 Sublimis
+ *
+ * This program is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.mapsforge.map.android.graphics;
+
+import android.graphics.Bitmap;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapsforge.core.graphics.Color;
+import org.mapsforge.core.graphics.Display;
+import org.mapsforge.core.graphics.Paint;
+import org.mapsforge.core.graphics.Position;
+import org.mapsforge.core.model.Point;
+import org.mapsforge.core.model.Rectangle;
+import org.mapsforge.core.model.Rotation;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class AndroidPointTextContainerTest {
+
+    @Test
+    public void testLabelClashBounds() {
+        final double Delta = 0.0001;
+
+        // Some paint
+        final Paint paint = new AndroidPaint();
+        // Need to set some fields for clashRect to be generated
+        paint.setColor(Color.BLACK);
+        paint.setBitmapShader(new AndroidBitmap(1, 1, Bitmap.Config.ARGB_8888));
+
+        // Some rotation
+        final Rotation rotation = new Rotation(37, 115, 93);
+
+        // Some container ("label") positioned ABOVE
+        final AndroidPointTextContainer container = new AndroidPointTextContainer(new Point(211, 143), 9, 17, Display.ALWAYS, 5, "some label", paint, null, null, Position.ABOVE, 150);
+
+        // Some origin
+        final Point origin = new Point(17, 19);
+
+        // Imitate drawing the label
+        final Point labelPosition = AndroidPointTextContainer.getRotRelPosition(container, origin.x, origin.y, rotation);
+        // Coordinates are chosen for the ABOVE position
+        final Rectangle labelRect = new Rectangle(labelPosition.x, labelPosition.y, labelPosition.x + container.boundary.getWidth(), labelPosition.y + container.boundary.getHeight());
+
+        // Create the clash rectangle
+        final Rectangle clashRect = AndroidPointTextContainer.getClashRect(container, rotation);
+
+        assert clashRect != null;
+
+        // Imitate drawing the clash rectangle as a label
+        final Rectangle clashRectAsLabel = AndroidPointTextContainer.getClashRectTransformed(container, origin.x, origin.y, rotation);
+
+        Assert.assertEquals("Label and clash rect centers do not match!", labelRect.getCenterX(), clashRectAsLabel.getCenterX(), Delta);
+        Assert.assertEquals("Label and clash rect widths not equal!", labelRect.getWidth(), clashRectAsLabel.getWidth(), Delta);
+        Assert.assertEquals("Label and clash rect heights not equal!", labelRect.getHeight(), clashRectAsLabel.getHeight(), Delta);
+    }
+
+    @Test
+    public void testLabelsClash() {
+        final double Delta = 0.0001;
+
+        // Some paint
+        final Paint paint = new AndroidPaint();
+        // Need to set some fields for clashRect to be generated
+        paint.setColor(Color.BLACK);
+        paint.setBitmapShader(new AndroidBitmap(1, 1, Bitmap.Config.ARGB_8888));
+        paint.setTextSize(15);
+
+        // Some rotation
+        final Rotation rotation = new Rotation(37, 115, 93);
+
+        // Single-line
+        {
+            // Some containers ("labels") positioned ABOVE
+            final AndroidPointTextContainer container1 = new AndroidPointTextContainer(new Point(211, 143), 9, 17, Display.ALWAYS, 5, "12345 67890", paint, null, null, Position.ABOVE, 150);
+            final AndroidPointTextContainer container2 = new AndroidPointTextContainer(new Point(207, 140), 9, 17, Display.ALWAYS, 5, "12345 67890", paint, null, null, Position.ABOVE, 150);
+
+            assert !container1.isMultiline;
+            assert !container2.isMultiline;
+
+            // Create the clash rectangles
+            Rectangle clashRect1 = AndroidPointTextContainer.getClashRect(container1, rotation);
+            Rectangle clashRect2 = AndroidPointTextContainer.getClashRect(container2, rotation);
+
+            assert clashRect1 != null;
+            assert clashRect2 != null;
+
+            // Only during testing it happens that clash rectangles have zero height
+            if (clashRect1.getHeight() < Delta || clashRect2.getHeight() < Delta) {
+                clashRect1 = clashRect1.enlarge(0, 0, 0, 50);
+                clashRect2 = clashRect2.enlarge(0, 0, 0, 50);
+            }
+
+            Assert.assertTrue("Labels do not clash, but they should (single line).", clashRect1.intersects(clashRect2));
+        }
+
+        // Multi-line
+        {
+            // Some containers ("labels") positioned ABOVE
+            final AndroidPointTextContainer container1 = new AndroidPointTextContainer(new Point(211, 143), 9, 17, Display.ALWAYS, 5, "12345 67890", paint, null, null, Position.ABOVE, 20);
+            final AndroidPointTextContainer container2 = new AndroidPointTextContainer(new Point(207, 140), 9, 17, Display.ALWAYS, 5, "12345 67890", paint, null, null, Position.ABOVE, 20);
+
+            assert container1.isMultiline;
+            assert container2.isMultiline;
+
+            // Create the clash rectangles
+            Rectangle clashRect1 = AndroidPointTextContainer.getClashRect(container1, rotation);
+            Rectangle clashRect2 = AndroidPointTextContainer.getClashRect(container2, rotation);
+
+            assert clashRect1 != null;
+            assert clashRect2 != null;
+
+            // Only during testing it happens that clash rectangles have zero height
+            if (clashRect1.getHeight() < Delta || clashRect2.getHeight() < Delta) {
+                clashRect1 = clashRect1.enlarge(0, 0, 0, 50);
+                clashRect2 = clashRect2.enlarge(0, 0, 0, 50);
+            }
+
+            Assert.assertTrue("Labels do not clash, but they should (multi line).", clashRect1.intersects(clashRect2));
+        }
+    }
+}

--- a/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/graphics/AwtPointTextContainer.java
+++ b/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/graphics/AwtPointTextContainer.java
@@ -1,6 +1,7 @@
 /*
  * Copyright 2014 Ludwig M Brinckmann
  * Copyright 2014-2016 devemux86
+ * Copyright 2024 Sublimis
  *
  * This program is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
@@ -31,11 +32,24 @@ import java.text.AttributedCharacterIterator;
 import java.text.AttributedString;
 
 public class AwtPointTextContainer extends PointTextContainer {
+    protected final Rectangle boundary;
+    public final int textHeight;
+    public final int textWidth;
+
     AwtPointTextContainer(Point xy, double horizontalOffset, double verticalOffset,
                           Display display, int priority, String text, Paint paintFront, Paint paintBack,
                           SymbolContainer symbolContainer, Position position, int maxTextWidth) {
         super(xy, horizontalOffset, verticalOffset, display, priority, text,
                 paintFront, paintBack, symbolContainer, position, maxTextWidth);
+
+        if (paintBack != null) {
+            this.textWidth = paintBack.getTextWidth(text);
+            this.textHeight = paintBack.getTextHeight(text);
+        } else {
+            this.textWidth = paintFront.getTextWidth(text);
+            this.textHeight = paintFront.getTextHeight(text);
+        }
+
         this.boundary = computeBoundary();
     }
 
@@ -116,6 +130,11 @@ public class AwtPointTextContainer extends PointTextContainer {
             }
             canvas.drawText(this.text, (int) (pointAdjusted.x + boundary.left), (int) (pointAdjusted.y + boundary.top + this.textHeight), this.paintFront);
         }
+    }
+
+    @Override
+    protected Rectangle getBoundary() {
+        return boundary;
     }
 
     private Rectangle computeBoundary() {

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/labels/LabelLayer.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/labels/LabelLayer.java
@@ -1,6 +1,7 @@
 /*
  * Copyright 2014-2016 Ludwig M Brinckmann
  * Copyright 2016 devemux86
+ * Copyright 2024 Sublimis
  *
  * This program is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
@@ -35,6 +36,7 @@ public class LabelLayer extends Layer {
     protected List<MapElementContainer> elementsToDraw;
     protected Tile upperLeft;
     protected Tile lowerRight;
+    protected Rotation rotation;
     protected int lastLabelStoreVersion;
 
     public LabelLayer(GraphicFactory graphicFactory, LabelStore labelStore) {
@@ -48,10 +50,11 @@ public class LabelLayer extends Layer {
         Tile newUpperLeft = LayerUtil.getUpperLeft(boundingBox, zoomLevel, displayModel.getTileSize());
         Tile newLowerRight = LayerUtil.getLowerRight(boundingBox, zoomLevel, displayModel.getTileSize());
         if (!newUpperLeft.equals(this.upperLeft) || !newLowerRight.equals(this.lowerRight)
-                || lastLabelStoreVersion != labelStore.getVersion()) {
-            // only need to get new data set if either set of tiles changed or the label store
+                || lastLabelStoreVersion != labelStore.getVersion() || !rotation.equals(this.rotation)) {
+            // only need to get new data set if either set of tiles changed or the label store or the rotation
             this.upperLeft = newUpperLeft;
             this.lowerRight = newLowerRight;
+            this.rotation = rotation;
             lastLabelStoreVersion = labelStore.getVersion();
             List<MapElementContainer> visibleItems = this.labelStore.getVisibleItems(upperLeft, lowerRight);
 


### PR DESCRIPTION
* Fix 🐞: Nondeterministic labels, i.e. certain labels sometimes appear, sometimes not, everything else the same. (This bug has been bothering us for the last cca 10 years!)
* Fix 🐞: Better label overlap avoidance algorithm
* Fix 🐞: Label overlap check not refreshed on map rotation
* Android: Label space now includes a small padding when checking for overlap (avoids placing labels too close together, which can sometimes appear as one word)
* Android: Better handling of multiline labels
* Android: Test for label overlap algorithm

## After:

![20241122-after1](https://github.com/user-attachments/assets/7ea56b35-37da-4268-83aa-5f01c375f460)

![20241122-after2](https://github.com/user-attachments/assets/1c809640-0600-4974-8f3c-fc8c0ea1ae21)


**`PointTextContainer.DEBUG_CLASH_BOUNDS` flag example:**

![20241122-after-debug](https://github.com/user-attachments/assets/754d27fb-136e-4b13-8b8b-d257e3c73d37)


## Before:

![20241122-before1](https://github.com/user-attachments/assets/0fd31a93-1e75-421d-a45a-05f19a4b5f10)
![20241122-before2](https://github.com/user-attachments/assets/ec6a7ba6-ff0d-4f6b-a6bd-da3ffd4a9414)
