### PR TITLE
Add MBTiles offline renderer + layer

### DIFF
--- a/mapsforge-map-android/src/main/java/org/mapsforge/map/android/mbtiles/MBTilesFile.java
+++ b/mapsforge-map-android/src/main/java/org/mapsforge/map/android/mbtiles/MBTilesFile.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2025 moving-bits
+ * based on work of cpesch
+ */
+
+package org.mapsforge.map.android.mbtiles;
+
+import android.database.Cursor;
+import android.database.SQLException;
+import android.database.sqlite.SQLiteDatabase;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.mapsforge.core.model.BoundingBox;
+
+public class MBTilesFile {
+
+    protected final SQLiteDatabase database;
+
+    private Map<String, String> metadata = null;
+
+    private static final String SELECT_METADATA = "SELECT name, value FROM metadata";
+    private static final String SELECT_TILES = "SELECT tile_data FROM tiles WHERE zoom_level=%s AND tile_column=%s AND tile_row=%s ORDER BY zoom_level DESC LIMIT 1";
+    private static final List<String> SUPPORTED_FORMATS = Arrays.asList("png", "jpg", "jpeg");
+
+    public MBTilesFile(final File file) {
+        this.database = SQLiteDatabase.openDatabase(file.getPath(), null, SQLiteDatabase.OPEN_READONLY);
+
+        final String format = getFormat();
+        if (format == null) {
+            throw new IllegalArgumentException("'metadata.format' field was not found. Is this an MBTiles database?");
+        }
+        if (!SUPPORTED_FORMATS.contains(format)) {
+            throw new IllegalArgumentException(String.format("Unsupported 'metadata.format: %s'. Supported format(s) are: %s", format, SUPPORTED_FORMATS));
+        }
+    }
+
+    public void close() {
+        try {
+            metadata = null;
+            this.database.close();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public BoundingBox getBoundingBox() {
+        final String bounds = getMetadata().get("bounds");
+        if (bounds == null) {
+            return null;
+        }
+        final String[] split = bounds.split(",");
+        if (split.length != 4) {
+            return null;
+        }
+        return new BoundingBox(Double.parseDouble(split[1]), Double.parseDouble(split[0]), Double.parseDouble(split[3]), Double.parseDouble(split[2]));
+    }
+
+    private String getFormat() {
+        return getMetadata().get("format");
+    }
+
+    private Integer getMetadata(final String name) {
+        final String value = getMetadata().get(name);
+        return value != null ? Integer.parseInt(value) : null;
+    }
+
+    private Map<String, String> getMetadata() {
+        if (this.metadata == null) {
+            this.metadata = new HashMap<>();
+            try (Cursor cursor = this.database.rawQuery(SELECT_METADATA, null)) {
+                while (cursor.moveToNext()) {
+                    final String key = cursor.getString(0);
+                    final String value = cursor.getString(1);
+                    this.metadata.put(key, value);
+                }
+            }
+        }
+        return this.metadata;
+    }
+
+    private Integer getZoomLevel(final String name, final String function) {
+        if (getMetadata(name) == null) {
+            final String result = getSingleValue("SELECT " + function + "(zoom_level) AS value FROM tiles");
+            if (result != null) {
+                getMetadata().put(name, result);
+            }
+        }
+        return getMetadata(name);
+    }
+
+    public Integer getZoomLevelMax() {
+        return getZoomLevel("maxzoom", "MAX");
+    }
+
+    public int getZoomLevelMin() {
+        return getZoomLevel("minzoom", "MIN");
+    }
+
+    private String getSingleValue(final String query) {
+        try (Cursor cursor = database.rawQuery(query, null)) {
+            if (cursor.moveToNext()) {
+                final int i = cursor.getColumnIndex("value");
+                return cursor.getString(i);
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        return null;
+    }
+
+    /**
+     * Converts a zoom level to a scale factor.
+     *
+     * @param zoomLevel the zoom level to convert.
+     * @return the corresponding scale factor.
+     */
+    private double zoomLevelToScale(final byte zoomLevel) {
+        return 1 << zoomLevel;
+    }
+
+    /**
+     * Converts a tile Y number at a certain zoom level to TMS notation.
+     *
+     * @param tileY     the tile Y number that should be converted.
+     * @param zoomLevel the zoom level at which the number should be converted.
+     * @return the TMS value of the tile Y number.
+     */
+    private long tileYToTMS(final long tileY, final byte zoomLevel) {
+        return (long) (zoomLevelToScale(zoomLevel) - tileY - 1);
+    }
+
+    public InputStream getTileAsBytes(final int tileX, final int tileY, final byte zoomLevel) {
+        final long tmsTileY = tileYToTMS(tileY, zoomLevel);
+        try (Cursor cursor = database.rawQuery(String.format(SELECT_TILES, zoomLevel, tileX, tmsTileY), null)) {
+            if (cursor.moveToNext()) {
+                final int i = cursor.getColumnIndex("tile_data");
+                return i < 0 ? null : new ByteArrayInputStream(cursor.getBlob(i));
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        return null;
+    }
+
+}

--- a/mapsforge-map-android/src/main/java/org/mapsforge/map/android/mbtiles/MBTilesMapWorkerPool.java
+++ b/mapsforge-map-android/src/main/java/org/mapsforge/map/android/mbtiles/MBTilesMapWorkerPool.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2025 moving-bits
+ * based on work of cpesch
+ */
+
+package org.mapsforge.map.android.mbtiles;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.mapsforge.core.graphics.TileBitmap;
+import org.mapsforge.core.util.Parameters;
+import org.mapsforge.map.layer.Layer;
+import org.mapsforge.map.layer.cache.TileCache;
+import org.mapsforge.map.layer.queue.JobQueue;
+
+class MBTilesMapWorkerPool implements Runnable {
+    private static final Logger LOGGER = Logger.getLogger(MBTilesMapWorkerPool.class.getName());
+
+    private final MBTilesRenderer renderer;
+    private boolean inShutdown, isRunning;
+    private final JobQueue<MBTilesRendererJob> jobQueue;
+    private final Layer layer;
+    private ExecutorService self, workers;
+    private final TileCache tileCache;
+
+    MBTilesMapWorkerPool(final TileCache tileCache, final JobQueue<MBTilesRendererJob> jobQueue, final MBTilesRenderer renderer, final TileMBTilesLayer layer) {
+        super();
+        this.tileCache = tileCache;
+        this.jobQueue = jobQueue;
+        this.renderer = renderer;
+        this.layer = layer;
+        this.inShutdown = false;
+        this.isRunning = false;
+    }
+
+    public void run() {
+        try {
+            while (!inShutdown) {
+                final MBTilesRendererJob rendererJob = this.jobQueue.get(Parameters.NUMBER_OF_THREADS);
+                if (rendererJob == null) {
+                    continue;
+                }
+                if (!this.tileCache.containsKey(rendererJob)) {
+                    workers.execute(new MapWorker(rendererJob));
+                } else {
+                    jobQueue.remove(rendererJob);
+                }
+            }
+        } catch (InterruptedException e) {
+            LOGGER.log(Level.SEVERE, "MapWorkerPool interrupted", e);
+        } catch (RejectedExecutionException e) {
+            LOGGER.log(Level.SEVERE, "MapWorkerPool rejected", e);
+        }
+    }
+
+    public synchronized void start() {
+        if (this.isRunning) {
+            return;
+        }
+        this.inShutdown = false;
+        this.self = Executors.newSingleThreadExecutor();
+        this.workers = Executors.newFixedThreadPool(Parameters.NUMBER_OF_THREADS);
+        this.self.execute(this);
+        this.isRunning = true;
+    }
+
+    public synchronized void stop() {
+        if (!this.isRunning) {
+            return;
+        }
+        this.inShutdown = true;
+        this.jobQueue.interrupt();
+
+        // Shutdown executors
+        this.self.shutdown();
+        this.workers.shutdown();
+
+        try {
+            if (!this.self.awaitTermination(100, TimeUnit.MILLISECONDS)) {
+                this.self.shutdownNow();
+                if (!this.self.awaitTermination(100, TimeUnit.MILLISECONDS)) {
+                    LOGGER.fine("Shutdown self executor failed");
+                }
+            }
+        } catch (InterruptedException e) {
+            LOGGER.log(Level.SEVERE, "Shutdown self executor interrupted", e);
+        }
+
+        try {
+            if (!this.workers.awaitTermination(100, TimeUnit.MILLISECONDS)) {
+                this.workers.shutdownNow();
+                if (!this.workers.awaitTermination(100, TimeUnit.MILLISECONDS)) {
+                    LOGGER.fine("Shutdown workers executor failed");
+                }
+            }
+        } catch (InterruptedException e) {
+            LOGGER.log(Level.SEVERE, "Shutdown workers executor interrupted", e);
+        }
+
+        this.isRunning = false;
+    }
+
+    class MapWorker implements Runnable {
+        private final MBTilesRendererJob rendererJob;
+
+        MapWorker(final MBTilesRendererJob rendererJob) {
+            this.rendererJob = rendererJob;
+        }
+
+        public void run() {
+            TileBitmap bitmap = null;
+            try {
+                if (inShutdown) {
+                    return;
+                }
+                bitmap = renderer.executeJob(rendererJob);
+                if (inShutdown) {
+                    return;
+                }
+
+                if (bitmap != null) {
+                    tileCache.put(rendererJob, bitmap);
+                }
+                layer.requestRedraw();
+            } finally {
+                jobQueue.remove(rendererJob);
+                if (bitmap != null) {
+                    bitmap.decrementRefCount();
+                }
+            }
+        }
+    }
+}

--- a/mapsforge-map-android/src/main/java/org/mapsforge/map/android/mbtiles/MBTilesRenderer.java
+++ b/mapsforge-map-android/src/main/java/org/mapsforge/map/android/mbtiles/MBTilesRenderer.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2025 moving-bits
+ * based on work of cpesch
+ */
+
+package org.mapsforge.map.android.mbtiles;
+
+import java.io.InputStream;
+import java.util.logging.Logger;
+
+import org.mapsforge.core.graphics.GraphicFactory;
+import org.mapsforge.core.graphics.TileBitmap;
+import org.mapsforge.core.model.Tile;
+
+public class MBTilesRenderer {
+    private static final Logger LOGGER = Logger.getLogger(MBTilesRenderer.class.getName());
+
+    private final MBTilesFile file;
+    private final GraphicFactory graphicFactory;
+    private final long timestamp;
+
+    MBTilesRenderer(final MBTilesFile file, final GraphicFactory graphicFactory) {
+        this.file = file;
+        this.graphicFactory = graphicFactory;
+        this.timestamp = System.currentTimeMillis();
+    }
+
+    /**
+     * Called when a job needs to be executed.
+     *
+     * @param rendererJob the job that should be executed.
+     */
+    public TileBitmap executeJob(final MBTilesRendererJob rendererJob) {
+
+        try {
+            final InputStream inputStream = file.getTileAsBytes(rendererJob.tile.tileX, rendererJob.tile.tileY, rendererJob.tile.zoomLevel);
+
+            final TileBitmap bitmap;
+            if (inputStream == null) {
+                bitmap = graphicFactory.createTileBitmap(rendererJob.tile.tileSize, rendererJob.hasAlpha);
+            } else {
+                bitmap = graphicFactory.createTileBitmap(inputStream, rendererJob.tile.tileSize, rendererJob.hasAlpha);
+                bitmap.scaleTo(rendererJob.tile.tileSize, rendererJob.tile.tileSize);
+            }
+            bitmap.setTimestamp(rendererJob.getDatabaseRenderer().getDataTimestamp(rendererJob.tile));
+            return bitmap;
+        } catch (Exception e) {
+            LOGGER.warning("Error while rendering job " + rendererJob + ": " + e.getMessage());
+            return null;
+        }
+    }
+
+    public long getDataTimestamp(final Tile tile) {
+        return timestamp;
+    }
+
+}

--- a/mapsforge-map-android/src/main/java/org/mapsforge/map/android/mbtiles/MBTilesRendererJob.java
+++ b/mapsforge-map-android/src/main/java/org/mapsforge/map/android/mbtiles/MBTilesRendererJob.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 moving-bits
+ * based on work of cpesch
+ */
+
+package org.mapsforge.map.android.mbtiles;
+
+import org.mapsforge.core.model.Tile;
+import org.mapsforge.map.layer.queue.Job;
+
+public class MBTilesRendererJob extends Job {
+    private final MBTilesRenderer renderer;
+    private final int hashCodeValue;
+
+    public MBTilesRendererJob(final Tile tile, final MBTilesRenderer renderer, final boolean isTransparent) {
+        super(tile, isTransparent);
+        this.renderer = renderer;
+        this.hashCodeValue = calculateHashCode();
+    }
+
+    public MBTilesRenderer getDatabaseRenderer() {
+        return renderer;
+    }
+
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (!super.equals(obj)) {
+            return false;
+        } else if (!(obj instanceof MBTilesRendererJob)) {
+            return false;
+        }
+        final MBTilesRendererJob other = (MBTilesRendererJob) obj;
+        return this.getDatabaseRenderer().equals(other.getDatabaseRenderer());
+    }
+
+    public int hashCode() {
+        return this.hashCodeValue;
+    }
+
+    private int calculateHashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + this.getDatabaseRenderer().hashCode();
+        return result;
+    }
+}

--- a/mapsforge-map-android/src/main/java/org/mapsforge/map/android/mbtiles/TileMBTilesLayer.java
+++ b/mapsforge-map-android/src/main/java/org/mapsforge/map/android/mbtiles/TileMBTilesLayer.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2025 moving-bits
+ * based on work of cpesch
+ */
+
+package org.mapsforge.map.android.mbtiles;
+
+import org.mapsforge.core.graphics.GraphicFactory;
+import org.mapsforge.core.graphics.TileBitmap;
+import org.mapsforge.core.model.Tile;
+import org.mapsforge.map.layer.TileLayer;
+import org.mapsforge.map.layer.cache.TileCache;
+import org.mapsforge.map.model.DisplayModel;
+import org.mapsforge.map.model.MapViewPosition;
+import org.mapsforge.map.model.common.Observer;
+
+public class TileMBTilesLayer extends TileLayer<MBTilesRendererJob> implements Observer {
+    private final MBTilesRenderer renderer;
+    private MBTilesMapWorkerPool mapWorkerPool;
+
+    public TileMBTilesLayer(final TileCache tileCache, final MapViewPosition mapViewPosition, final boolean isTransparent,
+                            final MBTilesFile file, final GraphicFactory graphicFactory) {
+        super(tileCache, mapViewPosition, graphicFactory.createMatrix(), isTransparent);
+        this.renderer = new MBTilesRenderer(file, graphicFactory);
+    }
+
+    public synchronized void setDisplayModel(final DisplayModel displayModel) {
+        super.setDisplayModel(displayModel);
+        if (displayModel != null) {
+            if (this.mapWorkerPool == null) {
+                this.mapWorkerPool = new MBTilesMapWorkerPool(this.tileCache, this.jobQueue, this.renderer, this);
+            }
+            this.mapWorkerPool.start();
+        } else if (this.mapWorkerPool != null) {
+            // if we do not have a displayModel any more we can stop rendering.
+            this.mapWorkerPool.stop();
+        }
+    }
+
+    protected MBTilesRendererJob createJob(final Tile tile) {
+        return new MBTilesRendererJob(tile, renderer, this.isTransparent);
+    }
+
+    /**
+     * Whether the tile is stale and should be refreshed.
+     * <br />
+     * This method is called from {@link #draw(org.mapsforge.core.model.BoundingBox, byte, org.mapsforge.core.graphics.Canvas, org.mapsforge.core.model.Point)} to determine whether the tile needs to
+     * be refreshed.
+     * <br />
+     * A tile is considered stale if the timestamp of the layer's {@link #renderer} is more recent than the
+     * {@code bitmap}'s {@link org.mapsforge.core.graphics.TileBitmap#getTimestamp()}.
+     * <br />
+     * When a tile has become stale, the layer will first display the tile referenced by {@code bitmap} and attempt to
+     * obtain a fresh copy in the background. When a fresh copy becomes available, the layer will replace is and update
+     * the cache. If a fresh copy cannot be obtained for whatever reason, the stale tile will continue to be used until
+     * another {@code #draw(BoundingBox, byte, Canvas, Point)} operation requests it again.
+     *
+     * @param tile   A tile.
+     * @param bitmap The bitmap for {@code tile} currently held in the layer's cache.
+     */
+    @Override
+    protected boolean isTileStale(final Tile tile, final TileBitmap bitmap) {
+        return this.renderer.getDataTimestamp(tile) > bitmap.getTimestamp();
+    }
+
+    @Override
+    protected void onAdd() {
+        this.mapWorkerPool.start();
+        if (tileCache != null) {
+            tileCache.addObserver(this);
+        }
+        super.onAdd();
+    }
+
+    @Override
+    protected void onRemove() {
+        this.mapWorkerPool.stop();
+        if (tileCache != null) {
+            tileCache.removeObserver(this);
+        }
+        super.onRemove();
+    }
+
+    @Override
+    public void onChange() {
+        this.requestRedraw();
+    }
+}

--- a/mapsforge-samples-android/AndroidManifest.xml
+++ b/mapsforge-samples-android/AndroidManifest.xml
@@ -108,6 +108,9 @@
             android:name=".MapsforgeMapViewer"
             android:configChanges="keyboardHidden|orientation|screenSize" />
         <activity
+            android:name=".MBTilesBitmapActivity"
+            android:configChanges="keyboardHidden|orientation|screenSize" />
+        <activity
             android:name=".MultiLingualMapViewer"
             android:configChanges="keyboardHidden|orientation|screenSize" />
         <activity

--- a/mapsforge-samples-android/res/values/strings.xml
+++ b/mapsforge-samples-android/res/values/strings.xml
@@ -101,4 +101,7 @@
     <string name="startup_message_twomaps">To run this sample activity, you need also a map with filename second.map installed on storage.</string>
     <string name="startup_message_poi">To run this sample activity, you need any poi with filename berlin.poi installed on storage.\n\nadb push file.poi /Android/media/org.mapsforge.samples.android/berlin.poi</string>
 
+    <string name="warning">Warning</string>
+    <string name="startup_message_mbtiles">To run this sample activity, you need an MBTiles database installed on storage.</string>
+    <string name="exit">Exit</string>
 </resources>

--- a/mapsforge-samples-android/src/main/java/org/mapsforge/samples/android/MBTilesBitmapActivity.java
+++ b/mapsforge-samples-android/src/main/java/org/mapsforge/samples/android/MBTilesBitmapActivity.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2025 moving-bits
+ *
+ * This program is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mapsforge.samples.android;
+
+import android.app.AlertDialog;
+import android.os.Bundle;
+
+import org.mapsforge.map.android.graphics.AndroidGraphicFactory;
+import org.mapsforge.map.android.mbtiles.MBTilesFile;
+import org.mapsforge.map.android.mbtiles.TileMBTilesLayer;
+import org.mapsforge.map.layer.cache.InMemoryTileCache;
+
+import java.io.File;
+
+/**
+ * An example activity making use of raster MBTiles.
+ */
+public class MBTilesBitmapActivity extends DefaultTheme {
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        File[] files = getExternalMediaDirs()[0].listFiles((dir, name) -> name.endsWith(".mbtiles"));
+        if (files == null || files.length == 0) {
+            AlertDialog.Builder builder = new AlertDialog.Builder(this)
+                    .setTitle(R.string.warning)
+                    .setMessage(getResources().getString(R.string.startup_message_mbtiles))
+                    .setPositiveButton(R.string.exit, (dialog, which) -> finish());
+            builder.show();
+            return;
+        }
+
+        for (File file : files) {
+            TileMBTilesLayer tilesLayer = new TileMBTilesLayer(new InMemoryTileCache(200), mapView.getModel().mapViewPosition, true, new MBTilesFile(file), AndroidGraphicFactory.INSTANCE);
+            mapView.getLayerManager().getLayers().add(tilesLayer);
+        }
+    }
+}

--- a/mapsforge-samples-android/src/main/java/org/mapsforge/samples/android/Samples.java
+++ b/mapsforge-samples-android/src/main/java/org/mapsforge/samples/android/Samples.java
@@ -99,6 +99,7 @@ public class Samples extends Activity {
         linearLayout.addView(createButton(LabelLayerUsingLabelCacheMapViewer.class));
         linearLayout.addView(createButton(LabelLayerUsingMapDataStoreMapViewer.class));
         linearLayout.addView(createButton(RotationMapViewer.class));
+        linearLayout.addView(createButton(MBTilesBitmapActivity.class));
 
         linearLayout.addView(createLabel("Overlays"));
         linearLayout.addView(createButton(OverlayMapViewer.class));


### PR DESCRIPTION
Adds rendering of bitmap (offline) `.mbtiles` map files to Mapsforge

See
- `TileMBTilesLayer` and related classes in `mapsforge-map-android/src/main/java/org/mapsforge/map/android/mbtiles`, and 
- sample application `MBTilesBitmapActivity` in `mapsforge-samples-android/src/main/java/org/mapsforge/samples/android`

Sample application expects at least one `.mbtiles` file in the app-specific media folder (typically `/Android/media/org.mapsforge.samples.android`).

For sample screenshots see https://github.com/cgeo/cgeo/pull/16876
