### PR TITLE
Hill shading improvements

### DIFF
--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/AThreadedHillShading.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/AThreadedHillShading.java
@@ -553,7 +553,7 @@ public abstract class AThreadedHillShading extends AShadingAlgorithm {
 
     @Override
     protected byte[] convert(InputStream inputStream, int dummyAxisLen, int dummyRowLen, int padding, int zoomLevel, double pxPerLat, double pxPerLon, HgtFileInfo hgtFileInfo) throws IOException {
-        return doTheWork_(hgtFileInfo, false, padding, zoomLevel, pxPerLat, pxPerLon);
+        return convert(hgtFileInfo, false, padding, zoomLevel, pxPerLat, pxPerLon);
     }
 
     /**
@@ -565,21 +565,15 @@ public abstract class AThreadedHillShading extends AShadingAlgorithm {
      * @param pxPerLon      Tile pixels per degree of longitude (to determine shading quality requirements)
      * @return
      */
-    protected byte[] doTheWork_(final HgtFileInfo hgtFileInfo, boolean isHighQuality, int padding, int zoomLevel, double pxPerLat, double pxPerLon) {
+    protected byte[] convert(final HgtFileInfo hgtFileInfo, boolean isHighQuality, int padding, int zoomLevel, double pxPerLat, double pxPerLon) {
         final byte[] output;
 
-        if (false == isDebugTiming()) {
+        if (!isDebugTiming()) {
             output = doTheWork(hgtFileInfo, isHighQuality, padding, zoomLevel, pxPerLat, pxPerLon);
         } else {
             final long startTs, finishTs;
 
-            if (false == isDebugTimingSequential()) {
-                startTs = System.nanoTime();
-
-                output = doTheWork(hgtFileInfo, isHighQuality, padding, zoomLevel, pxPerLat, pxPerLon);
-
-                finishTs = System.nanoTime();
-            } else {
+            if (isDebugTimingSequential()) {
                 // We want to process one file at a time for more accurate timings
                 synchronized (mDebugSync) {
                     startTs = System.nanoTime();
@@ -588,6 +582,12 @@ public abstract class AThreadedHillShading extends AShadingAlgorithm {
 
                     finishTs = System.nanoTime();
                 }
+            } else {
+                startTs = System.nanoTime();
+
+                output = doTheWork(hgtFileInfo, isHighQuality, padding, zoomLevel, pxPerLat, pxPerLon);
+
+                finishTs = System.nanoTime();
             }
 
             final long delayNano = finishTs - startTs;

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/AdaptiveClasyHillShading.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/AdaptiveClasyHillShading.java
@@ -110,7 +110,7 @@ public class AdaptiveClasyHillShading extends HiResClasyHillShading implements I
     protected byte[] convert(InputStream inputStream, int dummyAxisLen, int dummyRowLen, int padding, int zoomLevel, double pxPerLat, double pxPerLon, HgtFileInfo hgtFileInfo) throws IOException {
         final boolean isHighQuality = isHighQuality(hgtFileInfo, zoomLevel, pxPerLat, pxPerLon);
 
-        return doTheWork(hgtFileInfo, isHighQuality, padding, zoomLevel, pxPerLat, pxPerLon);
+        return doTheWork_(hgtFileInfo, isHighQuality, padding, zoomLevel, pxPerLat, pxPerLon);
     }
 
     @Override
@@ -124,8 +124,9 @@ public class AdaptiveClasyHillShading extends HiResClasyHillShading implements I
     }
 
     @Override
-    public void setAdaptiveZoomEnabled(boolean isEnabled) {
+    public AdaptiveClasyHillShading setAdaptiveZoomEnabled(boolean isEnabled) {
         mIsAdaptiveZoomEnabled = isEnabled;
+        return this;
     }
 
     @Override

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/AdaptiveClasyHillShading.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/AdaptiveClasyHillShading.java
@@ -110,7 +110,7 @@ public class AdaptiveClasyHillShading extends HiResClasyHillShading implements I
     protected byte[] convert(InputStream inputStream, int dummyAxisLen, int dummyRowLen, int padding, int zoomLevel, double pxPerLat, double pxPerLon, HgtFileInfo hgtFileInfo) throws IOException {
         final boolean isHighQuality = isHighQuality(hgtFileInfo, zoomLevel, pxPerLat, pxPerLon);
 
-        return doTheWork_(hgtFileInfo, isHighQuality, padding, zoomLevel, pxPerLat, pxPerLon);
+        return convert(hgtFileInfo, isHighQuality, padding, zoomLevel, pxPerLat, pxPerLon);
     }
 
     @Override

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/HgtCache.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/HgtCache.java
@@ -98,7 +98,7 @@ public class HgtCache {
                 }
 
                 // Our thread pool won't be needed any more
-                destroyThreadPool();
+                shutdownThreadPool();
 
                 return myMap;
             }
@@ -252,14 +252,30 @@ public class HgtCache {
         return new HillShadingThreadPool(threadCount, threadCount, queueSize, 1, ThreadPoolName).start();
     }
 
-    protected void destroyThreadPool() {
+    protected void shutdownThreadPool() {
         final AtomicReference<HillShadingThreadPool> threadPoolReference = ThreadPool;
 
         synchronized (threadPoolReference) {
             final HillShadingThreadPool threadPool = threadPoolReference.getAndSet(null);
 
             if (threadPool != null) {
-                threadPool.stop();
+                threadPool.shutdown();
+            }
+        }
+    }
+
+    public void interruptAndDestroy() {
+        if (shadingAlgorithm instanceof AThreadedHillShading) {
+            ((AThreadedHillShading) shadingAlgorithm).interruptAndDestroy();
+        }
+
+        final AtomicReference<HillShadingThreadPool> threadPoolReference = ThreadPool;
+
+        synchronized (threadPoolReference) {
+            final HillShadingThreadPool threadPool = threadPoolReference.getAndSet(null);
+
+            if (threadPool != null) {
+                threadPool.shutdownNow();
             }
         }
     }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/HiResClasyHillShading.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/HiResClasyHillShading.java
@@ -63,7 +63,7 @@ public class HiResClasyHillShading extends StandardClasyHillShading {
 
     @Override
     protected byte[] convert(InputStream inputStream, int dummyAxisLen, int dummyRowLen, int padding, int zoomLevel, double pxPerLat, double pxPerLon, HgtFileInfo hgtFileInfo) throws IOException {
-        return doTheWork_(hgtFileInfo, true, padding, zoomLevel, pxPerLat, pxPerLon);
+        return convert(hgtFileInfo, true, padding, zoomLevel, pxPerLat, pxPerLon);
     }
 
     @Override

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/HiResClasyHillShading.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/HiResClasyHillShading.java
@@ -63,7 +63,7 @@ public class HiResClasyHillShading extends StandardClasyHillShading {
 
     @Override
     protected byte[] convert(InputStream inputStream, int dummyAxisLen, int dummyRowLen, int padding, int zoomLevel, double pxPerLat, double pxPerLon, HgtFileInfo hgtFileInfo) throws IOException {
-        return doTheWork(hgtFileInfo, true, padding, zoomLevel, pxPerLat, pxPerLon);
+        return doTheWork_(hgtFileInfo, true, padding, zoomLevel, pxPerLat, pxPerLon);
     }
 
     @Override

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/HillShadingUtils.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/HillShadingUtils.java
@@ -163,8 +163,8 @@ public class HillShadingUtils {
         protected volatile ThreadPoolExecutor mThreadPool = null;
 
         public static class MyRejectedExecutionHandler implements RejectedExecutionHandler {
-            public static class MyRejectedException extends Throwable {
-                public MyRejectedException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+            public static class MyRejectedThrowable extends Throwable {
+                public MyRejectedThrowable(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
                     super(message, cause, enableSuppression, writableStackTrace);
                 }
             }
@@ -175,7 +175,7 @@ public class HillShadingUtils {
             }
 
             public void rejectedExecution(Runnable task, ThreadPoolExecutor executor) {
-                throwException(new MyRejectedException("Rejected", null, false, false));
+                throwException(new MyRejectedThrowable("Rejected", null, false, false));
             }
         }
 
@@ -261,10 +261,26 @@ public class HillShadingUtils {
          *
          * @return {@code this}
          */
-        public HillShadingThreadPool stop() {
+        public HillShadingThreadPool shutdown() {
             synchronized (mSync) {
                 if (mThreadPool != null) {
                     mThreadPool.shutdown();
+                    mThreadPool = null;
+                }
+            }
+
+            return this;
+        }
+
+        /**
+         * Calls {@code ThreadPoolExecutor.shutdownNow()}.
+         *
+         * @return {@code this}
+         */
+        public HillShadingThreadPool shutdownNow() {
+            synchronized (mSync) {
+                if (mThreadPool != null) {
+                    mThreadPool.shutdownNow();
                     mThreadPool = null;
                 }
             }
@@ -289,7 +305,7 @@ public class HillShadingUtils {
                             retVal = true;
                         }
                     }
-                } catch (Exception ignored) {
+                } catch (Throwable ignored) {
                 }
             }
 

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/HillsRenderConfig.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/HillsRenderConfig.java
@@ -121,4 +121,8 @@ public class HillsRenderConfig {
     public boolean isZoomLevelSupported(int zoomLevel, int lat, int lon) {
         return tileSource.isZoomLevelSupported(zoomLevel, lat, lon);
     }
+
+    public void interruptAndDestroy() {
+        tileSource.interruptAndDestroy();
+    }
 }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/IAdaptiveHillShading.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/IAdaptiveHillShading.java
@@ -31,5 +31,5 @@ public interface IAdaptiveHillShading {
     /**
      * @param isEnabled {@code true} to let the algorithm decide which zoom levels are supported (default); {@code false} to obey values as set in the render theme.
      */
-    void setAdaptiveZoomEnabled(boolean isEnabled);
+    IAdaptiveHillShading setAdaptiveZoomEnabled(boolean isEnabled);
 }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/MemoryCachingHgtReaderTileSource.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/MemoryCachingHgtReaderTileSource.java
@@ -74,7 +74,7 @@ public class MemoryCachingHgtReaderTileSource implements ShadeTileSource {
 
     protected HgtCache latestCache() {
         if (demFolder == null || algorithm == null) {
-            this.currentCache = null;
+            interruptAndDestroy();
             return null;
         }
 
@@ -132,6 +132,16 @@ public class MemoryCachingHgtReaderTileSource implements ShadeTileSource {
         }
 
         return retVal;
+    }
+
+    @Override
+    public void interruptAndDestroy() {
+        final HgtCache cache = currentCache;
+        this.currentCache = null;
+
+        if (cache != null) {
+            cache.interruptAndDestroy();
+        }
     }
 
     public void setDemFolder(DemFolder demFolder) {

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/ShadeTileSource.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/ShadeTileSource.java
@@ -44,4 +44,6 @@ public interface ShadeTileSource {
      * @return Whether the zoom level is supported on the lat/lon coordinates.
      */
     boolean isZoomLevelSupported(int zoomLevel, int lat, int lon);
+
+    void interruptAndDestroy();
 }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/MapWorkerPool.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/MapWorkerPool.java
@@ -101,6 +101,7 @@ public class MapWorkerPool implements Runnable {
         // Shutdown executors
         this.self.shutdown();
         this.workers.shutdown();
+        this.databaseRenderer.interruptAndDestroy();
 
         try {
             if (!this.self.awaitTermination(100, TimeUnit.MILLISECONDS)) {

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/StandardRenderer.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/StandardRenderer.java
@@ -229,6 +229,12 @@ public class StandardRenderer implements RenderCallback {
         }
     }
 
+    public void interruptAndDestroy() {
+        if (hillsRenderConfig != null) {
+            hillsRenderConfig.interruptAndDestroy();
+        }
+    }
+
     private static Point[] getTilePixelCoordinates(int tileSize) {
         Point[] result = new Point[5];
         result[0] = new Point(0, 0);

--- a/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/Hillshading.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/rendertheme/renderinstruction/Hillshading.java
@@ -289,7 +289,7 @@ public class Hillshading {
     protected boolean checkZoomLevelFine(int zoomLevel, HillsRenderConfig hillsRenderConfig, int shadingBottomLat, int shadingLeftLon) {
         boolean retVal = true;
 
-        if (hillsRenderConfig.isWideZoomRange()) {
+        if (hillsRenderConfig.isAdaptiveZoomEnabled()) {
             retVal = hillsRenderConfig.isZoomLevelSupported(zoomLevel, shadingBottomLat, shadingLeftLon);
         }
 


### PR DESCRIPTION
How about something like this?

* Interrupt and destroy hill shading thread pools from the `MapWorkerPool` (maybe #1595)
* Fix: `AdaptiveClasyHillShading.setAdaptiveZoomEnabled(false)` not entirely respected (https://github.com/cgeo/cgeo/issues/16438#issuecomment-2558517632)
* Threaded hill shading timing debug feature. Let `AThreadedHillShading.isDebugTiming()` return `true` to see the results:

```java
/**
 * @return {@code true} to measure and output rendering times per file.
 * @see #isDebugTimingSequential()
 */
protected boolean isDebugTiming() {
    return false;
}

/**
 * @return {@code true} to process one file at a time for more accurate timings. Note: Rendering will be slower.
 * @see #isDebugTiming()
 */
protected boolean isDebugTimingSequential() {
    return true;
}
```

The results will be presented like this:

```java
final double delayMs = Math.round(delayNano / 1e5) / 10.;

final String debugTag = this.getClass().getSimpleName() + "-R" + mReadingThreadsCount + "-C" + mComputingThreadsCount + "-E" + ElementsPerComputingTask + "-HQ" + (isHighQuality ? 1 : 0) + "-Z" + (zoomLevel < 10 ? "0" : "") + zoomLevel + " T: " + delayMs + " ms";

System.out.println(debugTag);
```

![image](https://github.com/user-attachments/assets/94c258bc-48a9-4307-8a70-ac7035d8cb99)
