### PR TITLE
Ways and POIs deduplication performance and correctness improvement

### DIFF
--- a/mapsforge-core/src/main/java/org/mapsforge/core/model/Tag.java
+++ b/mapsforge-core/src/main/java/org/mapsforge/core/model/Tag.java
@@ -1,6 +1,7 @@
 /*
  * Copyright 2010, 2011, 2012, 2013 mapsforge.org
  * Copyright 2015 devemux86
+ * Copyright 2025 Sublimis
  *
  * This program is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
@@ -73,18 +74,36 @@ public class Tag implements Comparable<Tag>, Serializable {
      * Compares this tag to the specified tag.
      * The tag comparison is based on a comparison of key and value in that order.
      *
-     * @param tag The tag to compare to.
+     * @param other The tag to compare to.
      * @return 0 if equal, &lt; 0 if considered "smaller", and &gt; 0 if considered "bigger".
      */
     @Override
-    public int compareTo(Tag tag) {
-        int keyResult = this.key.compareTo(tag.key);
+    public int compareTo(Tag other) {
+        int retVal = 0;
 
-        if (keyResult != 0) {
-            return keyResult;
+        if (this.key != null && other.key != null) {
+            retVal = this.key.compareTo(other.key);
+            if (retVal != 0) {
+                return retVal;
+            }
+        } else if (this.key != null) {
+            return -1;
+        } else if (other.key != null) {
+            return 1;
         }
 
-        return this.value.compareTo(tag.value);
+        if (this.value != null && other.value != null) {
+            retVal = this.value.compareTo(other.value);
+            if (retVal != 0) {
+                return retVal;
+            }
+        } else if (this.value != null) {
+            return -1;
+        } else if (other.value != null) {
+            return 1;
+        }
+
+        return retVal;
     }
 
     @Override

--- a/mapsforge-core/src/main/java/org/mapsforge/core/util/Utils.java
+++ b/mapsforge-core/src/main/java/org/mapsforge/core/util/Utils.java
@@ -18,6 +18,7 @@ package org.mapsforge.core.util;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 
 public final class Utils {
@@ -62,9 +63,9 @@ public final class Utils {
      * from the original collection without changing the order of the remaining elements.
      * <p>
      * The strategy is efficient for unsorted collections with fast find-and-remove operations, like
-     * {@link java.util.LinkedHashMap}, and/or for collections containing small fraction of duplicates.
+     * {@link HashSet}, and/or for collections containing small fraction of duplicates.
      *
-     * @param collection A collection with fast find-and-remove operations and/or expected small fraction of duplicates. {@code null}-s are permitted.
+     * @param collection A {@link Collection} with fast find-and-remove operations and/or expected small fraction of duplicates. {@code null}-s are permitted.
      * @param <T>        A type implementing the {@link Comparable} interface.
      * @return The original collection without duplicate elements. Order of the remaining elements is not changed.
      */

--- a/mapsforge-core/src/main/java/org/mapsforge/core/util/Utils.java
+++ b/mapsforge-core/src/main/java/org/mapsforge/core/util/Utils.java
@@ -19,6 +19,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.List;
 
 public final class Utils {
@@ -69,7 +72,7 @@ public final class Utils {
      * @param <T>        A type implementing the {@link Comparable} interface.
      * @return The original collection without duplicate elements. Order of the remaining elements is not changed.
      */
-    public static <T extends Comparable<T>> Collection<T> deduplicate(Collection<T> collection) {
+    public static <T extends Comparable<? super T>> Collection<T> deduplicate(Collection<T> collection) {
         if (!collection.isEmpty()) {
 
             final List<T> sortedList;
@@ -94,5 +97,40 @@ public final class Utils {
         }
 
         return collection;
+    }
+
+    /**
+     * Deduplicate a sorted collection by removing the duplicates
+     * from the original collection without changing the order of the remaining elements.
+     * <p>
+     * The strategy is efficient for collections with fast removal operations, like {@link LinkedList} or
+     * {@link LinkedHashSet}, and/or for collections containing small fraction of duplicates.
+     * <p>
+     * The collection is iterated sequentially, so the performance of the find operation is of no importance.
+     *
+     * @param sortedCollection A sorted collection with fast removals and/or expected small fraction of duplicates. {@code null}-s are permitted.
+     * @param <T>              A type implementing the {@link Comparable} interface.
+     * @return The original collection without duplicate elements. Order of the remaining elements is not changed.
+     */
+    public static <T extends Comparable<? super T>> Collection<T> deduplicateSorted(Collection<T> sortedCollection) {
+        if (!sortedCollection.isEmpty()) {
+            final Iterator<T> sortedIterator = sortedCollection.iterator();
+
+            T pivot = sortedIterator.next();
+
+            while (sortedIterator.hasNext()) {
+                final T item = sortedIterator.next();
+                if (pivot == item || (pivot != null && pivot.compareTo(item) == 0)) {
+                    // We're removing duplicates instead of building a new list from non-duplicates
+                    // because the expected number of duplicates is small and removals are fast.
+                    sortedIterator.remove();
+                    continue;
+                }
+
+                pivot = item;
+            }
+        }
+
+        return sortedCollection;
     }
 }

--- a/mapsforge-core/src/main/java/org/mapsforge/core/util/Utils.java
+++ b/mapsforge-core/src/main/java/org/mapsforge/core/util/Utils.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2016 devemux86
+ * Copyright 2025 Sublimis
  *
  * This program is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
@@ -14,6 +15,9 @@
  */
 package org.mapsforge.core.util;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 public final class Utils {
@@ -51,5 +55,43 @@ public final class Utils {
             }
         }
         return false;
+    }
+
+    /**
+     * Deduplicate a collection by first building a sorted list, then removing the duplicates
+     * from the original collection without changing the order of the remaining elements.
+     * <p>
+     * The strategy is efficient for unsorted collections with fast find-and-remove operations, like
+     * {@link java.util.LinkedHashMap}, and/or for collections containing small fraction of duplicates.
+     *
+     * @param collection A collection with fast find-and-remove operations and/or expected small fraction of duplicates. {@code null}-s are permitted.
+     * @param <T>        A type implementing the {@link Comparable} interface.
+     * @return The original collection without duplicate elements. Order of the remaining elements is not changed.
+     */
+    public static <T extends Comparable<T>> Collection<T> deduplicate(Collection<T> collection) {
+        if (!collection.isEmpty()) {
+
+            final List<T> sortedList;
+            {
+                sortedList = new ArrayList<>(collection);
+                Collections.sort(sortedList);
+            }
+
+            T pivot = sortedList.get(0);
+
+            for (int i = 1; i < sortedList.size(); i++) {
+                final T item = sortedList.get(i);
+                if (pivot == item || (pivot != null && pivot.compareTo(item) == 0)) {
+                    // We're removing duplicates instead of building a new list from non-duplicates
+                    // because the expected number of duplicates is small and removals are fast.
+                    collection.remove(item);
+                    continue;
+                }
+
+                pivot = item;
+            }
+        }
+
+        return collection;
     }
 }

--- a/mapsforge-map-reader/src/test/java/org/mapsforge/map/reader/EncodingTest.java
+++ b/mapsforge-map-reader/src/test/java/org/mapsforge/map/reader/EncodingTest.java
@@ -21,6 +21,8 @@ import org.mapsforge.core.util.MercatorProjection;
 import org.mapsforge.map.datastore.MapReadResult;
 import org.mapsforge.map.datastore.Way;
 
+import java.util.ArrayList;
+
 final class EncodingTest {
     private static final byte ZOOM_LEVEL = 8;
 
@@ -33,18 +35,18 @@ final class EncodingTest {
         // read all labels data, ways should be empty as in the example the way does not carry a name tag
         MapReadResult mapReadResult = mapFile.readLabels(tile);
         Assert.assertFalse(mapReadResult == null);
-        Assert.assertTrue(mapReadResult.pointOfInterests.isEmpty());
+        Assert.assertTrue(mapReadResult.pois.isEmpty());
         Assert.assertTrue(mapReadResult.ways.isEmpty());
 
         // read only poi data, ways should be empty
         mapReadResult = mapFile.readPoiData(tile);
         Assert.assertFalse(mapReadResult == null);
-        Assert.assertTrue(mapReadResult.pointOfInterests.isEmpty());
+        Assert.assertTrue(mapReadResult.pois.isEmpty());
         Assert.assertTrue(mapReadResult.ways.isEmpty());
 
         mapReadResult = mapFile.readMapData(tile);
 
-        Assert.assertTrue(mapReadResult.pointOfInterests.isEmpty());
+        Assert.assertTrue(mapReadResult.pois.isEmpty());
         Assert.assertEquals(1, mapReadResult.ways.size());
 
         LatLong latLong1 = new LatLong(0.0, 0.0);
@@ -53,7 +55,7 @@ final class EncodingTest {
         LatLong latLong4 = new LatLong(-0.1, 0.0);
         LatLong[][] latLongsExpected = new LatLong[][]{{latLong1, latLong2, latLong3, latLong4, latLong1}};
 
-        Way way = mapReadResult.ways.get(0);
+        Way way = new ArrayList<>(mapReadResult.ways).get(0);
         Assert.assertArrayEquals(latLongsExpected, way.latLongs);
 
         mapFile.close();

--- a/mapsforge-map-reader/src/test/java/org/mapsforge/map/reader/MapFileEmptyTest.java
+++ b/mapsforge-map-reader/src/test/java/org/mapsforge/map/reader/MapFileEmptyTest.java
@@ -37,7 +37,7 @@ public class MapFileEmptyTest {
 
             MapReadResult mapReadResult = mapFile.readMapData(tile);
 
-            Assert.assertTrue(mapReadResult.pointOfInterests.isEmpty());
+            Assert.assertTrue(mapReadResult.pois.isEmpty());
             Assert.assertTrue(mapReadResult.ways.isEmpty());
         }
 

--- a/mapsforge-map-reader/src/test/java/org/mapsforge/map/reader/MapFileWithDataTest.java
+++ b/mapsforge-map-reader/src/test/java/org/mapsforge/map/reader/MapFileWithDataTest.java
@@ -26,6 +26,7 @@ import org.mapsforge.map.datastore.Way;
 import org.mapsforge.map.reader.header.MapFileInfo;
 
 import java.io.File;
+import java.util.ArrayList;
 
 public class MapFileWithDataTest {
     private static final File MAP_FILE = new File("src/test/resources/with_data/output.map");
@@ -89,11 +90,11 @@ public class MapFileWithDataTest {
 
             MapReadResult mapReadResult = mapFile.readMapData(tile);
 
-            Assert.assertEquals(1, mapReadResult.pointOfInterests.size());
+            Assert.assertEquals(1, mapReadResult.pois.size());
             Assert.assertEquals(1, mapReadResult.ways.size());
 
-            checkPointOfInterest(mapReadResult.pointOfInterests.get(0));
-            checkWay(mapReadResult.ways.get(0));
+            checkPointOfInterest(new ArrayList<>(mapReadResult.pois).get(0));
+            checkWay(new ArrayList<>(mapReadResult.ways).get(0));
         }
 
         mapFile.close();

--- a/mapsforge-map/src/main/java/org/mapsforge/map/datastore/MapDataStore.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/datastore/MapDataStore.java
@@ -165,7 +165,7 @@ public abstract class MapDataStore {
         for (int x = upperLeft.tileX; x <= lowerRight.tileX; x++) {
             for (int y = upperLeft.tileY; y <= lowerRight.tileY; y++) {
                 Tile current = new Tile(x, y, upperLeft.zoomLevel, upperLeft.tileSize);
-                result.add(readLabels(current), false);
+                result.add(readLabels(current));
             }
         }
         return result;
@@ -197,7 +197,7 @@ public abstract class MapDataStore {
         for (int x = upperLeft.tileX; x <= lowerRight.tileX; x++) {
             for (int y = upperLeft.tileY; y <= lowerRight.tileY; y++) {
                 Tile current = new Tile(x, y, upperLeft.zoomLevel, upperLeft.tileSize);
-                result.add(readMapData(current), false);
+                result.add(readMapData(current));
             }
         }
         return result;
@@ -229,7 +229,7 @@ public abstract class MapDataStore {
         for (int x = upperLeft.tileX; x <= lowerRight.tileX; x++) {
             for (int y = upperLeft.tileY; y <= lowerRight.tileY; y++) {
                 Tile current = new Tile(x, y, upperLeft.zoomLevel, upperLeft.tileSize);
-                result.add(readPoiData(current), false);
+                result.add(readPoiData(current));
             }
         }
         return result;

--- a/mapsforge-map/src/main/java/org/mapsforge/map/datastore/MapReadResult.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/datastore/MapReadResult.java
@@ -19,8 +19,9 @@ package org.mapsforge.map.datastore;
 
 import org.mapsforge.core.util.Utils;
 
-import java.util.LinkedHashSet;
-import java.util.Set;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
 
 /**
  * An immutable container for the data returned from a MapDataStore.
@@ -34,20 +35,18 @@ public class MapReadResult {
 
     /**
      * The read ways.
-     * LinkedHashSet is used to: 1) maintain element order, 2) maximize element removal performance when deduplicating.
      */
-    public final Set<Way> ways;
+    public final List<Way> ways;
 
     /**
      * The read POIs.
-     * LinkedHashSet is used to: 1) maintain element order, 2) maximize element removal performance when deduplicating.
      */
-    public final Set<PointOfInterest> pois;
+    public final List<PointOfInterest> pois;
 
     public MapReadResult() {
-        // LinkedHashSet is used to: 1) maintain element order, 2) maximize element removal performance when deduplicating.
-        this.ways = new LinkedHashSet<>();
-        this.pois = new LinkedHashSet<>();
+        // Note: LinkedList is used to maximize element removal performance when deduplicating!
+        this.ways = new LinkedList<>();
+        this.pois = new LinkedList<>();
     }
 
     public void add(PoiWayBundle poiWayBundle) {
@@ -66,8 +65,11 @@ public class MapReadResult {
     }
 
     public MapReadResult deduplicate() {
-        Utils.deduplicate(this.ways);
-        Utils.deduplicate(this.pois);
+        Collections.sort(this.ways);
+        Utils.deduplicateSorted(this.ways);
+
+        Collections.sort(this.pois);
+        Utils.deduplicateSorted(this.pois);
 
         return this;
     }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/datastore/MapReadResult.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/datastore/MapReadResult.java
@@ -2,6 +2,7 @@
  * Copyright 2010, 2011, 2012, 2013 mapsforge.org
  * Copyright 2014-2015 Ludwig M Brinckmann
  * Copyright 2015-2022 devemux86
+ * Copyright 2025 Sublimis
  *
  * This program is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
@@ -16,9 +17,9 @@
  */
 package org.mapsforge.map.datastore;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
+import org.mapsforge.core.util.Utils;
+
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 /**
@@ -27,58 +28,47 @@ import java.util.Set;
 public class MapReadResult {
 
     /**
-     * Hash codes.
-     */
-    private final Set<Integer> hashPois = new HashSet<>();
-    private final Set<Integer> hashWays = new HashSet<>();
-
-    /**
      * True if the read area is completely covered by water, false otherwise.
      */
     public boolean isWater;
 
     /**
-     * The read POIs.
+     * The read ways.
+     * LinkedHashSet is used to: 1) maintain element order, 2) maximize element removal performance when deduplicating.
      */
-    public List<PointOfInterest> pointOfInterests;
+    public final Set<Way> ways;
 
     /**
-     * The read ways.
+     * The read POIs.
+     * LinkedHashSet is used to: 1) maintain element order, 2) maximize element removal performance when deduplicating.
      */
-    public List<Way> ways;
+    public final Set<PointOfInterest> pois;
 
     public MapReadResult() {
-        this.pointOfInterests = new ArrayList<>();
-        this.ways = new ArrayList<>();
+        // LinkedHashSet is used to: 1) maintain element order, 2) maximize element removal performance when deduplicating.
+        this.ways = new LinkedHashSet<>();
+        this.pois = new LinkedHashSet<>();
     }
 
     public void add(PoiWayBundle poiWayBundle) {
-        this.pointOfInterests.addAll(poiWayBundle.pois);
         this.ways.addAll(poiWayBundle.ways);
+        this.pois.addAll(poiWayBundle.pois);
     }
 
     /**
      * Adds other MapReadResult by combining pois and ways.
-     * Optionally deduplication can be requested (more expensive).
      *
-     * @param other       the MapReadResult to add to this.
-     * @param deduplicate true if check for duplicates is required.
+     * @param other the MapReadResult to add to this.
      */
-    public void add(MapReadResult other, boolean deduplicate) {
-        if (deduplicate) {
-            for (PointOfInterest poi : other.pointOfInterests) {
-                if (this.hashPois.add(poi.hashCode())) {
-                    this.pointOfInterests.add(poi);
-                }
-            }
-            for (Way way : other.ways) {
-                if (this.hashWays.add(way.hashCode())) {
-                    this.ways.add(way);
-                }
-            }
-        } else {
-            this.pointOfInterests.addAll(other.pointOfInterests);
-            this.ways.addAll(other.ways);
-        }
+    public void add(MapReadResult other) {
+        this.ways.addAll(other.ways);
+        this.pois.addAll(other.pois);
+    }
+
+    public MapReadResult deduplicate() {
+        Utils.deduplicate(this.ways);
+        Utils.deduplicate(this.pois);
+
+        return this;
     }
 }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/datastore/MultiMapDataStore.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/datastore/MultiMapDataStore.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2014-2015 Ludwig M Brinckmann
  * Copyright 2015-2022 devemux86
- * Copyright 2024 Sublimis
+ * Copyright 2024-2025 Sublimis
  *
  * This program is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
@@ -152,15 +152,15 @@ public class MultiMapDataStore extends MapDataStore {
                 }
                 return null;
             case RETURN_ALL:
-                return readLabels(tile, false);
+                return readLabelsPriv(tile);
             case DEDUPLICATE:
-                return readLabels(tile, true);
+                return readLabelsPriv(tile).deduplicate();
         }
         throw new IllegalStateException("Invalid data policy for multi map database");
 
     }
 
-    private MapReadResult readLabels(Tile tile, boolean deduplicate) {
+    private MapReadResult readLabelsPriv(Tile tile) {
         MapReadResult mapReadResult = new MapReadResult();
         boolean isTileFilled = false;
         for (MapDataStore mdb : mapDatabases) {
@@ -175,7 +175,7 @@ public class MultiMapDataStore extends MapDataStore {
                 }
                 boolean isWater = mapReadResult.isWater & result.isWater;
                 mapReadResult.isWater = isWater;
-                mapReadResult.add(result, deduplicate);
+                mapReadResult.add(result);
             }
 
             if (mdb.supportsFullTile(tile)) {
@@ -199,15 +199,15 @@ public class MultiMapDataStore extends MapDataStore {
                 }
                 return null;
             case RETURN_ALL:
-                return readLabels(upperLeft, lowerRight, false);
+                return readLabelsPriv(upperLeft, lowerRight);
             case DEDUPLICATE:
-                return readLabels(upperLeft, lowerRight, true);
+                return readLabelsPriv(upperLeft, lowerRight).deduplicate();
         }
         throw new IllegalStateException("Invalid data policy for multi map database");
 
     }
 
-    private MapReadResult readLabels(Tile upperLeft, Tile lowerRight, boolean deduplicate) {
+    private MapReadResult readLabelsPriv(Tile upperLeft, Tile lowerRight) {
         MapReadResult mapReadResult = new MapReadResult();
         boolean isTileFilled = false;
         for (MapDataStore mdb : mapDatabases) {
@@ -225,7 +225,7 @@ public class MultiMapDataStore extends MapDataStore {
                 }
                 boolean isWater = mapReadResult.isWater & result.isWater;
                 mapReadResult.isWater = isWater;
-                mapReadResult.add(result, deduplicate);
+                mapReadResult.add(result);
             }
 
             if (mdb.supportsFullArea(
@@ -249,14 +249,14 @@ public class MultiMapDataStore extends MapDataStore {
                 }
                 return null;
             case RETURN_ALL:
-                return readMapData(tile, false);
+                return readMapDataPriv(tile);
             case DEDUPLICATE:
-                return readMapData(tile, true);
+                return readMapDataPriv(tile).deduplicate();
         }
         throw new IllegalStateException("Invalid data policy for multi map database");
     }
 
-    private MapReadResult readMapData(Tile tile, boolean deduplicate) {
+    private MapReadResult readMapDataPriv(Tile tile) {
         MapReadResult mapReadResult = new MapReadResult();
         boolean isTileFilled = false;
         for (MapDataStore mdb : mapDatabases) {
@@ -271,7 +271,7 @@ public class MultiMapDataStore extends MapDataStore {
                 }
                 boolean isWater = mapReadResult.isWater & result.isWater;
                 mapReadResult.isWater = isWater;
-                mapReadResult.add(result, deduplicate);
+                mapReadResult.add(result);
             }
 
             if (mdb.supportsFullTile(tile)) {
@@ -295,14 +295,14 @@ public class MultiMapDataStore extends MapDataStore {
                 }
                 return null;
             case RETURN_ALL:
-                return readMapData(upperLeft, lowerRight, false);
+                return readMapDataPriv(upperLeft, lowerRight);
             case DEDUPLICATE:
-                return readMapData(upperLeft, lowerRight, true);
+                return readMapDataPriv(upperLeft, lowerRight).deduplicate();
         }
         throw new IllegalStateException("Invalid data policy for multi map database");
     }
 
-    private MapReadResult readMapData(Tile upperLeft, Tile lowerRight, boolean deduplicate) {
+    private MapReadResult readMapDataPriv(Tile upperLeft, Tile lowerRight) {
         MapReadResult mapReadResult = new MapReadResult();
         boolean isTileFilled = false;
         for (MapDataStore mdb : mapDatabases) {
@@ -320,7 +320,7 @@ public class MultiMapDataStore extends MapDataStore {
                 }
                 boolean isWater = mapReadResult.isWater & result.isWater;
                 mapReadResult.isWater = isWater;
-                mapReadResult.add(result, deduplicate);
+                mapReadResult.add(result);
             }
 
             if (mdb.supportsFullArea(
@@ -344,15 +344,15 @@ public class MultiMapDataStore extends MapDataStore {
                 }
                 return null;
             case RETURN_ALL:
-                return readPoiData(tile, false);
+                return readPoiDataPriv(tile);
             case DEDUPLICATE:
-                return readPoiData(tile, true);
+                return readPoiDataPriv(tile).deduplicate();
         }
         throw new IllegalStateException("Invalid data policy for multi map database");
 
     }
 
-    private MapReadResult readPoiData(Tile tile, boolean deduplicate) {
+    private MapReadResult readPoiDataPriv(Tile tile) {
         MapReadResult mapReadResult = new MapReadResult();
         boolean isTileFilled = false;
         for (MapDataStore mdb : mapDatabases) {
@@ -367,7 +367,7 @@ public class MultiMapDataStore extends MapDataStore {
                 }
                 boolean isWater = mapReadResult.isWater & result.isWater;
                 mapReadResult.isWater = isWater;
-                mapReadResult.add(result, deduplicate);
+                mapReadResult.add(result);
             }
 
             if (mdb.supportsFullTile(tile)) {
@@ -391,15 +391,15 @@ public class MultiMapDataStore extends MapDataStore {
                 }
                 return null;
             case RETURN_ALL:
-                return readPoiData(upperLeft, lowerRight, false);
+                return readPoiDataPriv(upperLeft, lowerRight);
             case DEDUPLICATE:
-                return readPoiData(upperLeft, lowerRight, true);
+                return readPoiDataPriv(upperLeft, lowerRight).deduplicate();
         }
         throw new IllegalStateException("Invalid data policy for multi map database");
 
     }
 
-    private MapReadResult readPoiData(Tile upperLeft, Tile lowerRight, boolean deduplicate) {
+    private MapReadResult readPoiDataPriv(Tile upperLeft, Tile lowerRight) {
         MapReadResult mapReadResult = new MapReadResult();
         boolean isTileFilled = false;
         for (MapDataStore mdb : mapDatabases) {
@@ -417,7 +417,7 @@ public class MultiMapDataStore extends MapDataStore {
                 }
                 boolean isWater = mapReadResult.isWater & result.isWater;
                 mapReadResult.isWater = isWater;
-                mapReadResult.add(result, deduplicate);
+                mapReadResult.add(result);
             }
 
             if (mdb.supportsFullArea(

--- a/mapsforge-map/src/main/java/org/mapsforge/map/datastore/MultiMapDataStore.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/datastore/MultiMapDataStore.java
@@ -26,27 +26,29 @@ import java.util.Comparator;
 import java.util.List;
 
 /**
- * A MapDatabase that reads and combines data from multiple map files.
- * The MultiMapDatabase supports the following modes for reading from multiple files:
+ * A {@link MapDataStore} that reads and combines data from multiple map files.
+ * It supports the following modes for reading from multiple files:
  * <p>
- * - RETURN_FIRST: The data from the first database to support a tile will be returned. This is the
+ * - RETURN_FIRST: Data from the first file to support a tile will be returned. This is the
  * fastest operation suitable when you know there is no overlap between map files.
  * <p>
- * - RETURN_ALL: The data from all files will be returned, the data will be combined. This is suitable
+ * - RETURN_ALL: Data from all files will be returned and combined. This is suitable
  * if more than one file can contain data for a tile, but you know there is no semantic overlap, e.g.
  * one file contains contour lines, another road data. Use {@link #setPriority(int)} to prioritize your maps.
  * <p>
- * - DEDUPLICATE: The data from all files will be returned but duplicates will be eliminated. This is
- * suitable when multiple maps cover the different areas, but there is some overlap at boundaries. This
- * is the most expensive operation and often it is actually faster to double paint objects.
+ * - DEDUPLICATE: Data from all files will be returned but duplicates will be removed. This is
+ * suitable when multiple maps cover different areas, but there is some overlap at boundaries.
  * Use {@link #setPriority(int)} to prioritize your maps.
  */
 public class MultiMapDataStore extends MapDataStore {
 
     public enum DataPolicy {
-        RETURN_FIRST, // return the first set of data
-        RETURN_ALL, // return all data from databases
-        DEDUPLICATE // return all data but eliminate duplicates
+        /** Return the first set of data */
+        RETURN_FIRST,
+        /** Return all data */
+        RETURN_ALL,
+        /** Return all data but remove duplicates */
+        DEDUPLICATE
     }
 
     private BoundingBox boundingBox;
@@ -55,10 +57,16 @@ public class MultiMapDataStore extends MapDataStore {
     private LatLong startPosition;
     private byte startZoomLevel;
 
+    /**
+     * Create {@link MultiMapDataStore} with {@link DataPolicy#DEDUPLICATE} behavior.
+     */
     public MultiMapDataStore() {
-        this(DataPolicy.RETURN_ALL);
+        this(DataPolicy.DEDUPLICATE);
     }
 
+    /**
+     * Create {@link MultiMapDataStore} with the selected {@link DataPolicy} behavior.
+     */
     public MultiMapDataStore(DataPolicy dataPolicy) {
         this.dataPolicy = dataPolicy;
         this.mapDatabases = new ArrayList<>();
@@ -152,15 +160,15 @@ public class MultiMapDataStore extends MapDataStore {
                 }
                 return null;
             case RETURN_ALL:
-                return readLabelsPriv(tile);
+                return readAllLabels(tile);
             case DEDUPLICATE:
-                return readLabelsPriv(tile).deduplicate();
+                return readAllLabels(tile).deduplicate();
         }
         throw new IllegalStateException("Invalid data policy for multi map database");
 
     }
 
-    private MapReadResult readLabelsPriv(Tile tile) {
+    private MapReadResult readAllLabels(Tile tile) {
         MapReadResult mapReadResult = new MapReadResult();
         boolean isTileFilled = false;
         for (MapDataStore mdb : mapDatabases) {
@@ -199,15 +207,15 @@ public class MultiMapDataStore extends MapDataStore {
                 }
                 return null;
             case RETURN_ALL:
-                return readLabelsPriv(upperLeft, lowerRight);
+                return readAllLabels(upperLeft, lowerRight);
             case DEDUPLICATE:
-                return readLabelsPriv(upperLeft, lowerRight).deduplicate();
+                return readAllLabels(upperLeft, lowerRight).deduplicate();
         }
         throw new IllegalStateException("Invalid data policy for multi map database");
 
     }
 
-    private MapReadResult readLabelsPriv(Tile upperLeft, Tile lowerRight) {
+    private MapReadResult readAllLabels(Tile upperLeft, Tile lowerRight) {
         MapReadResult mapReadResult = new MapReadResult();
         boolean isTileFilled = false;
         for (MapDataStore mdb : mapDatabases) {
@@ -249,14 +257,14 @@ public class MultiMapDataStore extends MapDataStore {
                 }
                 return null;
             case RETURN_ALL:
-                return readMapDataPriv(tile);
+                return readAllMapData(tile);
             case DEDUPLICATE:
-                return readMapDataPriv(tile).deduplicate();
+                return readAllMapData(tile).deduplicate();
         }
         throw new IllegalStateException("Invalid data policy for multi map database");
     }
 
-    private MapReadResult readMapDataPriv(Tile tile) {
+    private MapReadResult readAllMapData(Tile tile) {
         MapReadResult mapReadResult = new MapReadResult();
         boolean isTileFilled = false;
         for (MapDataStore mdb : mapDatabases) {
@@ -295,14 +303,14 @@ public class MultiMapDataStore extends MapDataStore {
                 }
                 return null;
             case RETURN_ALL:
-                return readMapDataPriv(upperLeft, lowerRight);
+                return readAllMapData(upperLeft, lowerRight);
             case DEDUPLICATE:
-                return readMapDataPriv(upperLeft, lowerRight).deduplicate();
+                return readAllMapData(upperLeft, lowerRight).deduplicate();
         }
         throw new IllegalStateException("Invalid data policy for multi map database");
     }
 
-    private MapReadResult readMapDataPriv(Tile upperLeft, Tile lowerRight) {
+    private MapReadResult readAllMapData(Tile upperLeft, Tile lowerRight) {
         MapReadResult mapReadResult = new MapReadResult();
         boolean isTileFilled = false;
         for (MapDataStore mdb : mapDatabases) {
@@ -344,15 +352,15 @@ public class MultiMapDataStore extends MapDataStore {
                 }
                 return null;
             case RETURN_ALL:
-                return readPoiDataPriv(tile);
+                return readAllPoiData(tile);
             case DEDUPLICATE:
-                return readPoiDataPriv(tile).deduplicate();
+                return readAllPoiData(tile).deduplicate();
         }
         throw new IllegalStateException("Invalid data policy for multi map database");
 
     }
 
-    private MapReadResult readPoiDataPriv(Tile tile) {
+    private MapReadResult readAllPoiData(Tile tile) {
         MapReadResult mapReadResult = new MapReadResult();
         boolean isTileFilled = false;
         for (MapDataStore mdb : mapDatabases) {
@@ -391,15 +399,15 @@ public class MultiMapDataStore extends MapDataStore {
                 }
                 return null;
             case RETURN_ALL:
-                return readPoiDataPriv(upperLeft, lowerRight);
+                return readAllPoiData(upperLeft, lowerRight);
             case DEDUPLICATE:
-                return readPoiDataPriv(upperLeft, lowerRight).deduplicate();
+                return readAllPoiData(upperLeft, lowerRight).deduplicate();
         }
         throw new IllegalStateException("Invalid data policy for multi map database");
 
     }
 
-    private MapReadResult readPoiDataPriv(Tile upperLeft, Tile lowerRight) {
+    private MapReadResult readAllPoiData(Tile upperLeft, Tile lowerRight) {
         MapReadResult mapReadResult = new MapReadResult();
         boolean isTileFilled = false;
         for (MapDataStore mdb : mapDatabases) {

--- a/mapsforge-map/src/main/java/org/mapsforge/map/datastore/PointOfInterest.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/datastore/PointOfInterest.java
@@ -1,6 +1,7 @@
 /*
  * Copyright 2010, 2011, 2012, 2013 mapsforge.org
  * Copyright 2014-2015 Ludwig M Brinckmann
+ * Copyright 2025 Sublimis
  *
  * This program is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
@@ -23,7 +24,7 @@ import java.util.List;
 /**
  * An immutable container for all data associated with a single point of interest node (POI).
  */
-public class PointOfInterest {
+public class PointOfInterest implements Comparable<PointOfInterest> {
     /**
      * The layer of this POI + 5 (to avoid negative values).
      */
@@ -46,31 +47,48 @@ public class PointOfInterest {
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        } else if (!(obj instanceof PointOfInterest)) {
-            return false;
-        }
-        PointOfInterest other = (PointOfInterest) obj;
-        if (this.layer != other.layer) {
-            return false;
-        } else if (!this.tags.equals(other.tags)) {
-            return false;
-        } else if (!this.position.equals(other.position)) {
-            return false;
-        }
-        return true;
+    public int hashCode() {
+        return System.identityHashCode(this);
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + layer;
-        result = prime * result + tags.hashCode();
-        result = prime * result + position.hashCode();
-        return result;
+    public boolean equals(Object o) {
+        return this == o;
     }
 
+    @Override
+    public int compareTo(PointOfInterest other) {
+        if (this == other) {
+            return 0;
+        }
+        if (null == other) {
+            return -1;
+        }
+
+        int retVal = 0;
+
+        retVal = Byte.compare(this.layer, other.layer);
+        if (retVal != 0) {
+            return retVal;
+        }
+
+        retVal = this.position.compareTo(other.position);
+        if (retVal != 0) {
+            return retVal;
+        }
+
+        retVal = Integer.compare(this.tags.size(), other.tags.size());
+        if (retVal != 0) {
+            return retVal;
+        }
+
+        for (int i = 0; i < this.tags.size(); i++) {
+            retVal = this.tags.get(i).compareTo(other.tags.get(i));
+            if (retVal != 0) {
+                return retVal;
+            }
+        }
+
+        return retVal;
+    }
 }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/datastore/PointOfInterest.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/datastore/PointOfInterest.java
@@ -20,6 +20,7 @@ import org.mapsforge.core.model.LatLong;
 import org.mapsforge.core.model.Tag;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * An immutable container for all data associated with a single point of interest node (POI).
@@ -44,16 +45,6 @@ public class PointOfInterest implements Comparable<PointOfInterest> {
         this.layer = layer;
         this.tags = tags;
         this.position = position;
-    }
-
-    @Override
-    public int hashCode() {
-        return System.identityHashCode(this);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        return this == o;
     }
 
     @Override
@@ -90,5 +81,19 @@ public class PointOfInterest implements Comparable<PointOfInterest> {
         }
 
         return retVal;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof PointOfInterest)) return false;
+
+        PointOfInterest that = (PointOfInterest) o;
+        return layer == that.layer && Objects.equals(position, that.position) && Objects.equals(tags, that.tags);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(layer, position, tags);
     }
 }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/datastore/Way.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/datastore/Way.java
@@ -1,6 +1,7 @@
 /*
  * Copyright 2010, 2011, 2012, 2013 mapsforge.org
  * Copyright 2014-2015 Ludwig M Brinckmann
+ * Copyright 2025 Sublimis
  *
  * This program is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
@@ -18,13 +19,12 @@ package org.mapsforge.map.datastore;
 import org.mapsforge.core.model.LatLong;
 import org.mapsforge.core.model.Tag;
 
-import java.util.Arrays;
 import java.util.List;
 
 /**
  * An immutable container for all data associated with a single way or area (closed way).
  */
-public class Way {
+public class Way implements Comparable<Way> {
     /**
      * The position of the area label (may be null).
      */
@@ -53,50 +53,73 @@ public class Way {
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        } else if (!(obj instanceof Way)) {
-            return false;
-        }
-        Way other = (Way) obj;
-        if (this.layer != other.layer) {
-            return false;
-        } else if (!this.tags.equals(other.tags)) {
-            return false;
-        } else if (this.labelPosition == null && other.labelPosition != null) {
-            return false;
-        } else if (this.labelPosition != null && !this.labelPosition.equals(other.labelPosition)) {
-            return false;
-        } else if (this.latLongs.length != other.latLongs.length) {
-            return false;
-        } else {
-            for (int i = 0; i < this.latLongs.length; i++) {
-                if (this.latLongs[i].length != other.latLongs[i].length) {
-                    return false;
-                } else {
-                    for (int j = 0; j < this.latLongs[i].length; j++) {
-                        if (!latLongs[i][j].equals(other.latLongs[i][j])) {
-                            return false;
-                        }
-                    }
-                }
-            }
-        }
-        return true;
+    public int hashCode() {
+        return System.identityHashCode(this);
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + layer;
-        result = prime * result + tags.hashCode();
-        result = prime * result + Arrays.deepHashCode(latLongs);
-        if (labelPosition != null) {
-            result = prime * result + labelPosition.hashCode();
-        }
-        return result;
+    public boolean equals(Object o) {
+        return this == o;
     }
 
+    @Override
+    public int compareTo(Way other) {
+        if (this == other) {
+            return 0;
+        }
+        if (null == other) {
+            return -1;
+        }
+
+        int retVal = 0;
+
+        retVal = Byte.compare(this.layer, other.layer);
+        if (retVal != 0) {
+            return retVal;
+        }
+
+        retVal = Integer.compare(this.latLongs.length, other.latLongs.length);
+        if (retVal != 0) {
+            return retVal;
+        }
+
+        retVal = Integer.compare(this.tags.size(), other.tags.size());
+        if (retVal != 0) {
+            return retVal;
+        }
+
+        if (this.labelPosition != null && other.labelPosition != null) {
+            retVal = this.labelPosition.compareTo(other.labelPosition);
+            if (retVal != 0) {
+                return retVal;
+            }
+        } else if (this.labelPosition != null) {
+            return -1;
+        } else if (other.labelPosition != null) {
+            return 1;
+        }
+
+        for (int i = 0; i < this.tags.size(); i++) {
+            retVal = this.tags.get(i).compareTo(other.tags.get(i));
+            if (retVal != 0) {
+                return retVal;
+            }
+        }
+
+        for (int i = 0; i < this.latLongs.length; i++) {
+            retVal = Integer.compare(this.latLongs[i].length, other.latLongs[i].length);
+            if (retVal != 0) {
+                return retVal;
+            }
+
+            for (int j = 0; j < this.latLongs[i].length; j++) {
+                retVal = this.latLongs[i][j].compareTo(other.latLongs[i][j]);
+                if (retVal != 0) {
+                    return retVal;
+                }
+            }
+        }
+
+        return retVal;
+    }
 }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/datastore/Way.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/datastore/Way.java
@@ -19,7 +19,9 @@ package org.mapsforge.map.datastore;
 import org.mapsforge.core.model.LatLong;
 import org.mapsforge.core.model.Tag;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * An immutable container for all data associated with a single way or area (closed way).
@@ -50,16 +52,6 @@ public class Way implements Comparable<Way> {
         this.tags = tags;
         this.latLongs = latLongs;
         this.labelPosition = labelPosition;
-    }
-
-    @Override
-    public int hashCode() {
-        return System.identityHashCode(this);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        return this == o;
     }
 
     @Override
@@ -121,5 +113,18 @@ public class Way implements Comparable<Way> {
         }
 
         return retVal;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Way)) return false;
+        Way way = (Way) o;
+        return layer == way.layer && Objects.equals(labelPosition, way.labelPosition) && Objects.deepEquals(latLongs, way.latLongs) && Objects.equals(tags, way.tags);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(labelPosition, Arrays.deepHashCode(latLongs), layer, tags);
     }
 }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/labels/MapDataStoreLabelStore.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/labels/MapDataStoreLabelStore.java
@@ -75,7 +75,7 @@ public class MapDataStoreLabelStore implements LabelStore {
                 return new ArrayList<>();
             }
 
-            for (PointOfInterest pointOfInterest : mapReadResult.pointOfInterests) {
+            for (PointOfInterest pointOfInterest : mapReadResult.pois) {
                 renderContext.setDrawingLayer(pointOfInterest.layer);
                 renderContext.rendererJob.renderThemeFuture.get().matchNode(standardRenderer.getRenderCallback(), renderContext, pointOfInterest);
             }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/StandardRenderer.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/StandardRenderer.java
@@ -149,7 +149,7 @@ public class StandardRenderer {
             return;
         }
 
-        for (PointOfInterest pointOfInterest : mapReadResult.pointOfInterests) {
+        for (PointOfInterest pointOfInterest : mapReadResult.pois) {
             renderPointOfInterest(renderContext, pointOfInterest);
         }
 

--- a/mapsforge-samples-android/src/main/java/org/mapsforge/samples/android/MultiMapLowResWorld.java
+++ b/mapsforge-samples-android/src/main/java/org/mapsforge/samples/android/MultiMapLowResWorld.java
@@ -79,7 +79,7 @@ public class MultiMapLowResWorld extends DefaultTheme {
 //            }
         };
         worldMapFile.setPriority(-1);
-        multiMapDataStore = new MultiMapDataStore(MultiMapDataStore.DataPolicy.RETURN_ALL);
+        multiMapDataStore = new MultiMapDataStore(MultiMapDataStore.DataPolicy.DEDUPLICATE);
         MapFile mapFile1 = (MapFile) getMapFile1();
         //mapFile1.restrictToZoomRange((byte) 8, Byte.MAX_VALUE);
         multiMapDataStore.addMapDataStore(mapFile1, true, true);

--- a/mapsforge-samples-android/src/main/java/org/mapsforge/samples/android/ReverseGeocodeViewer.java
+++ b/mapsforge-samples-android/src/main/java/org/mapsforge/samples/android/ReverseGeocodeViewer.java
@@ -75,7 +75,7 @@ public class ReverseGeocodeViewer extends DefaultTheme {
 
         // Filter POI
         sb.append("*** POI ***");
-        for (PointOfInterest pointOfInterest : mapReadResult.pointOfInterests) {
+        for (PointOfInterest pointOfInterest : mapReadResult.pois) {
             Point layerXY = this.mapView.getMapViewProjection().toPixels(pointOfInterest.position);
             if (!Rotation.noRotation(this.mapView.getMapRotation()) && layerXY != null) {
                 layerXY = this.mapView.getMapRotation().rotate(layerXY, true);

--- a/mapsforge-samples-awt/src/main/java/org/mapsforge/samples/awt/Samples.java
+++ b/mapsforge-samples-awt/src/main/java/org/mapsforge/samples/awt/Samples.java
@@ -176,7 +176,7 @@ public final class Samples {
         } else {
             // Vector
             mapView.getModel().displayModel.setFixedTileSize(tileSize);
-            final MultiMapDataStore multiMapDataStore = new MultiMapDataStore(MultiMapDataStore.DataPolicy.RETURN_ALL);
+            final MultiMapDataStore multiMapDataStore = new MultiMapDataStore(MultiMapDataStore.DataPolicy.DEDUPLICATE);
             for (File file : mapFiles) {
                 final MapFile mapFileDataStore = new MapFile(file);
 


### PR DESCRIPTION
Deduplication performance and correctness improvement for ways **and POIs**.

* Tested using three `Germany_oam.osm.map` files (just renamed, so exactly 3x duplication), without POIs.
* `MapWorkerPool.DEBUG_TIMING = true`, starting with München area on scale = 20km.
* Tested on AWT only.

Results:

* `DEDUPLICATE` (improved) took **2.3** seconds on average (±0.1) to draw the map.
* `RETURN_ALL` took **3.1** seconds on average (±0.1) to draw the map.

The performance of the legacy DEDUPLICATE method was tested later and found to be comparable to RETURN_ALL, thus significantly slower (unsurprisingly).

An additional advantage of the new deduplication approach is correctness: This algorithm does not suffer from [hash collisions](https://en.wikipedia.org/wiki/Hash_collision), unlike the previous one. This becomes increasingly important as maps get bigger.

Android wasn't tested, but the relative results could be even better there, given that mobile devices have weaker GPUs. Not sure, though, maybe someone could do some testing on Android.

This makes the `DEDUPLICATE` method a good candidate for the recommended and default behavior, possibly mitigating the need for map bounding polygons (#1608).
