### PR TITLE
DirectRenderer changes

### DIFF
--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/DirectRenderer.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/renderer/DirectRenderer.java
@@ -42,6 +42,7 @@ public class DirectRenderer extends DatabaseRenderer {
      * @param graphicFactory    the graphic factory.
      * @param labelStore        from where labels are read.
      * @param renderLabels      if labels should be rendered.
+     * @param cacheLabels       if labels should be cached.
      * @param hillsRenderConfig the hillshading setup to be used (can be null).
      */
     public DirectRenderer(MapDataStore mapDataStore, GraphicFactory graphicFactory, LabelStore labelStore, boolean renderLabels, boolean cacheLabels, HillsRenderConfig hillsRenderConfig) {


### PR DESCRIPTION
Best flow for using `DirectRenderer` seems to be now:

- using `TileBasedLabelStore` to get to labels for already loaded tiles. I've previously used `MapDataStoreLabelStore`, but it caused huge problems in low zoom levels (loading of too much data)
- rendering of labels over `LabelLayer` 

We need to process labels, but not render them. So they are stored in `TileBasedLabelStore`. In the end, it is only needed to modify `DirectRenderer` to enable caching (optional) + using generic `LabelStore`.