### PR TITLE
LatLong.compareTo() fix

### DIFF
--- a/mapsforge-core/src/main/java/org/mapsforge/core/model/LatLong.java
+++ b/mapsforge-core/src/main/java/org/mapsforge/core/model/LatLong.java
@@ -1,6 +1,7 @@
 /*
  * Copyright 2010, 2011, 2012, 2013 mapsforge.org
  * Copyright 2015-2022 devemux86
+ * Copyright 2025 Sublimis
  *
  * This program is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
@@ -78,12 +79,16 @@ public class LatLong implements Comparable<LatLong> {
      */
     @Override
     public int compareTo(LatLong latLong) {
-        if (this.latitude > latLong.latitude || this.longitude > latLong.longitude) {
+        if (this.latitude > latLong.latitude) {
             return 1;
-        } else if (this.latitude < latLong.latitude
-                || this.longitude < latLong.longitude) {
+        } else if (this.latitude < latLong.latitude) {
+            return -1;
+        } else if (this.longitude > latLong.longitude) {
+            return 1;
+        } else if (this.longitude < latLong.longitude) {
             return -1;
         }
+
         return 0;
     }
 

--- a/mapsforge-core/src/main/java/org/mapsforge/core/model/LatLong.java
+++ b/mapsforge-core/src/main/java/org/mapsforge/core/model/LatLong.java
@@ -19,6 +19,7 @@ package org.mapsforge.core.model;
 import org.mapsforge.core.util.LatLongUtils;
 import org.mapsforge.core.util.Parameters;
 
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -79,17 +80,20 @@ public class LatLong implements Comparable<LatLong> {
      */
     @Override
     public int compareTo(LatLong latLong) {
-        if (this.latitude > latLong.latitude) {
-            return 1;
-        } else if (this.latitude < latLong.latitude) {
-            return -1;
-        } else if (this.longitude > latLong.longitude) {
-            return 1;
-        } else if (this.longitude < latLong.longitude) {
-            return -1;
-        }
+        return Point.compareCoord(this.longitude, this.latitude, latLong.longitude, latLong.latitude);
+    }
 
-        return 0;
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof LatLong)) return false;
+        LatLong latLong = (LatLong) o;
+        return Double.compare(getLatitude(), latLong.getLatitude()) == 0 && Double.compare(getLongitude(), latLong.getLongitude()) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getLatitude(), getLongitude());
     }
 
     /**
@@ -113,23 +117,6 @@ public class LatLong implements Comparable<LatLong> {
      */
     public double distance(LatLong other) {
         return LatLongUtils.distance(this, other);
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        } else if (!(obj instanceof LatLong)) {
-            return false;
-        } else {
-            LatLong other = (LatLong) obj;
-            if (this.latitude != other.latitude) {
-                return false;
-            } else if (this.longitude != other.longitude) {
-                return false;
-            }
-            return true;
-        }
     }
 
     /**
@@ -198,18 +185,6 @@ public class LatLong implements Comparable<LatLong> {
      */
     public int getLongitudeE6() {
         return LatLongUtils.degreesToMicrodegrees(this.longitude);
-    }
-
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        long temp;
-        temp = Double.doubleToLongBits(this.latitude);
-        result = prime * result + (int) (temp ^ (temp >>> 32));
-        temp = Double.doubleToLongBits(this.longitude);
-        result = prime * result + (int) (temp ^ (temp >>> 32));
-        return result;
     }
 
     /**

--- a/mapsforge-core/src/main/java/org/mapsforge/core/model/Point.java
+++ b/mapsforge-core/src/main/java/org/mapsforge/core/model/Point.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2010, 2011, 2012, 2013 mapsforge.org
+ * Copyright 2025 Sublimis
  *
  * This program is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
@@ -15,6 +16,7 @@
 package org.mapsforge.core.model;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * A Point represents an immutable pair of double coordinates.
@@ -43,51 +45,27 @@ public class Point implements Comparable<Point>, Serializable {
 
     @Override
     public int compareTo(Point point) {
-        if (this.x > point.x) {
-            return 1;
-        } else if (this.x < point.x) {
-            return -1;
-        } else if (this.y > point.y) {
-            return 1;
-        } else if (this.y < point.y) {
-            return -1;
-        }
-        return 0;
-    }
-
-    /**
-     * @return the euclidian distance from this point to the given point.
-     */
-    public double distance(Point point) {
-        return Math.hypot(this.x - point.x, this.y - point.y);
+        return compareCoord(this.x, this.y, point.x, point.y);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        } else if (!(obj instanceof Point)) {
-            return false;
-        }
-        Point other = (Point) obj;
-        if (Double.doubleToLongBits(this.x) != Double.doubleToLongBits(other.x)) {
-            return false;
-        } else if (Double.doubleToLongBits(this.y) != Double.doubleToLongBits(other.y)) {
-            return false;
-        }
-        return true;
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Point)) return false;
+        Point point = (Point) o;
+        return Double.compare(x, point.x) == 0 && Double.compare(y, point.y) == 0;
     }
 
     @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        long temp;
