### PR TITLE
Ways deduplication performance improvement

### DIFF
--- a/mapsforge-map-reader/src/test/java/org/mapsforge/map/reader/EncodingTest.java
+++ b/mapsforge-map-reader/src/test/java/org/mapsforge/map/reader/EncodingTest.java
@@ -21,6 +21,8 @@ import org.mapsforge.core.util.MercatorProjection;
 import org.mapsforge.map.datastore.MapReadResult;
 import org.mapsforge.map.datastore.Way;
 
+import java.util.ArrayList;
+
 final class EncodingTest {
     private static final byte ZOOM_LEVEL = 8;
 
@@ -53,7 +55,7 @@ final class EncodingTest {
         LatLong latLong4 = new LatLong(-0.1, 0.0);
         LatLong[][] latLongsExpected = new LatLong[][]{{latLong1, latLong2, latLong3, latLong4, latLong1}};
 
-        Way way = mapReadResult.ways.get(0);
+        Way way = new ArrayList<>(mapReadResult.ways).get(0);
         Assert.assertArrayEquals(latLongsExpected, way.latLongs);
 
         mapFile.close();

--- a/mapsforge-map-reader/src/test/java/org/mapsforge/map/reader/MapFileWithDataTest.java
+++ b/mapsforge-map-reader/src/test/java/org/mapsforge/map/reader/MapFileWithDataTest.java
@@ -26,6 +26,7 @@ import org.mapsforge.map.datastore.Way;
 import org.mapsforge.map.reader.header.MapFileInfo;
 
 import java.io.File;
+import java.util.ArrayList;
 
 public class MapFileWithDataTest {
     private static final File MAP_FILE = new File("src/test/resources/with_data/output.map");
@@ -93,7 +94,7 @@ public class MapFileWithDataTest {
             Assert.assertEquals(1, mapReadResult.ways.size());
 
             checkPointOfInterest(mapReadResult.pointOfInterests.get(0));
-            checkWay(mapReadResult.ways.get(0));
+            checkWay(new ArrayList<>(mapReadResult.ways).get(0));
         }
 
         mapFile.close();

--- a/mapsforge-map/src/main/java/org/mapsforge/map/datastore/MultiMapDataStore.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/datastore/MultiMapDataStore.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2014-2015 Ludwig M Brinckmann
  * Copyright 2015-2022 devemux86
- * Copyright 2024 Sublimis
+ * Copyright 2024-2025 Sublimis
  *
  * This program is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
@@ -154,7 +154,7 @@ public class MultiMapDataStore extends MapDataStore {
             case RETURN_ALL:
                 return readLabels(tile, false);
             case DEDUPLICATE:
-                return readLabels(tile, true);
+                return readLabels(tile, true).deduplicate();
         }
         throw new IllegalStateException("Invalid data policy for multi map database");
 
@@ -201,7 +201,7 @@ public class MultiMapDataStore extends MapDataStore {
             case RETURN_ALL:
                 return readLabels(upperLeft, lowerRight, false);
             case DEDUPLICATE:
-                return readLabels(upperLeft, lowerRight, true);
+                return readLabels(upperLeft, lowerRight, true).deduplicate();
         }
         throw new IllegalStateException("Invalid data policy for multi map database");
 
@@ -251,7 +251,7 @@ public class MultiMapDataStore extends MapDataStore {
             case RETURN_ALL:
                 return readMapData(tile, false);
             case DEDUPLICATE:
-                return readMapData(tile, true);
+                return readMapData(tile, true).deduplicate();
         }
         throw new IllegalStateException("Invalid data policy for multi map database");
     }
@@ -297,7 +297,7 @@ public class MultiMapDataStore extends MapDataStore {
             case RETURN_ALL:
                 return readMapData(upperLeft, lowerRight, false);
             case DEDUPLICATE:
-                return readMapData(upperLeft, lowerRight, true);
+                return readMapData(upperLeft, lowerRight, true).deduplicate();
         }
         throw new IllegalStateException("Invalid data policy for multi map database");
     }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/datastore/Way.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/datastore/Way.java
@@ -1,6 +1,7 @@
 /*
  * Copyright 2010, 2011, 2012, 2013 mapsforge.org
  * Copyright 2014-2015 Ludwig M Brinckmann
+ * Copyright 2025 Sublimis
  *
  * This program is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
@@ -18,13 +19,12 @@ package org.mapsforge.map.datastore;
 import org.mapsforge.core.model.LatLong;
 import org.mapsforge.core.model.Tag;
 
-import java.util.Arrays;
 import java.util.List;
 
 /**
  * An immutable container for all data associated with a single way or area (closed way).
  */
-public class Way {
+public class Way implements Comparable<Way> {
     /**
      * The position of the area label (may be null).
      */
@@ -53,50 +53,73 @@ public class Way {
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        } else if (!(obj instanceof Way)) {
-            return false;
-        }
-        Way other = (Way) obj;
-        if (this.layer != other.layer) {
-            return false;
-        } else if (!this.tags.equals(other.tags)) {
-            return false;
-        } else if (this.labelPosition == null && other.labelPosition != null) {
-            return false;
-        } else if (this.labelPosition != null && !this.labelPosition.equals(other.labelPosition)) {
-            return false;
-        } else if (this.latLongs.length != other.latLongs.length) {
-            return false;
-        } else {
-            for (int i = 0; i < this.latLongs.length; i++) {
-                if (this.latLongs[i].length != other.latLongs[i].length) {
-                    return false;
-                } else {
-                    for (int j = 0; j < this.latLongs[i].length; j++) {
-                        if (!latLongs[i][j].equals(other.latLongs[i][j])) {
-                            return false;
-                        }
-                    }
-                }
-            }
-        }
-        return true;
+    public int hashCode() {
+        return System.identityHashCode(this);
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + layer;
-        result = prime * result + tags.hashCode();
-        result = prime * result + Arrays.deepHashCode(latLongs);
-        if (labelPosition != null) {
-            result = prime * result + labelPosition.hashCode();
-        }
-        return result;
+    public boolean equals(Object o) {
+        return this == o;
     }
 
+    @Override
+    public int compareTo(Way other) {
+        if (this == other) {
+            return 0;
+        }
+        if (null == other) {
+            return -1;
+        }
+
+        int retVal = 0;
+
+        retVal = Byte.compare(this.layer, other.layer);
+        if (retVal != 0) {
+            return retVal;
+        }
+
+        retVal = Integer.compare(this.latLongs.length, other.latLongs.length);
+        if (retVal != 0) {
+            return retVal;
+        }
+
+        retVal = Integer.compare(this.tags.size(), other.tags.size());
+        if (retVal != 0) {
+            return retVal;
+        }
+
+        if (this.labelPosition != null && other.labelPosition != null) {
+            retVal = this.labelPosition.compareTo(other.labelPosition);
+            if (retVal != 0) {
+                return retVal;
+            }
+        } else if (this.labelPosition != null) {
+            return -1;
+        } else if (other.labelPosition != null) {
+            return 1;
+        }
+
+        for (int i = 0; i < this.tags.size(); i++) {
+            retVal = this.tags.get(i).compareTo(other.tags.get(i));
+            if (retVal != 0) {
+                return retVal;
+            }
+        }
+
+        for (int i = 0; i < this.latLongs.length; i++) {
+            retVal = Integer.compare(this.latLongs[i].length, other.latLongs[i].length);
+            if (retVal != 0) {
+                return retVal;
+            }
+
+            for (int j = 0; j < this.latLongs[i].length; j++) {
+                retVal = this.latLongs[i][j].compareTo(other.latLongs[i][j]);
+                if (retVal != 0) {
+                    return retVal;
+                }
+            }
+        }
+
+        return retVal;
+    }
 }

--- a/mapsforge-samples-awt/src/main/java/org/mapsforge/samples/awt/Samples.java
+++ b/mapsforge-samples-awt/src/main/java/org/mapsforge/samples/awt/Samples.java
@@ -176,7 +176,7 @@ public final class Samples {
         } else {
             // Vector
             mapView.getModel().displayModel.setFixedTileSize(tileSize);
-            final MultiMapDataStore multiMapDataStore = new MultiMapDataStore(MultiMapDataStore.DataPolicy.RETURN_ALL);
+            final MultiMapDataStore multiMapDataStore = new MultiMapDataStore(MultiMapDataStore.DataPolicy.DEDUPLICATE);
             for (File file : mapFiles) {
                 final MapFile mapFileDataStore = new MapFile(file);
 


### PR DESCRIPTION
* Deduplication performance was improved just for ways (pois not used).
* Tested using three `Germany_oam.osm.map` files (just renamed, so exactly 3x duplication).
* `MapWorkerPool.DEBUG_TIMING = true`, starting with München area on scale = 20km.
* Tested on AWT only.

`DEDUPLICATE` (improved) took **2.3** seconds on average (±0.1).
`RETURN_ALL` took **3.1** seconds on average (±0.1).

The performance of the legacy DEDUPLICATE method was tested later and found to be comparable to RETURN_ALL, thus significantly slower (unsurprisingly).

Android wasn't tested, but the relative results could be even better there, given that mobile devices have weaker GPUs. Not sure, though, maybe someone could do some testing on Android.

This makes the `DEDUPLICATE` method a good candidate for the recommended and default behavior, possibly mitigating the need for map bounding polygons (#1608).