### PR TITLE
AndroidBitmap.compress use max quality

### DIFF
--- a/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidBitmap.java
+++ b/mapsforge-map-android/src/main/java/org/mapsforge/map/android/graphics/AndroidBitmap.java
@@ -93,7 +93,7 @@ public class AndroidBitmap extends BaseBitmap implements Bitmap {
 
     @Override
     public void compress(OutputStream outputStream) throws IOException {
-        if (!this.bitmap.compress(CompressFormat.PNG, 0, outputStream)) {
+        if (!this.bitmap.compress(CompressFormat.PNG, 100, outputStream)) {
             throw new IOException("Failed to write bitmap to output stream");
         }
     }


### PR DESCRIPTION
(ignored for png)