-        temp = Double.doubleToLongBits(this.x);
-        result = prime * result + (int) (temp ^ (temp >>> 32));
-        temp = Double.doubleToLongBits(this.y);
-        result = prime * result + (int) (temp ^ (temp >>> 32));
-        return result;
+        return Objects.hash(x, y);
+    }
+
+    /**
+     * @return the euclidean distance from this point to the given point.
+     */
+    public double distance(Point point) {
+        return Math.hypot(this.x - point.x, this.y - point.y);
     }
 
     public Point offset(double dx, double dy) {
@@ -116,5 +94,18 @@ public class Point implements Comparable<Point>, Serializable {
         stringBuilder.append(", y=");
         stringBuilder.append(this.y);
         return stringBuilder.toString();
+    }
+
+    public static int compareCoord(double x1, double y1, double x2, double y2) {
+        if (x1 > x2) {
+            return 1;
+        } else if (x1 < x2) {
+            return -1;
+        } else if (y1 > y2) {
+            return 1;
+        } else if (y1 < y2) {
+            return -1;
+        }
+        return 0;
     }
 }

--- a/mapsforge-core/src/test/java/org/mapsforge/core/model/LatLongTest.java
+++ b/mapsforge-core/src/test/java/org/mapsforge/core/model/LatLongTest.java
@@ -70,8 +70,8 @@ public class LatLongTest {
         LatLong zeroOne = new LatLong(0, 1);
         LatLong zeroOneTwo = new LatLong(0, 1);
 
-        assertEquals(oneZero.compareTo(zeroOne), 1);
-        assertEquals(zeroOne.compareTo(oneZero), -1);
+        assertEquals(zeroOne.compareTo(oneZero), 1);
+        assertEquals(oneZero.compareTo(zeroOne), -1);
         assertEquals(zeroOne.compareTo(zeroOneTwo), 0);
     }
 

--- a/mapsforge-core/src/test/java/org/mapsforge/core/model/LatLongTest.java
+++ b/mapsforge-core/src/test/java/org/mapsforge/core/model/LatLongTest.java
@@ -3,6 +3,7 @@
  * Copyright 2010, 2011, 2012 Patrick Jungermann
  * Copyright 2010, 2011, 2012 Eike Send
  * Copyright 2015 devemux86
+ * Copyright 2025 Sublimis
  *
  * This program is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
@@ -61,6 +62,17 @@ public class LatLongTest {
 
         assertEquals(52.52235, alex.getLatitude(), 0d);
         assertEquals(13.4125, alex.getLongitude(), 0d);
+    }
+
+    @Test
+    public void testCompareTo() {
+        LatLong oneZero = new LatLong(1, 0);
+        LatLong zeroOne = new LatLong(0, 1);
+        LatLong zeroOneTwo = new LatLong(0, 1);
+
+        assertEquals(oneZero.compareTo(zeroOne), 1);
+        assertEquals(zeroOne.compareTo(oneZero), -1);
+        assertEquals(zeroOne.compareTo(zeroOneTwo), 0);
     }
 
     @Test


### PR DESCRIPTION
`LatLong.compareTo()` was incorrectly implemented, so it could happen that e.g. `latLon1.compareTo(latLon2) == latLon2.compareTo(latLon1) == 1` for coordinates `latLon1=(1, 0)` and `latLon2=(0, 1)`.

Although the fix is ​​crucial, `LatLong.compareTo()` does not seem to be used at the moment (is this correct?), so it may not change any current behavior of the library.