### PR TITLE
Detailing the prevention of non-deterministic labels

### DIFF
--- a/mapsforge-core/src/main/java/org/mapsforge/core/mapelements/WayTextContainer.java
+++ b/mapsforge-core/src/main/java/org/mapsforge/core/mapelements/WayTextContainer.java
@@ -42,12 +42,12 @@ public class WayTextContainer extends MapElementContainer {
         this.paintFront = paintFront;
         this.paintBack = paintBack;
 
-        this.boundary = null;
         // a way text container should always run left to right, but I leave this in because it might matter
         // if we support right-to-left text.
         // we also need to make the container larger by textHeight as otherwise the end points do
         // not correctly reflect the size of the text on screen
         this.boundaryAbsolute = lineString.getBounds().enlarge(textHeight / 2d, textHeight / 2d, textHeight / 2d, textHeight / 2d);
+        this.boundary = this.boundaryAbsolute.shift(new Point(-this.xy.x, -this.xy.y));
         this.textOrientation = textOrientation;
     }
 

--- a/mapsforge-core/src/main/java/org/mapsforge/core/model/Rectangle.java
+++ b/mapsforge-core/src/main/java/org/mapsforge/core/model/Rectangle.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2010, 2011, 2012, 2013 mapsforge.org
+ * Copyright 2024 Sublimis
  *
  * This program is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
