### PR TITLE
- improved getting correct OSMTags

### DIFF
--- a/mapsforge-map-writer/src/main/java/org/mapsforge/map/writer/util/OSMUtils.java
+++ b/mapsforge-map-writer/src/main/java/org/mapsforge/map/writer/util/OSMUtils.java
@@ -316,31 +316,20 @@ public final class OSMUtils {
         return value;
     }
 
+
     /**
-     * @param value string represented value
-     * @return a string represented primitive type
+     * Check if certain key/value define a color value.
+     *
+     * @param key   the key of the tag
+     * @param value the value of the tag
+     * @return true if the key/value pair represents a color value, false otherwise.
      */
-    public static String getValueType(String key, String value) {
-        Double f = OSMUtils.parseDoubleUnit(value);
-        if (f != null) {
-            if (Math.round(f) == f) {
-                if (f.byteValue() == f) {
-                    return "%b";
-                } else if (f.shortValue() == f) {
-                    return "%h";
-                } else {
-                    return "%i";
-                }
-            }
-            return "%f";
-        }
+    public static boolean isColorValue(String key, String value) {
         if (key.contains("colour")) {
             Matcher matcher = COLOR_PATTERN.matcher(value); // Encode color as integer
-            if (matcher.matches() || ColorsCSS.get(value) != null) {
-                return "%i";
-            }
+            return matcher.matches() || ColorsCSS.get(value) != null;
         }
-        return "%s";
+        return false;
     }
 
     /**


### PR DESCRIPTION
This commit refactors the `OSMTagMapping` class to simplify and clarify the logic for retrieving `OSMTag` objects.

**Explanation**:
We did this change with @voldapet somewhere in March 2025.
The reason: (not 100% sure now) was because of incorrect mapping `int`/`short` values of Netherlands/Belgium crossings in the `rcn_ref` and `rwn_ref` tags. We have already used this code in our generator for a few months and it should work as expected. Unfortunately, a precise check of the logic, mainly in the `OSMTagMapping.getTag` method, is highly recommended.

**Key changes**:
-   Created a `getTag` private helper method to consolidate the common logic for retrieving tags from `stringToPoiTag` and `stringToWayTag` maps. This method now uses the `ValueType` enum for clearer type checking.
-   Updated `getPoiTag` and `getWayTag` to utilise the new `getTag` method and the `GetTagAlternative` interface.
