### PR TITLE
Remove AndroidMaps URL from map providers list

### DIFF
--- a/docs/Mapsforge-Maps.md
+++ b/docs/Mapsforge-Maps.md
@@ -1,7 +1,6 @@
 # Mapsforge map providers (in lexical order)
 
 - [alternativaslibres](https://alternativaslibres.org/en/downloads-mf.php)
-- [AndroidMaps](https://www.androidmaps.co.uk/)
 - [BBBike](https://extract.bbbike.org/?format=mapsforge-osm.zip)
 - [Freizeitkarte](https://www.freizeitkarte-osm.de/android/en/index.html)
 - [Kurviger](https://download.kurviger.de/)


### PR DESCRIPTION
The AndroidMaps URL was redirecting to ads rather than offering map downloads.

Addresses #1796 