@@ -145,12 +146,32 @@ public class Rectangle implements Serializable {
      * @return true if this Rectangle intersects with the given Rectangle, false otherwise.
      */
     public boolean intersects(Rectangle rectangle) {
+        if (rectangle == null) {
+            return false;
+        }
+
         if (this == rectangle) {
             return true;
         }
 
         return this.left <= rectangle.right && rectangle.left <= this.right && this.top <= rectangle.bottom
                 && rectangle.top <= this.bottom;
+    }
+
+    /**
+     * @return true if this Rectangle contains the given Rectangle, false otherwise.
+     */
+    public boolean contains(Rectangle rectangle) {
+        if (rectangle == null) {
+            return false;
+        }
+
+        if (this == rectangle) {
+            return true;
+        }
+
+        return this.left <= rectangle.left && this.right >= rectangle.right && this.top <= rectangle.top
+                && this.bottom >= rectangle.bottom;
     }
 
     public boolean intersectsCircle(double pointX, double pointY, double radius) {

--- a/mapsforge-core/src/test/java/org/mapsforge/core/mapelements/MapElementContainerTest.java
+++ b/mapsforge-core/src/test/java/org/mapsforge/core/mapelements/MapElementContainerTest.java
@@ -35,7 +35,7 @@ public class MapElementContainerTest {
 
         protected MyDummyContainer(Point xy, Display display, int priority) {
             super(xy, display, priority);
-            boundary = new Rectangle(xy.x, xy.y, xy.x + 10, xy.y + 10);
+            boundary = new Rectangle(0, 0, 10, 10);
         }
 
         @Override

--- a/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidPointTextContainer.java
+++ b/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidPointTextContainer.java
@@ -173,7 +173,7 @@ public class AndroidPointTextContainer extends PointTextContainer {
 
     @Override
     public void draw(Canvas canvas, Point origin, Matrix matrix, Rotation rotation) {
-        if (!this.isVisible) {
+        if (this.isNotVisible()) {
             return;
         }
 

--- a/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/graphics/AwtPointTextContainer.java
+++ b/mapsforge-map-awt/src/main/java/org/mapsforge/map/awt/graphics/AwtPointTextContainer.java
@@ -74,7 +74,7 @@ public class AwtPointTextContainer extends PointTextContainer {
 
     @Override
     public void draw(Canvas canvas, Point origin, Matrix matrix, Rotation rotation) {
-        if (this.paintFront.isTransparent() && (this.paintBack == null || this.paintBack.isTransparent())) {
+        if (this.isNotVisible()) {
             return;
         }
 

--- a/mapsforge-map-awt/src/test/java/org/mapsforge/map/awt/graphics/AwtPointTextContainerTest.java
+++ b/mapsforge-map-awt/src/test/java/org/mapsforge/map/awt/graphics/AwtPointTextContainerTest.java
@@ -52,7 +52,7 @@ public class AwtPointTextContainerTest {
         final Rectangle labelRect = new Rectangle(labelPosition.x, labelPosition.y, labelPosition.x + container.boundary.getWidth(), labelPosition.y + container.boundary.getHeight());
 
         // Create the clash rectangle
-        final Rectangle clashRect = AwtPointTextContainer.getClashRect(container, rotation);
+        final Rectangle clashRect = container.getClashRect(rotation);
 
         assert clashRect != null;
 
@@ -91,8 +91,8 @@ public class AwtPointTextContainerTest {
             assert lines2 <= 1;
 
             // Create the clash rectangles
-            Rectangle clashRect1 = AwtPointTextContainer.getClashRect(container1, rotation);
-            Rectangle clashRect2 = AwtPointTextContainer.getClashRect(container2, rotation);
+            Rectangle clashRect1 = container1.getClashRect(rotation);
+            Rectangle clashRect2 = container2.getClashRect(rotation);
 
             assert clashRect1 != null;
             assert clashRect2 != null;
@@ -119,8 +119,8 @@ public class AwtPointTextContainerTest {
             assert lines2 > 1;
 
             // Create the clash rectangles
-            Rectangle clashRect1 = AwtPointTextContainer.getClashRect(container1, rotation);
-            Rectangle clashRect2 = AwtPointTextContainer.getClashRect(container2, rotation);
+            Rectangle clashRect1 = container1.getClashRect(rotation);
+            Rectangle clashRect2 = container2.getClashRect(rotation);
 
             assert clashRect1 != null;
             assert clashRect2 != null;

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/labels/MapDataStoreLabelStore.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/labels/MapDataStoreLabelStore.java
@@ -76,12 +76,12 @@ public class MapDataStoreLabelStore implements LabelStore {
             }
 
             for (PointOfInterest pointOfInterest : mapReadResult.pointOfInterests) {
-                renderContext.setDrawingLayers(pointOfInterest.layer);
+                renderContext.setDrawingLayer(pointOfInterest.layer);
                 renderContext.rendererJob.renderThemeFuture.get().matchNode(standardRenderer, renderContext, pointOfInterest);
             }
             for (Way way : mapReadResult.ways) {
                 PolylineContainer polylineContainer = new PolylineContainer(way, upperLeft, lowerRight);
-                renderContext.setDrawingLayers(polylineContainer.getLayer());
+                renderContext.setDrawingLayer(polylineContainer.getLayer());
 
                 if (polylineContainer.isClosedWay()) {
                     renderContext.renderTheme.matchClosedWay(standardRenderer, renderContext, polylineContainer);

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/labels/MapDataStoreLabelStore.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/labels/MapDataStoreLabelStore.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2015 Ludwig M Brinckmann
+ * Copyright 2024 Sublimis
  *
  * This program is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
@@ -21,7 +22,6 @@ import org.mapsforge.map.datastore.MapDataStore;
 import org.mapsforge.map.datastore.MapReadResult;
 import org.mapsforge.map.datastore.PointOfInterest;
 import org.mapsforge.map.datastore.Way;
-import org.mapsforge.map.layer.renderer.CanvasRasterer;
 import org.mapsforge.map.layer.renderer.PolylineContainer;
 import org.mapsforge.map.layer.renderer.RendererJob;
 import org.mapsforge.map.layer.renderer.StandardRenderer;
@@ -47,7 +47,7 @@ public class MapDataStoreLabelStore implements LabelStore {
 
         this.textScale = textScale;
         this.renderThemeFuture = renderThemeFuture;
-        // TODO what about way symbols, we have the problem that ways without names but symbols will not be included.
+        // TODO (2015): what about way symbols, we have the problem that ways without names but symbols will not be included.
         this.standardRenderer = new StandardRenderer(mapDataStore, graphicFactory, true);
         this.displayModel = displayModel;
     }
@@ -67,7 +67,7 @@ public class MapDataStoreLabelStore implements LabelStore {
 
         try {
             RendererJob rendererJob = new RendererJob(upperLeft, this.standardRenderer.mapDataStore, this.renderThemeFuture, this.displayModel, this.textScale, true, true);
-            RenderContext renderContext = new RenderContext(rendererJob, new CanvasRasterer(standardRenderer.graphicFactory));
+            RenderContext renderContext = new RenderContext(rendererJob, standardRenderer.graphicFactory);
 
             MapReadResult mapReadResult = standardRenderer.mapDataStore.readLabels(upperLeft, lowerRight);
 
@@ -90,7 +90,7 @@ public class MapDataStoreLabelStore implements LabelStore {
                 }
             }
 
-            return renderContext.labels;
+            return renderContext.getLabels();
         } catch (Exception e) {
             return new ArrayList<>();
         }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/DirectRenderer.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/DirectRenderer.java
@@ -22,17 +22,14 @@ package org.mapsforge.map.layer.renderer;
 import org.mapsforge.core.graphics.GraphicFactory;
 import org.mapsforge.core.model.Tile;
 import org.mapsforge.map.datastore.MapDataStore;
-import org.mapsforge.map.layer.cache.TileCache;
 import org.mapsforge.map.layer.hills.HillsRenderConfig;
-import org.mapsforge.map.layer.labels.TileBasedLabelStore;
+import org.mapsforge.map.layer.labels.MapDataStoreLabelStore;
 
 /**
- * Note (2024): The DirectRenderer is deprecated, it is here just for compatibility.
- * It doesn't contain any new functionality not already covered by its superclass, DatabaseRenderer.
- * The deterministic labels also made calls to the {@link TileRefresher} interface obsolete.
- * <p>
  * The DirectRenderer renders map tiles by reading from a {@link MapDataStore}.
  * Just rendering the tiles without any memory of what happened before.
+ * <p>
+ * Note (2024): The deterministic labels made calls to the {@link TileRefresher} interface obsolete.
  *
  * @see <a href="https://github.com/mapsforge/mapsforge/issues/1085">mapsforge/mapsforge#1085</a>
  */
@@ -40,21 +37,15 @@ public class DirectRenderer extends DatabaseRenderer {
 
     /**
      * Constructs a new DirectRenderer.
-     * There are three possible configurations:
-     * 1) render labels directly onto tiles: renderLabels == true && tileCache != null
-     * 2) do not render labels but cache them: renderLabels == false && labelStore != null
-     * 3) do not render or cache labels: renderLabels == false && labelStore == null
      *
      * @param mapDataStore      the data source.
      * @param graphicFactory    the graphic factory.
-     * @param tileCache         where tiles are cached (needed if labels are drawn directly onto tiles, otherwise null)
-     * @param labelStore        where labels are cached.
+     * @param labelStore        from where labels are read.
      * @param renderLabels      if labels should be rendered.
-     * @param cacheLabels       if labels should be cached.
      * @param hillsRenderConfig the hillshading setup to be used (can be null).
      */
-    public DirectRenderer(MapDataStore mapDataStore, GraphicFactory graphicFactory, TileCache tileCache, TileBasedLabelStore labelStore, boolean renderLabels, boolean cacheLabels, HillsRenderConfig hillsRenderConfig) {
-        super(mapDataStore, graphicFactory, tileCache, labelStore, renderLabels, cacheLabels, hillsRenderConfig);
+    public DirectRenderer(MapDataStore mapDataStore, GraphicFactory graphicFactory, MapDataStoreLabelStore labelStore, boolean renderLabels, HillsRenderConfig hillsRenderConfig) {
+        super(mapDataStore, graphicFactory, null, labelStore, renderLabels, false, hillsRenderConfig);
     }
 
     /**

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/StandardRenderer.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/StandardRenderer.java
@@ -113,7 +113,7 @@ public class StandardRenderer implements RenderCallback {
     public void renderAreaCaption(final RenderContext renderContext, Display display, int priority, String caption, float horizontalOffset, float verticalOffset, Paint fill, Paint stroke, Position position, int maxTextWidth, PolylineContainer way) {
         if (renderLabels) {
             Point centerPoint = way.getCenterAbsolute().offset(horizontalOffset, verticalOffset);
-            renderContext.labels.add(this.graphicFactory.createPointTextContainer(centerPoint, horizontalOffset, verticalOffset,
+            renderContext.addLabel(this.graphicFactory.createPointTextContainer(centerPoint, horizontalOffset, verticalOffset,
                     display, priority, caption, fill, stroke, null, position, maxTextWidth));
         }
     }
@@ -122,7 +122,7 @@ public class StandardRenderer implements RenderCallback {
     public void renderAreaSymbol(final RenderContext renderContext, Display display, int priority, Bitmap symbol, PolylineContainer way) {
         if (renderLabels) {
             Point centerPosition = way.getCenterAbsolute();
-            renderContext.labels.add(new SymbolContainer(centerPosition, display, priority, null, symbol, true));
+            renderContext.addLabel(new SymbolContainer(centerPosition, display, priority, null, symbol, true));
         }
     }
 
@@ -130,7 +130,7 @@ public class StandardRenderer implements RenderCallback {
     public void renderPointOfInterestCaption(final RenderContext renderContext, Display display, int priority, String caption, float horizontalOffset, float verticalOffset, Paint fill, Paint stroke, Position position, int maxTextWidth, PointOfInterest poi) {
         if (renderLabels) {
             Point poiPosition = MercatorProjection.getPixelAbsolute(poi.position, renderContext.rendererJob.tile.mapSize);
-            renderContext.labels.add(this.graphicFactory.createPointTextContainer(poiPosition, horizontalOffset, verticalOffset,
+            renderContext.addLabel(this.graphicFactory.createPointTextContainer(poiPosition, horizontalOffset, verticalOffset,
                     display, priority, caption, fill, stroke, null, position, maxTextWidth));
         }
     }
@@ -146,7 +146,7 @@ public class StandardRenderer implements RenderCallback {
     public void renderPointOfInterestSymbol(final RenderContext renderContext, Display display, int priority, Rectangle boundary, Bitmap symbol, PointOfInterest poi) {
         if (renderLabels) {
             Point poiPosition = MercatorProjection.getPixelAbsolute(poi.position, renderContext.rendererJob.tile.mapSize);
-            renderContext.labels.add(new SymbolContainer(poiPosition, display, priority, boundary, symbol, true));
+            renderContext.addLabel(new SymbolContainer(poiPosition, display, priority, boundary, symbol, true));
         }
     }
 
@@ -159,7 +159,7 @@ public class StandardRenderer implements RenderCallback {
     public void renderWaySymbol(final RenderContext renderContext, Display display, int priority, Bitmap symbol, float dy, Rectangle boundary, boolean repeat, float repeatGap, float repeatStart, SymbolOrientation symbolOrientation, PolylineContainer way) {
         if (renderLabels) {
             WayDecorator.renderSymbol(symbol, display, priority, dy, boundary, repeat, repeatGap,
-                    repeatStart, symbolOrientation, way.getCoordinatesAbsolute(), renderContext.labels);
+                    repeatStart, symbolOrientation, way.getCoordinatesAbsolute(), renderContext);
         }
     }
 
@@ -168,7 +168,7 @@ public class StandardRenderer implements RenderCallback {
                               boolean repeat, float repeatGap, float repeatStart, TextOrientation textOrientation, PolylineContainer way) {
         if (renderLabels) {
             WayDecorator.renderText(graphicFactory, way.getUpperLeft(), way.getLowerRight(), textKey, display, priority, dy, fill, stroke,
-                    repeat, repeatGap, repeatStart, textOrientation, way.getCoordinatesAbsolute(), renderContext.labels);
+                    repeat, repeatGap, repeatStart, textOrientation, way.getCoordinatesAbsolute(), renderContext);
         }
     }
 

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/StandardRenderer.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/StandardRenderer.java
@@ -177,12 +177,12 @@ public class StandardRenderer implements RenderCallback {
     }
 
     protected void renderPointOfInterest(final RenderContext renderContext, PointOfInterest pointOfInterest) {
-        renderContext.setDrawingLayers(pointOfInterest.layer);
+        renderContext.setDrawingLayer(pointOfInterest.layer);
         renderContext.renderTheme.matchNode(this, renderContext, pointOfInterest);
     }
 
     protected void renderWaterBackground(final RenderContext renderContext) {
-        renderContext.setDrawingLayers((byte) 0);
+        renderContext.setDrawingLayer((byte) 0);
         Point[] coordinates = getTilePixelCoordinates(renderContext.rendererJob.tile.tileSize);
         Point tileOrigin = renderContext.rendererJob.tile.getOrigin();
         for (int i = 0; i < coordinates.length; i++) {
@@ -193,7 +193,7 @@ public class StandardRenderer implements RenderCallback {
     }
 
     protected void renderWay(final RenderContext renderContext, PolylineContainer way) {
-        renderContext.setDrawingLayers(way.getLayer());
+        renderContext.setDrawingLayer(way.getLayer());
 
         if (way.isClosedWay()) {
             if (renderContext.rendererJob.tile.zoomLevel >= Parameters.POLYGON_ZOOM_MIN) {

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/WayDecorator.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/WayDecorator.java
@@ -1,6 +1,7 @@
 /*
  * Copyright 2010, 2011, 2012, 2013 mapsforge.org
  * Copyright 2019 Adrian Batzill
+ * Copyright 2024 Sublimis
  *
  * This program is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
@@ -16,12 +17,10 @@
 package org.mapsforge.map.layer.renderer;
 
 import org.mapsforge.core.graphics.*;
-import org.mapsforge.core.mapelements.MapElementContainer;
 import org.mapsforge.core.mapelements.SymbolContainer;
 import org.mapsforge.core.mapelements.WayTextContainer;
 import org.mapsforge.core.model.*;
-
-import java.util.List;
+import org.mapsforge.map.rendertheme.RenderContext;
 
 final class WayDecorator {
 
@@ -31,7 +30,7 @@ final class WayDecorator {
     static void renderSymbol(Bitmap symbolBitmap, Display display, int priority, float dy, Rectangle boundary,
                              boolean repeatSymbol, float repeatGap, float repeatStart,
                              SymbolOrientation symbolOrientation, Point[][] coordinates,
-                             List<MapElementContainer> currentItems) {
+                             RenderContext renderContext) {
         int skipPixels = (int) repeatStart;
 
         Point[] c;
@@ -100,7 +99,7 @@ final class WayDecorator {
                 double cooX = previousX + segmentOffset * diffXpx;
                 double cooY = previousY + segmentOffset * diffYpx;
                 Point point = new Point(cooX, cooY);
-                currentItems.add(new SymbolContainer(point, display, priority, boundary, symbolBitmap, theta, false));
+                renderContext.addLabel(new SymbolContainer(point, display, priority, boundary, symbolBitmap, theta, false));
 
                 // increment offset by the gap and the width of drawn image
                 segmentOffset += symbolBitmap.getWidth() + repeatGap;
@@ -131,12 +130,12 @@ final class WayDecorator {
      * @param fill          fill paint for text
      * @param stroke        stroke paint for text
      * @param coordinates   the list of way coordinates
-     * @param currentLabels the list of labels to which a new WayTextContainer will be added
+     * @param renderContext render context with the list of labels to which a new WayTextContainer will be added
      */
     static void renderText(GraphicFactory graphicFactory, Tile upperLeft, Tile lowerRight, String text, Display display, int priority, float dy,
                            Paint fill, Paint stroke,
                            boolean repeat, float repeatGap, float repeatStart, TextOrientation textOrientation, Point[][] coordinates,
-                           List<MapElementContainer> currentLabels) {
+                           RenderContext renderContext) {
         if (coordinates.length == 0) {
             return;
         }
@@ -179,7 +178,7 @@ final class WayDecorator {
 
             // check to prevent inverted way names now happens when drawing, because with rotation we do
             // not know the screen positions in advance any more.
-            currentLabels.add(new WayTextContainer(graphicFactory, linePart, display, priority, text, fill, stroke, textHeight, textOrientation));
+            renderContext.addLabel(new WayTextContainer(graphicFactory, linePart, display, priority, text, fill, stroke, textHeight, textOrientation));
         }
     }
 

--- a/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/RenderContext.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/RenderContext.java
@@ -65,7 +65,7 @@ public class RenderContext {
         this.canvasRasterer.destroy();
     }
 
-    public void setDrawingLayers(byte layer) {
+    public void setDrawingLayer(byte layer) {
         if (layer < 0) {
             layer = 0;
         } else if (layer >= RenderContext.LAYERS) {

--- a/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/Hillshading.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/Hillshading.java
@@ -65,7 +65,7 @@ public class Hillshading {
     public void render(final RenderContext renderContext, HillsRenderConfig hillsRenderConfig) {
         if (hillsRenderConfig == null) {
             if (always) {
-                renderContext.setDrawingLayers(layer);
+                renderContext.setDrawingLayer(layer);
                 ShapeContainer hillShape = new HillshadingContainer(null, this.magnitude, null, null);
                 renderContext.addToCurrentDrawingLayer(level, new ShapePaintContainer(hillShape, null));
             }
@@ -177,7 +177,7 @@ public class Hillshading {
                 final Rectangle maptileRect = new Rectangle(maptileSubrectLeft, maptileSubrectTop, maptileSubrectRight, maptileSubrectBottom);
                 final ShapeContainer hillShape = new HillshadingContainer(shadingTile, effectiveMagnitude, hillsRect, maptileRect);
 
-                renderContext.setDrawingLayers(layer);
+                renderContext.setDrawingLayer(layer);
                 renderContext.addToCurrentDrawingLayer(level, new ShapePaintContainer(hillShape, null));
             }
         }

--- a/mapsforge-map/src/test/java/org/mapsforge/map/layer/LayerUtilTest.java
+++ b/mapsforge-map/src/test/java/org/mapsforge/map/layer/LayerUtilTest.java
@@ -1,6 +1,7 @@
 /*
  * Copyright 2010, 2011, 2012, 2013 mapsforge.org
  * Copyright 2014 Ludwig M Brinckmann
+ * Copyright 2024 Sublimis
  *
  * This program is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
@@ -17,15 +18,45 @@ package org.mapsforge.map.layer;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.mapsforge.core.graphics.Canvas;
+import org.mapsforge.core.graphics.Display;
+import org.mapsforge.core.graphics.Matrix;
+import org.mapsforge.core.mapelements.MapElementContainer;
 import org.mapsforge.core.model.BoundingBox;
 import org.mapsforge.core.model.Point;
+import org.mapsforge.core.model.Rectangle;
+import org.mapsforge.core.model.Rotation;
 import org.mapsforge.core.model.Tile;
 import org.mapsforge.map.util.LayerUtil;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 public class LayerUtilTest {
     private static final int[] TILE_SIZES = {256, 128, 376, 512, 100};
+
+    static class MyDummyContainer extends MapElementContainer {
+        public static final int Width = 100;
+        public static final int Height = 10;
+
+        protected final Rectangle boundary;
+
+        protected MyDummyContainer(Point xy, Display display, int priority) {
+            super(xy, display, priority);
+            boundary = new Rectangle(0, 0, Width, Height);
+        }
+
+        @Override
+        protected Rectangle getBoundary() {
+            return boundary;
+        }
+
+        @Override
+        public void draw(Canvas canvas, Point origin, Matrix matrix, Rotation rotation) {
+        }
+    }
 
     @Test
     public void getTilePositionsTest() {
@@ -39,5 +70,43 @@ public class LayerUtilTest {
             Assert.assertEquals(new Tile(0, 0, (byte) 0, tileSize), tilePosition.tile);
             Assert.assertEquals(new Point(0, 0), tilePosition.point);
         }
+    }
+
+    @Test
+    public void collisionAndContestingFreeOrderedTest() {
+        final Tile tile = new Tile(0, 0, (byte) 1, 256);
+        final Point tileOrigin = tile.getOrigin();
+
+        final MapElementContainer container1 = new MyDummyContainer(new Point(220, 105).offset(tileOrigin.x, tileOrigin.y), Display.ALWAYS, 1);
+        final MapElementContainer container2 = new MyDummyContainer(new Point(200, 100).offset(tileOrigin.x, tileOrigin.y), Display.ALWAYS, 1);
+        final MapElementContainer container3 = new MyDummyContainer(new Point(200, 200).offset(tileOrigin.x, tileOrigin.y), Display.ALWAYS, 0);
+
+        final List<MapElementContainer> mainList = Arrays.asList(container1, container2, container3);
+
+
+        Collections.sort(mainList, Collections.reverseOrder());
+
+        // The list is already sorted
+        Assert.assertSame(mainList.get(0), container1);
+        Assert.assertSame(mainList.get(1), container2);
+
+
+        final List<MapElementContainer> list1 = LayerUtil.collisionFreeOrdered(new ArrayList<>(mainList), Rotation.NULL_ROTATION, false);
+
+        // One element should be removed, namely container2 as it clashes with container1
+        // and at the same time has lower drawing priority because of its position
+        Assert.assertEquals(list1.size(), 2);
+        Assert.assertSame(list1.get(0), container1);
+        Assert.assertSame(list1.get(1), container3);
+
+
+        final List<MapElementContainer> list2 = LayerUtil.collisionAndContestingFreeOrdered(new ArrayList<>(mainList), tile, Rotation.NULL_ROTATION, false);
+
+        // Two elements should be removed, specifically container1 and container2 because they are multi-tiled
+        // and also clash with each other (their drawing priority is defined to be the same in this case)
+        Assert.assertEquals(list2.size(), 1);
+
+        // Only container3 survives, although it is multi-tiled, because its position is not contested by other labels
+        Assert.assertSame(list2.get(0), container3);
     }
 }


### PR DESCRIPTION
1. Improve `DirectRenderer`, i.e. make labels that are rendered directly on tiles (when using `MapDataStoreLabelStore`) deterministic with this one change: Omit drawing labels that span multiple tiles **and** clash with labels of similar priority.
2. Improve labels/symbols clash detection (using clash rectangles, not just absolute boundary).
3. Improve invisible labels/symbols handling (remove them before processing the rest).
4. `CanvasRasterer.renderContext` reference (it's natural, because `CanvasRasterer` only lives inside `RenderContext`).
5. Improve `RenderContext` fields encapsulation.
6. Tests for `LayerUtil.collisionAndContestingFreeOrdered()` and `LayerUtil.collisionFreeOrdered()`.

After implementing points 1. and 2., not a single label tear was observed when using the `DirectRenderer` method. It seems that the problem with non-deterministic labels has finally been completely solved. Yay!

Note that point 1. didn't change the way the current implementation of `DatabaseRenderer` handles tile-rendered labels when using `TileBasedLabelStore`.

We hope you don't mind points 4. and 5. It would be a pity to revert them because they make the code more future-proof and OOP-compliant (and less error-prone).