### PR TITLE
Multi-map improvements

### DIFF
--- a/mapsforge-map-reader/src/main/java/org/mapsforge/map/reader/MapFile.java
+++ b/mapsforge-map-reader/src/main/java/org/mapsforge/map/reader/MapFile.java
@@ -238,6 +238,12 @@ public class MapFile extends MapDataStore {
             this.databaseIndexCache = new IndexCache(this.inputChannel, INDEX_CACHE_SIZE);
 
             this.timestamp = mapFile.lastModified();
+
+            // 2024: This may be removed in the future when world.map users get used to the map priorities feature
+            if ("world.map".equalsIgnoreCase(mapFile.getName())) {
+                // Some random (very) negative value no one will use
+                setPriority(Integer.MIN_VALUE + 374);
+            }
         } catch (Exception e) {
             // make sure that the channel is closed
             closeFileChannel();

--- a/mapsforge-map-reader/src/main/java/org/mapsforge/map/reader/MapFile.java
+++ b/mapsforge-map-reader/src/main/java/org/mapsforge/map/reader/MapFile.java
@@ -238,12 +238,6 @@ public class MapFile extends MapDataStore {
             this.databaseIndexCache = new IndexCache(this.inputChannel, INDEX_CACHE_SIZE);
 
             this.timestamp = mapFile.lastModified();
-
-            // 2024: This may be removed in the future when world.map users get used to the map priorities feature
-            if ("world.map".equalsIgnoreCase(mapFile.getName())) {
-                // Some random (very) negative value no one will use
-                setPriority(Integer.MIN_VALUE + 374);
-            }
         } catch (Exception e) {
             // make sure that the channel is closed
             closeFileChannel();

--- a/mapsforge-map-reader/src/main/java/org/mapsforge/map/reader/MapFile.java
+++ b/mapsforge-map-reader/src/main/java/org/mapsforge/map/reader/MapFile.java
@@ -6,6 +6,7 @@
  * Copyright 2016 bvgastel
  * Copyright 2017 linuskr
  * Copyright 2017 Gustl22
+ * Copyright 2024 Sublimis
  *
  * This program is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
@@ -1073,9 +1074,27 @@ public class MapFile extends MapDataStore {
     }
 
     @Override
+    public boolean supportsFullTile(Tile tile) {
+        return supportsFullArea(tile.getBoundingBox(), tile.zoomLevel);
+    }
+
+    @Override
     public boolean supportsArea(BoundingBox boundingBox, byte zoomLevel) {
         return boundingBox.intersects(getMapFileInfo().boundingBox)
                 && (zoomLevel >= this.zoomLevelMin && zoomLevel <= this.zoomLevelMax);
+    }
+
+    @Override
+    public boolean supportsFullArea(BoundingBox boundingBox, byte zoomLevel) {
+        final BoundingBox bbox1 = getMapFileInfo().boundingBox;
+        final BoundingBox bbox2 = boundingBox;
+        return bbox1.intersects(bbox2)
+                && zoomLevel >= this.zoomLevelMin
+                && zoomLevel <= this.zoomLevelMax
+                && bbox1.contains(bbox2.maxLatitude, bbox2.maxLongitude)
+                && bbox1.contains(bbox2.minLatitude, bbox2.minLongitude)
+                && bbox1.contains(bbox2.maxLatitude, bbox2.minLongitude)
+                && bbox1.contains(bbox2.minLatitude, bbox2.maxLongitude);
     }
 
     /**

--- a/mapsforge-map/src/main/java/org/mapsforge/map/datastore/MapDataStore.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/datastore/MapDataStore.java
@@ -30,6 +30,12 @@ import java.util.Locale;
  */
 public abstract class MapDataStore {
 
+    /**
+     * Priority of this MapDataStore. A higher number means a higher priority. Negative numbers have a special
+     * meaning, they should only be used for so-called background maps. Data from background maps is only read
+     * if no other map has provided a (complete) map tile. The most famous example of a background map is a
+     * low-resolution world map. The default priority is 0.
+     */
     protected int priority = 0;
 
     /**
@@ -233,10 +239,28 @@ public abstract class MapDataStore {
         this.mapCallback = mapCallback;
     }
 
+    /**
+     * Returns the priority of this MapDataStore. A higher number means a higher priority. Negative numbers
+     * have a special meaning, they should only be used for so-called background maps. Data from background
+     * maps is only read if no other map has provided a (complete) map tile. The most famous example of a
+     * background map is a low-resolution world map.
+     *
+     * @return The priority of this MapDataStore. Default is 0.
+     */
     public int getPriority() {
         return priority;
     }
 
+    /**
+     * Sets the priority of this MapDataStore. A higher number means a higher priority. Negative numbers have
+     * a special meaning, they should only be used for so-called background maps. Data from background maps is
+     * only read if no other map has provided a (complete) map tile. The most famous example of a background
+     * map is a low-resolution world map. The default priority is 0.
+     *
+     * @param priority Priority of this MapDataStore. Negative number means background map priority (see above
+     *                 for the description).
+     * @return {@code this} (for chaining)
+     */
     public MapDataStore setPriority(int priority) {
         this.priority = priority;
         return this;

--- a/mapsforge-map/src/main/java/org/mapsforge/map/datastore/MapDataStore.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/datastore/MapDataStore.java
@@ -2,6 +2,7 @@
  * Copyright 2014-2015 Ludwig M Brinckmann
  * Copyright 2015 devemux86
  * Copyright 2015 lincomatic
+ * Copyright 2024 Sublimis
  *
  * This program is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
@@ -253,6 +254,14 @@ public abstract class MapDataStore {
     public abstract boolean supportsTile(Tile tile);
 
     /**
+     * Returns true if MapDatabase contains a complete tile.
+     *
+     * @param tile tile to be rendered.
+     * @return true if complete tile is part of database.
+     */
+    public abstract boolean supportsFullTile(Tile tile);
+
+    /**
      * Returns true if MapDatabase covers (even partially) certain area in required zoom level.
      *
      * @param boundingBox area we test
@@ -260,6 +269,15 @@ public abstract class MapDataStore {
      * @return true if area is part of the database.
      */
     public abstract boolean supportsArea(BoundingBox boundingBox, byte zoomLevel);
+
+    /**
+     * Returns true if MapDatabase covers certain area completely in required zoom level.
+     *
+     * @param boundingBox area we test
+     * @param zoomLevel   zoom level we test
+     * @return true if complete area is part of the database.
+     */
+    public abstract boolean supportsFullArea(BoundingBox boundingBox, byte zoomLevel);
 
     /**
      * Returns true if a way should be included in the result set for readLabels()

--- a/mapsforge-map/src/main/java/org/mapsforge/map/datastore/MapDataStore.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/datastore/MapDataStore.java
@@ -28,7 +28,9 @@ import java.util.Locale;
 /**
  * Base class for map data retrieval.
  */
-public abstract class MapDataStore {
+public abstract class MapDataStore implements Comparable<MapDataStore> {
+
+    protected int priority = 0;
 
     /**
      * Extracts substring of preferred language from multilingual string.<br/>
@@ -229,6 +231,21 @@ public abstract class MapDataStore {
 
     public void setMapCallback(MapCallback mapCallback) {
         this.mapCallback = mapCallback;
+    }
+
+    public int getPriority() {
+        return priority;
+    }
+
+    public MapDataStore setPriority(int priority) {
+        this.priority = priority;
+        return this;
+    }
+
+    @Override
+    public int compareTo(MapDataStore other) {
+        // Reverse order
+        return -Integer.compare(this.getPriority(), other.getPriority());
     }
 
     /**

--- a/mapsforge-map/src/main/java/org/mapsforge/map/datastore/MapDataStore.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/datastore/MapDataStore.java
@@ -28,7 +28,7 @@ import java.util.Locale;
 /**
  * Base class for map data retrieval.
  */
-public abstract class MapDataStore implements Comparable<MapDataStore> {
+public abstract class MapDataStore {
 
     protected int priority = 0;
 
@@ -240,12 +240,6 @@ public abstract class MapDataStore implements Comparable<MapDataStore> {
     public MapDataStore setPriority(int priority) {
         this.priority = priority;
         return this;
-    }
-
-    @Override
-    public int compareTo(MapDataStore other) {
-        // Reverse order
-        return -Integer.compare(this.getPriority(), other.getPriority());
     }
 
     /**

--- a/mapsforge-map/src/main/java/org/mapsforge/map/datastore/MultiMapDataStore.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/datastore/MultiMapDataStore.java
@@ -39,6 +39,7 @@ import java.util.List;
  * - DEDUPLICATE: The data from all files will be returned but duplicates will be eliminated. This is
  * suitable when multiple maps cover the different areas, but there is some overlap at boundaries. This
  * is the most expensive operation and often it is actually faster to double paint objects.
+ * Use {@link #setPriority(int)} to prioritize your maps.
  */
 public class MultiMapDataStore extends MapDataStore {
 

--- a/mapsforge-samples-android/src/main/java/org/mapsforge/samples/android/MultiMapLowResWorld.java
+++ b/mapsforge-samples-android/src/main/java/org/mapsforge/samples/android/MultiMapLowResWorld.java
@@ -78,7 +78,8 @@ public class MultiMapLowResWorld extends DefaultTheme {
 //                return tile.zoomLevel <= 10 && super.supportsTile(tile);
 //            }
         };
-        multiMapDataStore = new MultiMapDataStore(MultiMapDataStore.DataPolicy.RETURN_AUTOFILL);
+        worldMapFile.setPriority(-1);
+        multiMapDataStore = new MultiMapDataStore(MultiMapDataStore.DataPolicy.RETURN_ALL);
         MapFile mapFile1 = (MapFile) getMapFile1();
         //mapFile1.restrictToZoomRange((byte) 8, Byte.MAX_VALUE);
         multiMapDataStore.addMapDataStore(mapFile1, true, true);

--- a/mapsforge-samples-android/src/main/java/org/mapsforge/samples/android/MultiMapLowResWorld.java
+++ b/mapsforge-samples-android/src/main/java/org/mapsforge/samples/android/MultiMapLowResWorld.java
@@ -1,6 +1,7 @@
 /*
  * Copyright 2014 Ludwig M Brinckmann
  * Copyright 2015-2019 devemux86
+ * Copyright 2024 Sublimis
  *
  * This program is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
@@ -17,7 +18,7 @@ package org.mapsforge.samples.android;
 
 import android.content.Context;
 import android.os.Bundle;
-import org.mapsforge.core.model.Tile;
+
 import org.mapsforge.map.datastore.MapDataStore;
 import org.mapsforge.map.datastore.MultiMapDataStore;
 import org.mapsforge.map.reader.MapFile;
@@ -71,13 +72,13 @@ public class MultiMapLowResWorld extends DefaultTheme {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         worldMapFile = new MapFile(getWorldMapFile(this)) {
-            @Override
-            public boolean supportsTile(Tile tile) {
-                // Example low res world map has sufficient detail up to zoom level 7
-                return tile.zoomLevel <= 10 && super.supportsTile(tile);
-            }
+//            @Override
+//            public boolean supportsTile(Tile tile) {
+//                // Example low res world map has sufficient detail up to zoom level 7
+//                return tile.zoomLevel <= 10 && super.supportsTile(tile);
+//            }
         };
-        multiMapDataStore = new MultiMapDataStore(MultiMapDataStore.DataPolicy.RETURN_ALL);
+        multiMapDataStore = new MultiMapDataStore(MultiMapDataStore.DataPolicy.RETURN_AUTOFILL);
         MapFile mapFile1 = (MapFile) getMapFile1();
         mapFile1.restrictToZoomRange((byte) 8, Byte.MAX_VALUE);
         multiMapDataStore.addMapDataStore(mapFile1, true, true);

--- a/mapsforge-samples-awt/src/main/java/org/mapsforge/samples/awt/Samples.java
+++ b/mapsforge-samples-awt/src/main/java/org/mapsforge/samples/awt/Samples.java
@@ -155,15 +155,20 @@ public final class Samples {
         } else {
             // Vector
             mapView.getModel().displayModel.setFixedTileSize(tileSize);
-            MultiMapDataStore mapDataStore = new MultiMapDataStore(MultiMapDataStore.DataPolicy.RETURN_ALL);
+            final MultiMapDataStore multiMapDataStore = new MultiMapDataStore(MultiMapDataStore.DataPolicy.RETURN_ALL);
             for (File file : mapFiles) {
-                mapDataStore.addMapDataStore(new MapFile(file), false, false);
+                final MapFile mapFileDataStore = new MapFile(file);
+
+                if (getWorldMapFileName().equalsIgnoreCase(file.getName())) {
+                    mapFileDataStore.setPriority(-1);
+                }
+                multiMapDataStore.addMapDataStore(mapFileDataStore, false, false);
             }
-            TileRendererLayer tileRendererLayer = createTileRendererLayer(tileCache, mapDataStore, mapView.getModel().mapViewPosition, hillsRenderConfig);
+            TileRendererLayer tileRendererLayer = createTileRendererLayer(tileCache, multiMapDataStore, mapView.getModel().mapViewPosition, hillsRenderConfig);
             layers.add(tileRendererLayer);
             LabelLayer labelLayer = new LabelLayer(AwtGraphicFactory.INSTANCE, tileRendererLayer.getLabelStore());
             mapView.getLayerManager().getLayers().add(labelLayer);
-            boundingBox = mapDataStore.boundingBox();
+            boundingBox = multiMapDataStore.boundingBox();
         }
 
         // Debug
@@ -243,6 +248,13 @@ public final class Samples {
                 result.add(mapFile);
         }
         return result;
+    }
+
+    /**
+     * @return the name of the low res world map file.
+     */
+    public static String getWorldMapFileName() {
+        return "world.map";
     }
 
     private Samples() {


### PR DESCRIPTION
~~* MultiMapDataStore.DataPolicy.RETURN_AUTOFILL: Return data from all datasets in the sequence that support a tile, up to the one that contains data for the entire tile (usually a world map). In other words, once a dataset fills the entire tile, the remaining datasets are not processed for that tile.~~

Here we are solving the following multi-map artifacts:

1. Low-res map coastline peeks out from behind high-res map (RETURN_ALL issue)

2. Incomplete tile returned on map edge (RETURN_FIRST issue; RETURN_ALL has this issue only when zoom levels are limited as in the sample app)

3. Return data from all maps that overlap on a tile


Motivation: Prevent ugly gaps at the edges of the map when the map does not cover the tile completely, and we have a background world map that should easily cover this gap. Additionally, prevent the land areas of the (low-res) world map from "peeking" behind the land areas of a (hi-res) main map, when the main map can provide the entire tile itself.

These problems can be easily seen in the Android application sample MultiMapLowResWorld.