### PR TITLE
Android: Use cache folder/subfolder to cache SVG files

### DIFF
--- a/mapsforge-core/src/main/java/org/mapsforge/core/util/Constants.java
+++ b/mapsforge-core/src/main/java/org/mapsforge/core/util/Constants.java
@@ -18,17 +18,6 @@ package org.mapsforge.core.util;
 public final class Constants {
 
     /**
-     * Display-friendly, human readable name of the library.
-     */
-    public static final String LIBRARY_DISPLAY_NAME = "Mapsforge";
-
-    /**
-     * Filename-friendly, machine readable name of the library.
-     * To be used when there's a need to name a file, folder, or similar.
-     */
-    public static final String LIBRARY_FILE_NAME = "mapsforge";
-
-    /**
      * Maximum amount of memory that the Java virtual machine will attempt to use, in megabytes.
      */
     public static final long MAX_MEMORY_MB = Runtime.getRuntime().maxMemory() / 1000 / 1000;

--- a/mapsforge-core/src/main/java/org/mapsforge/core/util/Constants.java
+++ b/mapsforge-core/src/main/java/org/mapsforge/core/util/Constants.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2024 devemux86
- * Copyright 2024 Sublimis
+ * Copyright 2024-2025 Sublimis
  *
  * This program is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
@@ -17,6 +17,20 @@ package org.mapsforge.core.util;
 
 public final class Constants {
 
+    /**
+     * Display-friendly, human readable name of the library.
+     */
+    public static final String LIBRARY_DISPLAY_NAME = "Mapsforge";
+
+    /**
+     * Filename-friendly, machine readable name of the library.
+     * To be used when there's a need to name a file, folder, or similar.
+     */
+    public static final String LIBRARY_FILE_NAME = "mapsforge";
+
+    /**
+     * Maximum amount of memory that the Java virtual machine will attempt to use, in megabytes.
+     */
     public static final long MAX_MEMORY_MB = Runtime.getRuntime().maxMemory() / 1000 / 1000;
 
     private Constants() {

--- a/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidGraphicFactory.java
+++ b/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidGraphicFactory.java
@@ -31,6 +31,7 @@ import org.mapsforge.core.mapelements.PointTextContainer;
 import org.mapsforge.core.mapelements.SymbolContainer;
 import org.mapsforge.core.model.BoundingBox;
 import org.mapsforge.core.model.Point;
+import org.mapsforge.core.util.Constants;
 import org.mapsforge.map.model.DisplayModel;
 
 import java.io.*;
@@ -63,7 +64,6 @@ public final class AndroidGraphicFactory implements GraphicFactory {
 
     public static final Config MONO_ALPHA_BITMAP = Config.ALPHA_8;
 
-    public final String LibraryFolderName = "mapsforge";
     private final Object cacheFolderSync = new Object();
     private volatile File cacheFolder = null;
 
@@ -332,7 +332,7 @@ public final class AndroidGraphicFactory implements GraphicFactory {
             synchronized (this.cacheFolderSync) {
                 ourCacheFolder = this.cacheFolder;
                 if (ourCacheFolder == null) {
-                    ourCacheFolder = new File(this.context.getCacheDir(), LibraryFolderName);
+                    ourCacheFolder = new File(this.context.getCacheDir(), Constants.LIBRARY_FILE_NAME);
                     ourCacheFolder.mkdirs();
                     this.cacheFolder = ourCacheFolder;
                 }

--- a/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidGraphicFactory.java
+++ b/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidGraphicFactory.java
@@ -31,7 +31,6 @@ import org.mapsforge.core.mapelements.PointTextContainer;
 import org.mapsforge.core.mapelements.SymbolContainer;
 import org.mapsforge.core.model.BoundingBox;
 import org.mapsforge.core.model.Point;
-import org.mapsforge.core.util.Constants;
 import org.mapsforge.map.model.DisplayModel;
 
 import java.io.*;
@@ -64,6 +63,7 @@ public final class AndroidGraphicFactory implements GraphicFactory {
 
     public static final Config MONO_ALPHA_BITMAP = Config.ALPHA_8;
 
+    public static final String LIBRARY_FILE_NAME = "mapsforge";
     private final Object cacheFolderSync = new Object();
     private volatile File cacheFolder = null;
 
@@ -332,7 +332,7 @@ public final class AndroidGraphicFactory implements GraphicFactory {
             synchronized (this.cacheFolderSync) {
                 ourCacheFolder = this.cacheFolder;
                 if (ourCacheFolder == null) {
-                    ourCacheFolder = new File(this.context.getCacheDir(), Constants.LIBRARY_FILE_NAME);
+                    ourCacheFolder = new File(this.context.getCacheDir(), LIBRARY_FILE_NAME);
                     ourCacheFolder.mkdirs();
                     this.cacheFolder = ourCacheFolder;
                 }

--- a/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidGraphicFactory.java
+++ b/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidGraphicFactory.java
@@ -4,6 +4,7 @@
  * Copyright 2014-2021 devemux86
  * Copyright 2017 usrusr
  * Copyright 2018 Adrian Batzill
+ * Copyright 2025 Sublimis
  *
  * This program is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
@@ -61,6 +62,10 @@ public final class AndroidGraphicFactory implements GraphicFactory {
 
 
     public static final Config MONO_ALPHA_BITMAP = Config.ALPHA_8;
+
+    public final String LibraryFolderName = "mapsforge";
+    private final Object cacheFolderSync = new Object();
+    private volatile File cacheFolder = null;
 
     public static android.graphics.Bitmap convertToAndroidBitmap(Drawable drawable) {
         android.graphics.Bitmap bitmap;
@@ -268,7 +273,7 @@ public final class AndroidGraphicFactory implements GraphicFactory {
         if (this.svgCacheDir != null) {
             return new File(this.svgCacheDir, name).delete();
         }
-        return this.context.deleteFile(name);
+        return getCacheFile(name).delete();
     }
 
     /*
@@ -278,7 +283,7 @@ public final class AndroidGraphicFactory implements GraphicFactory {
         if (this.svgCacheDir != null) {
             return this.svgCacheDir.list();
         }
-        return this.context.fileList();
+        return getCacheFile("").list();
     }
 
     /*
@@ -288,7 +293,7 @@ public final class AndroidGraphicFactory implements GraphicFactory {
         if (this.svgCacheDir != null) {
             return new FileInputStream(new File(this.svgCacheDir, name));
         }
-        return this.context.openFileInput(name);
+        return new FileInputStream(getCacheFile(name));
     }
 
     /*
@@ -298,7 +303,7 @@ public final class AndroidGraphicFactory implements GraphicFactory {
         if (this.svgCacheDir != null) {
             return new FileOutputStream(new File(this.svgCacheDir, name), mode == Context.MODE_APPEND);
         }
-        return this.context.openFileOutput(name, mode);
+        return new FileOutputStream(getCacheFile(name), mode == Context.MODE_APPEND);
     }
 
     @Override
@@ -319,5 +324,21 @@ public final class AndroidGraphicFactory implements GraphicFactory {
 
     public void setSvgCacheDir(File svgCacheDir) {
         this.svgCacheDir = svgCacheDir;
+    }
+
+    public File getCacheFile(String filename) {
+        File ourCacheFolder = this.cacheFolder;
+        if (ourCacheFolder == null) {
+            synchronized (this.cacheFolderSync) {
+                ourCacheFolder = this.cacheFolder;
+                if (ourCacheFolder == null) {
+                    ourCacheFolder = new File(this.context.getCacheDir(), LibraryFolderName);
+                    ourCacheFolder.mkdirs();
+                    this.cacheFolder = ourCacheFolder;
+                }
+            }
+        }
+
+        return new File(ourCacheFolder, filename);
     }
 }


### PR DESCRIPTION
On Android there is an elegant concept of a "cache folder" which should be used to cache SVG files. No application wants thousands of files in the root of its private folder, which is currently done. Even in the cache folder we create a separate subfolder for that.