### PR TITLE
* Fix: Normalize input to CanvasRasterer.fillOutsideAreas()

### DIFF
--- a/mapsforge-core/src/main/java/org/mapsforge/core/model/Rectangle.java
+++ b/mapsforge-core/src/main/java/org/mapsforge/core/model/Rectangle.java
@@ -218,15 +218,15 @@ public class Rectangle implements Serializable {
         return new Rectangle(this.left + origin.x, this.top + origin.y, this.right + origin.x, this.bottom + origin.y);
     }
 
-    public Rectangle normalizeToDimensions(double width, double height) {
+    public Rectangle clampClipCoordinates(double horizontal, double vertical) {
         Rectangle output = this;
 
-        if (output.left != 0 || output.top != 0) {
-            output = output.shift(new Point(-this.left, -this.top));
-        }
-
-        if (output.getWidth() > width || output.getHeight() > height) {
-            output = new Rectangle(0, 0, Math.min(output.getWidth(), width), Math.min(output.getHeight(), height));
+        if (output.getWidth() > horizontal || output.getHeight() > vertical) {
+            final double newLeft = Math.abs(output.left) > horizontal ? Math.signum(output.left) * horizontal : output.left;
+            final double newTop = Math.abs(output.top) > vertical ? Math.signum(output.top) * vertical : output.top;
+            final double newRight = Math.abs(output.right) > horizontal ? Math.signum(output.right) * horizontal : output.right;
+            final double newBottom = Math.abs(output.bottom) > vertical ? Math.signum(output.bottom) * vertical : output.bottom;
+            output = new Rectangle(newLeft, newTop, newRight, newBottom);
         }
 
         return output;

--- a/mapsforge-core/src/main/java/org/mapsforge/core/model/Rectangle.java
+++ b/mapsforge-core/src/main/java/org/mapsforge/core/model/Rectangle.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2010, 2011, 2012, 2013 mapsforge.org
- * Copyright 2024 Sublimis
+ * Copyright 2024-2025 Sublimis
  *
  * This program is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
@@ -216,6 +216,20 @@ public class Rectangle implements Serializable {
             return this;
         }
         return new Rectangle(this.left + origin.x, this.top + origin.y, this.right + origin.x, this.bottom + origin.y);
+    }
+
+    public Rectangle normalizeToDimensions(double width, double height) {
+        Rectangle output = this;
+
+        if (output.left != 0 || output.top != 0) {
+            output = output.shift(new Point(-this.left, -this.top));
+        }
+
+        if (output.getWidth() > width || output.getHeight() > height) {
+            output = new Rectangle(0, 0, Math.min(output.getWidth(), width), Math.min(output.getHeight(), height));
+        }
+
+        return output;
     }
 
     @Override

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/CanvasRasterer.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/CanvasRasterer.java
@@ -84,6 +84,10 @@ public class CanvasRasterer {
      * @param insideArea the inside area on which not to draw
      */
     void fillOutsideAreas(Color color, Rectangle insideArea) {
+
+        // Normalize input to prevent overwhelming the canvas with extreme coordinate values
+        insideArea = insideArea.normalizeToDimensions(this.canvas.getWidth(), this.canvas.getHeight());
+
         this.canvas.setClipDifference((float) insideArea.left, (float) insideArea.top, (float) insideArea.getWidth(), (float) insideArea.getHeight());
         this.canvas.fillColor(color);
         this.canvas.resetClip();
@@ -97,6 +101,10 @@ public class CanvasRasterer {
      * @param insideArea the inside area on which not to draw
      */
     void fillOutsideAreas(int color, Rectangle insideArea) {
+
+        // Normalize input to prevent overwhelming the canvas with extreme coordinate values
+        insideArea = insideArea.normalizeToDimensions(this.canvas.getWidth(), this.canvas.getHeight());
+
         this.canvas.setClipDifference((float) insideArea.left, (float) insideArea.top, (float) insideArea.getWidth(), (float) insideArea.getHeight());
         this.canvas.fillColor(color);
         this.canvas.resetClip();

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/CanvasRasterer.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/CanvasRasterer.java
@@ -85,8 +85,8 @@ public class CanvasRasterer {
      */
     void fillOutsideAreas(Color color, Rectangle insideArea) {
 
-        // Normalize input to prevent overwhelming the canvas with extreme coordinate values
-        insideArea = insideArea.normalizeToDimensions(this.canvas.getWidth(), this.canvas.getHeight());
+        // Clamp input to prevent overwhelming the canvas with extreme coordinate values
+        insideArea = insideArea.clampClipCoordinates(this.canvas.getWidth(), this.canvas.getHeight());
 
         this.canvas.setClipDifference((float) insideArea.left, (float) insideArea.top, (float) insideArea.getWidth(), (float) insideArea.getHeight());
         this.canvas.fillColor(color);
@@ -102,8 +102,8 @@ public class CanvasRasterer {
      */
     void fillOutsideAreas(int color, Rectangle insideArea) {
 
-        // Normalize input to prevent overwhelming the canvas with extreme coordinate values
-        insideArea = insideArea.normalizeToDimensions(this.canvas.getWidth(), this.canvas.getHeight());
+        // Clamp input to prevent overwhelming the canvas with extreme coordinate values
+        insideArea = insideArea.clampClipCoordinates(this.canvas.getWidth(), this.canvas.getHeight());
 
         this.canvas.setClipDifference((float) insideArea.left, (float) insideArea.top, (float) insideArea.getWidth(), (float) insideArea.getHeight());
         this.canvas.fillColor(color);


### PR DESCRIPTION
* Fix: Normalize input to `CanvasRasterer.fillOutsideAreas()` to prevent overwhelming the canvas with extreme coordinate values

#1659 